### PR TITLE
Follow symlinks in specs

### DIFF
--- a/lib/solargraph/language_server/message/extended/check_gem_version.rb
+++ b/lib/solargraph/language_server/message/extended/check_gem_version.rb
@@ -18,7 +18,7 @@ module Solargraph
             if available > current
               host.show_message_request "Solagraph gem version #{available} is available.",
                                         LanguageServer::MessageTypes::INFO,
-                                        ['Update now'] { |result|
+                                        ['Update now'] do |result|
                                           break unless result == 'Update now'
                                           o, s = Open3.capture2("gem update solargraph")
                                           if s == 0
@@ -26,7 +26,7 @@ module Solargraph
                                           else
                                             host.show_message 'An error occurred while updating the gem.', LanguageServer::MessageTypes::ERROR
                                           end
-                                        }
+                                        end
             elsif params['verbose']
               host.show_message "The Solargraph gem is up to date (version #{Solargraph::VERSION})."
             end

--- a/spec/api_map/config_spec.rb
+++ b/spec/api_map/config_spec.rb
@@ -1,23 +1,22 @@
 require 'tmpdir'
 
 describe Solargraph::Workspace::Config do
+  let(:config) { described_class.new(workspace_path) }
+  let(:workspace_path) { Dir.mktmpdir }
+
+  after(:each) { FileUtils.remove_entry(workspace_path) }
+
   it "reads workspace files from config" do
-    Dir.mktmpdir do |dir|
-      File.open(File.join(dir, 'foo.rb'), 'w') do |file|
-        file << 'test'
-      end
-      File.open(File.join(dir, 'bar.rb'), 'w') do |file|
-        file << 'test'
-      end
-      File.open(File.join(dir, '.solargraph.yml'), 'w') do |file|
-        file.puts "include:"
-        file.puts "  - foo.rb"
-        file.puts "exclude:"
-        file.puts "  - bar.rb"
-      end
-      config = Solargraph::Workspace::Config.new(dir)
-      expect(config.included).to eq([File.join(dir, 'foo.rb')])
-      expect(config.excluded).to eq([File.join(dir, 'bar.rb')])
+    File.write(File.join(workspace_path, 'foo.rb'), 'test')
+    File.write(File.join(workspace_path, 'bar.rb'), 'test')
+    File.open(File.join(workspace_path, '.solargraph.yml'), 'w') do |file|
+      file.puts "include:"
+      file.puts "  - foo.rb"
+      file.puts "exclude:"
+      file.puts "  - bar.rb"
     end
+
+    expect(config.included).to eq([File.join(workspace_path, 'foo.rb')])
+    expect(config.excluded).to eq([File.join(workspace_path, 'bar.rb')])
   end
 end

--- a/spec/api_map/config_spec.rb
+++ b/spec/api_map/config_spec.rb
@@ -2,7 +2,7 @@ require 'tmpdir'
 
 describe Solargraph::Workspace::Config do
   let(:config) { described_class.new(workspace_path) }
-  let(:workspace_path) { Dir.mktmpdir }
+  let(:workspace_path) { File.realpath(Dir.mktmpdir) }
 
   after(:each) { FileUtils.remove_entry(workspace_path) }
 

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -18,14 +18,17 @@ describe Solargraph::Library do
   end
 
   it "does not open created files in the workspace" do
-    Dir.mktmpdir do |dir|
-      file = File.join(dir, 'file.rb')
-      File.write(file, 'a = b')
-      library = Solargraph::Library.load(dir)
-      result = library.create(file, File.read(file))
+    Dir.mktmpdir do |temp_dir_path|
+      # Ensure we resolve any symlinks to their real path
+      workspace_path = File.realpath(temp_dir_path)
+      file_path = File.join(workspace_path, 'file.rb')
+      File.write(file_path, 'a = b')
+      library = Solargraph::Library.load(workspace_path)
+      result = library.create(file_path, File.read(file_path))
+
       expect(result).to be(true)
       expect {
-        library.checkout file
+        library.checkout file_path
       }.to raise_error(Solargraph::FileNotFoundError)
     end
   end
@@ -111,12 +114,14 @@ describe Solargraph::Library do
   end
 
   it "adds mergeable files to the workspace in create_from_disk" do
-    Dir.mktmpdir do |dir|
-      library = Solargraph::Library.load(dir)
-      filename = File.join(dir, 'created.rb')
-      File.write(filename, "puts 'hello'")
-      expect(library.create_from_disk(filename)).to be(true)
-      expect(library.contain?(filename)).to be(true)
+    Dir.mktmpdir do |temp_dir_path|
+      # Ensure we resolve any symlinks to their real path
+      workspace_path = File.realpath(temp_dir_path)
+      library = Solargraph::Library.load(workspace_path)
+      file_path = File.join(workspace_path, 'created.rb')
+      File.write(file_path, "puts 'hello'")
+      expect(library.create_from_disk(file_path)).to be(true)
+      expect(library.contain?(file_path)).to be(true)
     end
   end
 

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -1,62 +1,55 @@
 require 'tmpdir'
 
 describe Solargraph::Workspace do
+  let(:dir_path) { Dir.mktmpdir }
+  after(:each) { FileUtils.remove_entry(dir_path) }
+
   it "loads sources from a directory" do
-    Dir.mktmpdir do |dir|
-      file = File.join(dir, 'file.rb')
-      File.write file, 'exit'
-      workspace = Solargraph::Workspace.new(dir)
-      expect(workspace.filenames).to include(file)
-      expect(workspace.has_file?(file)).to be(true)
-    end
+    file = File.join(dir_path, 'file.rb')
+    File.write file, 'exit'
+    workspace = Solargraph::Workspace.new(dir_path)
+    expect(workspace.filenames).to include(file)
+    expect(workspace.has_file?(file)).to be(true)
   end
 
   it "ignores non-Ruby files by default" do
-    Dir.mktmpdir do |dir|
-      file = File.join(dir, 'file.rb')
-      File.write file, 'exit'
-      not_ruby = File.join(dir, 'not_ruby.txt')
-      File.write not_ruby, 'text'
-      workspace = Solargraph::Workspace.new(dir)
-      expect(workspace.filenames).to include(file)
-      expect(workspace.filenames).not_to include(not_ruby)
-    end
+    file = File.join(dir_path, 'file.rb')
+    File.write file, 'exit'
+    not_ruby = File.join(dir_path, 'not_ruby.txt')
+    File.write not_ruby, 'text'
+    workspace = Solargraph::Workspace.new(dir_path)
+    expect(workspace.filenames).to include(file)
+    expect(workspace.filenames).not_to include(not_ruby)
   end
 
   it "does not merge non-workspace sources" do
-    Dir.mktmpdir do |dir|
-      workspace = Solargraph::Workspace.new(dir)
-      source = Solargraph::Source.load_string('exit', 'not_ruby.txt')
-      workspace.merge source
-      expect(workspace.filenames).not_to include(source.filename)
-    end
+    workspace = Solargraph::Workspace.new(dir_path)
+    source = Solargraph::Source.load_string('exit', 'not_ruby.txt')
+    workspace.merge source
+    expect(workspace.filenames).not_to include(source.filename)
   end
 
   it "updates sources" do
-    Dir.mktmpdir do |dir|
-      file = File.join(dir, 'file.rb')
-      File.write file, 'exit'
-      workspace = Solargraph::Workspace.new(dir)
-      original = workspace.source(file)
-      updated = Solargraph::Source.load_string('puts "updated"', file)
-      workspace.merge updated
-      expect(workspace.filenames).to include(file)
-      expect(workspace.source(file)).not_to eq(original)
-      expect(workspace.source(file)).to eq(updated)
-    end
+    file = File.join(dir_path, 'file.rb')
+    File.write file, 'exit'
+    workspace = Solargraph::Workspace.new(dir_path)
+    original = workspace.source(file)
+    updated = Solargraph::Source.load_string('puts "updated"', file)
+    workspace.merge updated
+    expect(workspace.filenames).to include(file)
+    expect(workspace.source(file)).not_to eq(original)
+    expect(workspace.source(file)).to eq(updated)
   end
 
   it "removes deleted sources" do
-    Dir.mktmpdir do |dir|
-      file = File.join(dir, 'file.rb')
-      File.write file, 'exit'
-      workspace = Solargraph::Workspace.new(dir)
-      expect(workspace.filenames).to include(file)
-      original = workspace.source(file)
-      File.unlink file
-      workspace.remove original
-      expect(workspace.filenames).not_to include(file)
-    end
+    file = File.join(dir_path, 'file.rb')
+    File.write file, 'exit'
+    workspace = Solargraph::Workspace.new(dir_path)
+    expect(workspace.filenames).to include(file)
+    original = workspace.source(file)
+    File.unlink file
+    workspace.remove original
+    expect(workspace.filenames).not_to include(file)
   end
 
   it "raises an exception for workspace size limits" do

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -1,7 +1,7 @@
 require 'tmpdir'
 
 describe Solargraph::Workspace do
-  let(:dir_path) { Dir.mktmpdir }
+  let(:dir_path) { File.realpath(Dir.mktmpdir) }
   after(:each) { FileUtils.remove_entry(dir_path) }
 
   it "loads sources from a directory" do

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -1,24 +1,23 @@
 require 'tmpdir'
 
 describe Solargraph::Workspace do
-  let(:dir_path) { File.realpath(Dir.mktmpdir) }
-  after(:each) { FileUtils.remove_entry(dir_path) }
+  let(:dir_path)  { File.realpath(Dir.mktmpdir) }
+  let(:file_path) { File.join(dir_path, 'file.rb') }
+
+  before(:each)   { File.write(file_path, 'exit') }
+  after(:each)    { FileUtils.remove_entry(dir_path) }
 
   it "loads sources from a directory" do
-    file = File.join(dir_path, 'file.rb')
-    File.write file, 'exit'
     workspace = Solargraph::Workspace.new(dir_path)
-    expect(workspace.filenames).to include(file)
-    expect(workspace.has_file?(file)).to be(true)
+    expect(workspace.filenames).to include(file_path)
+    expect(workspace.has_file?(file_path)).to be(true)
   end
 
   it "ignores non-Ruby files by default" do
-    file = File.join(dir_path, 'file.rb')
-    File.write file, 'exit'
     not_ruby = File.join(dir_path, 'not_ruby.txt')
     File.write not_ruby, 'text'
     workspace = Solargraph::Workspace.new(dir_path)
-    expect(workspace.filenames).to include(file)
+    expect(workspace.filenames).to include(file_path)
     expect(workspace.filenames).not_to include(not_ruby)
   end
 
@@ -30,26 +29,22 @@ describe Solargraph::Workspace do
   end
 
   it "updates sources" do
-    file = File.join(dir_path, 'file.rb')
-    File.write file, 'exit'
     workspace = Solargraph::Workspace.new(dir_path)
-    original = workspace.source(file)
-    updated = Solargraph::Source.load_string('puts "updated"', file)
+    original = workspace.source(file_path)
+    updated = Solargraph::Source.load_string('puts "updated"', file_path)
     workspace.merge updated
-    expect(workspace.filenames).to include(file)
-    expect(workspace.source(file)).not_to eq(original)
-    expect(workspace.source(file)).to eq(updated)
+    expect(workspace.filenames).to include(file_path)
+    expect(workspace.source(file_path)).not_to eq(original)
+    expect(workspace.source(file_path)).to eq(updated)
   end
 
   it "removes deleted sources" do
-    file = File.join(dir_path, 'file.rb')
-    File.write file, 'exit'
     workspace = Solargraph::Workspace.new(dir_path)
-    expect(workspace.filenames).to include(file)
-    original = workspace.source(file)
-    File.unlink file
+    expect(workspace.filenames).to include(file_path)
+    original = workspace.source(file_path)
+    File.unlink file_path
     workspace.remove original
-    expect(workspace.filenames).not_to include(file)
+    expect(workspace.filenames).not_to include(file_path)
   end
 
   it "raises an exception for workspace size limits" do

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -1,6 +1,7 @@
 require 'tmpdir'
 
 describe Solargraph::Workspace do
+  let(:workspace) { described_class.new(dir_path) }
   let(:dir_path)  { File.realpath(Dir.mktmpdir) }
   let(:file_path) { File.join(dir_path, 'file.rb') }
 
@@ -8,7 +9,6 @@ describe Solargraph::Workspace do
   after(:each)    { FileUtils.remove_entry(dir_path) }
 
   it "loads sources from a directory" do
-    workspace = Solargraph::Workspace.new(dir_path)
     expect(workspace.filenames).to include(file_path)
     expect(workspace.has_file?(file_path)).to be(true)
   end
@@ -16,42 +16,43 @@ describe Solargraph::Workspace do
   it "ignores non-Ruby files by default" do
     not_ruby = File.join(dir_path, 'not_ruby.txt')
     File.write not_ruby, 'text'
-    workspace = Solargraph::Workspace.new(dir_path)
+
     expect(workspace.filenames).to include(file_path)
     expect(workspace.filenames).not_to include(not_ruby)
   end
 
   it "does not merge non-workspace sources" do
-    workspace = Solargraph::Workspace.new(dir_path)
     source = Solargraph::Source.load_string('exit', 'not_ruby.txt')
     workspace.merge source
+
     expect(workspace.filenames).not_to include(source.filename)
   end
 
   it "updates sources" do
-    workspace = Solargraph::Workspace.new(dir_path)
     original = workspace.source(file_path)
     updated = Solargraph::Source.load_string('puts "updated"', file_path)
     workspace.merge updated
+
     expect(workspace.filenames).to include(file_path)
     expect(workspace.source(file_path)).not_to eq(original)
     expect(workspace.source(file_path)).to eq(updated)
   end
 
   it "removes deleted sources" do
-    workspace = Solargraph::Workspace.new(dir_path)
     expect(workspace.filenames).to include(file_path)
+
     original = workspace.source(file_path)
     File.unlink file_path
     workspace.remove original
+
     expect(workspace.filenames).not_to include(file_path)
   end
 
   it "raises an exception for workspace size limits" do
-    config = double
-    allow(config).to receive(:calculated).and_return(Array.new(Solargraph::Workspace::MAX_WORKSPACE_SIZE + 1))
+    config = double(:config, calculated: Array.new(Solargraph::Workspace::MAX_WORKSPACE_SIZE + 1))
+
     expect {
-      workspace = Solargraph::Workspace.new('.', config)
+      Solargraph::Workspace.new('.', config)
     }.to raise_error(Solargraph::WorkspaceTooLargeError)
   end
 end


### PR DESCRIPTION
* Dry up some of the duplication in the workspace specs
* Fix specs on mac to resolve symlinks

I had a few spec failures when running the tests, it turns out the `Solargraph::Source::Config#process_globs` resolves symlinks before adding the files to the workspace, but the tests were not.

On my mac, ruby tmp files go into `/var` which is symlinked to `/private/var` so it was complaining that `['/private/var/file.rb'] does not include ['/var/file.rb']`

There were a few more specs that appear to have this issue as well, I'm happy to fix them as well if you'd like.

```
229 examples, 20 failures

Failed examples:

rspec ./spec/api_map/config_spec.rb:4 # Solargraph::Workspace::Config reads workspace files from config
rspec ./spec/diagnostics/require_not_found_spec.rb:12 # Solargraph::Diagnostics::RequireNotFound reports unresolved requires
rspec ./spec/language_server/protocol_spec.rb:44 # Protocol handles initialize
rspec ./spec/language_server/protocol_spec.rb:50 # Protocol handles textDocument/didOpen
rspec ./spec/language_server/protocol_spec.rb:96 # Protocol handles textDocument/completion
rspec ./spec/language_server/protocol_spec.rb:111 # Protocol handles workspace/symbol
rspec ./spec/language_server/protocol_spec.rb:119 # Protocol handles textDocument/definition
rspec ./spec/language_server/protocol_spec.rb:134 # Protocol handles completionItem/resolve
rspec ./spec/language_server/protocol_spec.rb:154 # Protocol handles textDocument/documentSymbol
rspec ./spec/language_server/protocol_spec.rb:164 # Protocol handles textDocument/hover
rspec ./spec/language_server/protocol_spec.rb:180 # Protocol handles textDocument/signatureHelp
rspec ./spec/language_server/protocol_spec.rb:195 # Protocol handles workspace/symbol
rspec ./spec/language_server/protocol_spec.rb:204 # Protocol handles textDocument/didClose
rspec ./spec/language_server/protocol_spec.rb:214 # Protocol handles $/solargraph/search
rspec ./spec/language_server/protocol_spec.rb:223 # Protocol handles $/solargraph/document
rspec ./spec/library_spec.rb:20 # Solargraph::Library does not open created files in the workspace
rspec ./spec/library_spec.rb:113 # Solargraph::Library adds mergeable files to the workspace in create_from_disk
rspec ./spec/yard_map_spec.rb:22 # Solargraph::YardMap gets locations from required gems
rspec ./spec/yard_map_spec.rb:96 # Solargraph::YardMap tracks unresolved requires
rspec ./spec/yard_map_spec.rb:102 # Solargraph::YardMap uses a clean bundler environment in workspaces with unloaded gemfiles
```