### PR TITLE
Fixed an error that occurred in a local variable that does not exist.

### DIFF
--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -363,7 +363,7 @@ module Solargraph
       spec.nondevelopment_dependencies.each do |dep|
         gy = YARD::Registry.yardoc_file_for_gem(dep.name)
         if gy.nil?
-          STDERR.puts "Required path not found: #{r}"
+          STDERR.puts "Required path not found: #{dep.name}"
         else
           #STDERR.puts "Adding #{gy}"
           yardocs.unshift gy

--- a/spec/yard_map_spec.rb
+++ b/spec/yard_map_spec.rb
@@ -10,4 +10,11 @@ describe Solargraph::YardMap do
     result = yard_map.get_methods('String')
     expect(result.map(&:to_s)).to include('try_convert')
   end
+
+  it "is not raise Exception in add_gem_dependencies" do
+    allow(YARD::Registry).to receive(:yardoc_file_for_gem).with("parser").and_return(false)
+    allow(YARD::Registry).to receive(:yardoc_file_for_gem).with("ast").and_return(nil)
+    Solargraph::YardMap.new required: ['parser']
+    expect(true).to eq true
+  end
 end


### PR DESCRIPTION
Following error occured when calling YardMap.new.
```
     Failure/Error: STDERR.puts "Required path not found: #{r}"
     
     NameError:
       undefined local variable or method `r' for #<Solargraph::YardMap:0x007feb130cbc40>
     # ./lib/solargraph/yard_map.rb:368:in `block in add_gem_dependencies'
     # ./lib/solargraph/yard_map.rb:363:in `each'
     # ./lib/solargraph/yard_map.rb:363:in `add_gem_dependencies'
     # ./lib/solargraph/yard_map.rb:37:in `block in initialize'
     # ./lib/solargraph/yard_map.rb:26:in `each'
     # ./lib/solargraph/yard_map.rb:26:in `initialize'
```

I fixed that error.