### PR TITLE
Use pure-ruby kramdown instead of redcarpet

### DIFF
--- a/lib/solargraph/page.rb
+++ b/lib/solargraph/page.rb
@@ -1,21 +1,11 @@
 require 'ostruct'
 require 'tilt'
-require 'redcarpet'
+require 'kramdown'
 require 'htmlentities'
 require 'coderay'
 
 module Solargraph
   class Page
-    class SolargraphRenderer < Redcarpet::Render::HTML
-      def normal_text text
-        HTMLEntities.new.encode(text, :named)
-      end
-      def block_code code, language
-        CodeRay.scan(code, language || :ruby).div
-      end
-    end
-    private_constant :SolargraphRenderer
-
     class Binder < OpenStruct
       def initialize locals, render_method
         super(locals)
@@ -31,8 +21,17 @@ module Solargraph
         helper = Solargraph::Pin::Helper.new
         html = helper.html_markup_rdoc(text)
         conv = ReverseMarkdown.convert(html, github_flavored: true)
-        markdown = Redcarpet::Markdown.new(SolargraphRenderer.new(prettify: true), fenced_code_blocks: true)
-        markdown.render(conv)
+        Kramdown::Document.new(
+          conv,
+          input: 'GFM',
+          entity_output: :symbolic,
+          syntax_highlighter_opts: {
+            block: {
+              line_numbers: false,
+            },
+            default_lang: :ruby
+          },
+        ).to_html
       end
 
       def ruby_to_html code

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'bundler', '~> 1.14'
   s.add_runtime_dependency 'eventmachine', '~> 1.2', '>= 1.2.5'
   s.add_runtime_dependency 'reverse_markdown', '~> 1.0', '>= 1.0.5'
-  s.add_runtime_dependency 'redcarpet', '~> 3.2', '>= 3.2.3'
+  s.add_runtime_dependency 'kramdown'
   s.add_runtime_dependency 'htmlentities', '~> 4.3', '>= 4.3.4'
   s.add_runtime_dependency 'coderay', '~> 1.1'
   s.add_runtime_dependency 'rubocop', '~> 0.52'


### PR DESCRIPTION
I wanted to try out solargraph (and vscode-ruby) in a JRuby project, but couldn't even install it as redcarpet requires native extensions which cannot be installed in JRuby.

This replaces the markdown generation with the kramdown gem, which is implemented in pure ruby, and thus should work for JRuby as well as MRI. I tried to figure out reasonable options to get a somewhat similar behavior to the redcarpet version, but there didn't seem to be an automated test for this, so I wasn't really sure what would be a good test case.