### PR TITLE
Add Travis-based continuous integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,15 @@
+language: ruby
+rvm:
+  - 2.2
+  - 2.3
+  - 2.4
+  - jruby-1.7.27
+  - jruby-9.0.5.0
+  - jruby-9.1.16.0
+matrix:
+  include:
+    - rvm: 2.4
+      os: osx
+script: rspec
+cache:
+  - bundler

--- a/lib/solargraph/page.rb
+++ b/lib/solargraph/page.rb
@@ -1,21 +1,11 @@
 require 'ostruct'
 require 'tilt'
-require 'redcarpet'
+require 'kramdown'
 require 'htmlentities'
 require 'coderay'
 
 module Solargraph
   class Page
-    class SolargraphRenderer < Redcarpet::Render::HTML
-      def normal_text text
-        HTMLEntities.new.encode(text, :named)
-      end
-      def block_code code, language
-        CodeRay.scan(code, language || :ruby).div
-      end
-    end
-    private_constant :SolargraphRenderer
-
     class Binder < OpenStruct
       def initialize locals, render_method
         super(locals)
@@ -31,8 +21,17 @@ module Solargraph
         helper = Solargraph::Pin::Helper.new
         html = helper.html_markup_rdoc(text)
         conv = ReverseMarkdown.convert(html, github_flavored: true)
-        markdown = Redcarpet::Markdown.new(SolargraphRenderer.new(prettify: true), fenced_code_blocks: true)
-        markdown.render(conv)
+        Kramdown::Document.new(
+          conv,
+          input: 'GFM',
+          entity_output: :symbolic,
+          syntax_highlighter_opts: {
+            block: {
+              line_numbers: false,
+            },
+            default_lang: :ruby
+          },
+        ).to_html
       end
 
       def ruby_to_html code

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -23,7 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'bundler', '~> 1.14'
   s.add_runtime_dependency 'eventmachine', '~> 1.2', '>= 1.2.5'
   s.add_runtime_dependency 'reverse_markdown', '~> 1.0', '>= 1.0.5'
-  s.add_runtime_dependency 'redcarpet', '~> 3.2', '>= 3.2.3'
+  s.add_runtime_dependency 'kramdown'
   s.add_runtime_dependency 'htmlentities', '~> 4.3', '>= 4.3.4'
   s.add_runtime_dependency 'coderay', '~> 1.1'
   s.add_runtime_dependency 'rubocop', '~> 0.52'

--- a/spec/api_map/config_spec.rb
+++ b/spec/api_map/config_spec.rb
@@ -3,6 +3,7 @@ require 'tmpdir'
 describe Solargraph::Workspace::Config do
   it "reads workspace files from config" do
     Dir.mktmpdir do |dir|
+      dir = File.realdirpath(dir)
       File.open(File.join(dir, 'foo.rb'), 'w') do |file|
         file << 'test'
       end

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -3,6 +3,7 @@ require 'tmpdir'
 describe Solargraph::Workspace do
   it "loads sources from a directory" do
     Dir.mktmpdir do |dir|
+      dir = File.realdirpath(dir)
       file = File.join(dir, 'file.rb')
       File.write file, 'exit'
       workspace = Solargraph::Workspace.new(dir)
@@ -13,6 +14,7 @@ describe Solargraph::Workspace do
 
   it "ignores non-Ruby files by default" do
     Dir.mktmpdir do |dir|
+      dir = File.realdirpath(dir)
       file = File.join(dir, 'file.rb')
       File.write file, 'exit'
       not_ruby = File.join(dir, 'not_ruby.txt')
@@ -25,6 +27,7 @@ describe Solargraph::Workspace do
 
   it "does not merge non-workspace sources" do
     Dir.mktmpdir do |dir|
+      dir = File.realdirpath(dir)
       workspace = Solargraph::Workspace.new(dir)
       source = Solargraph::Source.load_string('exit', 'not_ruby.txt')
       workspace.merge source
@@ -34,6 +37,7 @@ describe Solargraph::Workspace do
 
   it "updates sources" do
     Dir.mktmpdir do |dir|
+      dir = File.realdirpath(dir)
       file = File.join(dir, 'file.rb')
       File.write file, 'exit'
       workspace = Solargraph::Workspace.new(dir)
@@ -48,6 +52,7 @@ describe Solargraph::Workspace do
 
   it "removes deleted sources" do
     Dir.mktmpdir do |dir|
+      dir = File.realdirpath(dir)
       file = File.join(dir, 'file.rb')
       File.write file, 'exit'
       workspace = Solargraph::Workspace.new(dir)


### PR DESCRIPTION
In order to demonstrate my difficulty in getting Solargraph running on my machine I decided to add a `.travis.yml` file to try and run the specs on Travis CI.

In addition to the Travis CI configuration, this also includes the changes from #46 and a version of #45 that I developed before looking at existing PRs. The motivation for including these changes is to illustrate the remaining test failures.

I don't understand completely what is going on, but it seems like the test suite assumes that gems (and yardocs) are installed globally, but it wasn't clear to me. I suspected that the fact that I use rbenv and install dependencies into `vendor/bundle` inside the project directory was the underlying issue, but given that it fails with RVM on Travis, I'm somewhat more confused.