### PR TITLE
Fix in-memory cache issue and add some nice minor utilities

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,7 +8,7 @@ begin
 rescue LoadError
 end
 
-desc "Open an irb session preloaded with this library"
+desc "Open a Pry session preloaded with this library"
 task :console do
-  sh "irb -I lib -r solargraph.rb"
+  sh "pry -I lib -r solargraph.rb"
 end

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,14 @@
 require 'rake'
 require 'rspec/core/rake_task'
 require 'bundler/gem_tasks'
+
+begin
+  require 'rspec/core/rake_task'
+  RSpec::Core::RakeTask.new(:spec)
+rescue LoadError
+end
+
+desc "Open an irb session preloaded with this library"
+task :console do
+  sh "irb -I lib -r solargraph.rb"
+end

--- a/lib/solargraph/workspace/config.rb
+++ b/lib/solargraph/workspace/config.rb
@@ -13,7 +13,7 @@ module Solargraph
       def initialize workspace = nil
         @workspace = workspace
         include_globs = ['**/*.rb']
-        exclude_globs = ['spec/**/*', 'test/**/*', 'vendor/**/*']
+        exclude_globs = ['spec/**/*', 'test/**/*', 'vendor/**/*', '.bundle/**/*']
         unless @workspace.nil?
           sfile = File.join(@workspace, '.solargraph.yml')
           if File.file?(sfile)
@@ -44,7 +44,7 @@ module Solargraph
       end
 
       # An array of files excluded from the workspace.
-      # 
+      #
       # @return [Array<String>]
       def excluded
         return [] if workspace.nil?

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -30,4 +30,5 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency 'rspec', '~> 3.5', '>= 3.5.0'
   s.add_development_dependency 'simplecov', '~> 0.14'
+  s.add_development_dependency 'pry', '~> 0.11.3'
 end


### PR DESCRIPTION
With this PR Solargraph does a complete parse of the codebase at its initialization. 

I was able to achieve almost instantaneous `Go To Definition` **on different constants** after using this feature for the first time.

It also kept working all when I moved definitions from file to file or removed some. 