### PR TITLE
straw man proposal for adding sourcegraph file extension support

### DIFF
--- a/lib/solargraph.rb
+++ b/lib/solargraph.rb
@@ -24,6 +24,7 @@ module Solargraph
 
   autoload :Shell,          'solargraph/shell'
   autoload :Source,         'solargraph/source'
+  autoload :SourceRemote,   'solargraph/source_remote'
   autoload :ApiMap,         'solargraph/api_map'
   autoload :YardMap,        'solargraph/yard_map'
   autoload :Pin,            'solargraph/pin'
@@ -33,8 +34,10 @@ module Solargraph
   autoload :CoreFills,      'solargraph/core_fills'
   autoload :LanguageServer, 'solargraph/language_server'
   autoload :Workspace,      'solargraph/workspace'
+  autoload :WorkspaceRemote,'solargraph/workspace_remote'
   autoload :Page,           'solargraph/page'
   autoload :Library,        'solargraph/library'
+  autoload :LibraryRemote,  'solargraph/library_remote'
   autoload :Diagnostics,    'solargraph/diagnostics'
 
   YARDOC_PATH = File.join(File.realpath(File.dirname(__FILE__)), '..', 'yardoc')

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -66,7 +66,9 @@ module Solargraph
         @cancel_semaphore.synchronize { @cancel.delete id }
       end
 
-      # Get / Set initialized property
+      # Get / Set initialized property. False when server is started.
+      # Initialization begins after first initialize request. Set to true
+      # after initialization completes.
       #
       # @param val [Boolean]
       # @return [Boolean]
@@ -98,7 +100,7 @@ module Solargraph
             # wait till initialized to process - each request is in own thread
             # so this will only block the request thread
             while !@initialized
-              sleep 1
+              sleep 0.1
             end
             start_method request
           end

--- a/lib/solargraph/language_server/message/initialize.rb
+++ b/lib/solargraph/language_server/message/initialize.rb
@@ -4,7 +4,6 @@ module Solargraph
       class Initialize < Base
         def process
           host.configure params['initializationOptions']
-          host.prepare params['rootPath']
           result = {
             capabilities: {
               textDocumentSync: 2, # @todo What should this be?

--- a/lib/solargraph/library_remote.rb
+++ b/lib/solargraph/library_remote.rb
@@ -1,0 +1,30 @@
+module Solargraph
+  class LibraryRemote < Solargraph::Library
+
+    # @param workspace [Solargraph::Workspace]
+    def initialize host
+      @host = host
+    end
+
+    # @return [Solargraph::Workspace]
+    def workspace workspace = nil
+      @workspace = workspace unless workspace.nil?
+      @workspace
+    end
+
+    def api_map
+      return @api_map if @api_map
+      @api_map = Solargraph::ApiMap.new(@workspace)
+      @host.initialized true
+      @api_map
+    end
+
+    def self.load host, directory
+      library = Solargraph::LibraryRemote.new host
+      workspace = Solargraph::WorkspaceRemote.new(host, library, directory)
+      library.workspace workspace
+      library
+    end
+
+  end
+end

--- a/lib/solargraph/library_remote.rb
+++ b/lib/solargraph/library_remote.rb
@@ -1,6 +1,5 @@
 module Solargraph
   class LibraryRemote < Solargraph::Library
-
     # @param workspace [Solargraph::Workspace]
     def initialize host
       @host = host
@@ -25,6 +24,5 @@ module Solargraph
       library.workspace workspace
       library
     end
-
   end
 end

--- a/lib/solargraph/source_remote.rb
+++ b/lib/solargraph/source_remote.rb
@@ -1,0 +1,18 @@
+module Solargraph
+  class SourceRemote < Solargraph::Source
+    class << self
+      # @param filename [String]
+      # @return [Solargraph::Source]
+      def load filename
+      	raise NoMethodError.new "load not supported when using remote files"
+      end
+
+      # @param code [String]
+      # @param filename [String]
+      # @return [Solargraph::Source]
+      def load_string code, filename = nil
+        SourceRemote.new code, filename
+      end
+    end
+  end
+end

--- a/lib/solargraph/source_remote.rb
+++ b/lib/solargraph/source_remote.rb
@@ -1,10 +1,14 @@
 module Solargraph
   class SourceRemote < Solargraph::Source
     class << self
+      # In the parent class this method does a blocking laod and returns
+      # the file contents which is not possible with the async network
+      # loading done by this sub-class. The only way to create a new
+      # SourceRemote instance is to pass in the file content with load_string.
       # @param filename [String]
       # @return [Solargraph::Source]
       def load filename
-      	raise NoMethodError.new "load not supported when using remote files"
+        raise NoMethodError.new "load not supported when using remote files"
       end
 
       # @param code [String]

--- a/lib/solargraph/workspace_remote.rb
+++ b/lib/solargraph/workspace_remote.rb
@@ -1,0 +1,57 @@
+module Solargraph
+  class WorkspaceRemote < Solargraph::Workspace
+
+  	autoload :ConfigRemote, 'solargraph/workspace_remote/config_remote'
+
+    # @param directory [String]
+    def initialize host, library, directory = nil
+      @host = host
+      @library = library
+      @directory = directory
+      @directory = nil if @directory == ''
+      load_file_list unless @directory.nil?
+    end
+
+    # @return [Solargraph::Workspace::Config]
+    def config files = nil
+      @config = Solargraph::WorkspaceRemote::ConfigRemote.new(@directory, files) if @config.nil? or !files.nil?
+      @config
+    end
+
+    def load_file_list
+      @host.send_request "workspace/xfiles", {'base' => "file://#{@directory}"} do |response|
+        files = []
+        response.each do |file|
+          files.push file['uri']
+        end
+        config files
+        load_sources
+      end
+    end
+
+    def load_sources
+      source_hash.clear
+      unless directory.nil?
+        size = config.calculated.length
+        if size == 0
+          @host.initialized true
+          return
+        end
+        raise WorkspaceTooLargeError.new(size, config.max_files) if config.max_files > 0 and size > config.max_files
+        loaded = 0
+        config.calculated.each do |fileuri|
+          @host.send_request "textDocument/xcontent", {'textDocument' => {'uri' => fileuri}} do |response|
+            filename = fileuri.gsub(/^[^:]+:\/\//, "")
+            source_hash[filename] = Solargraph::SourceRemote.load_string(response['text'], filename)
+            loaded += 1
+            if loaded == size and !@host.initialized
+              @library.api_map
+            end
+          end
+        end
+      end
+      @stime = Time.now
+    end
+
+  end
+end

--- a/lib/solargraph/workspace_remote.rb
+++ b/lib/solargraph/workspace_remote.rb
@@ -1,6 +1,5 @@
 module Solargraph
   class WorkspaceRemote < Solargraph::Workspace
-
   	autoload :ConfigRemote, 'solargraph/workspace_remote/config_remote'
 
     # @param directory [String]
@@ -52,6 +51,5 @@ module Solargraph
       end
       @stime = Time.now
     end
-
   end
 end

--- a/lib/solargraph/workspace_remote/config_remote.rb
+++ b/lib/solargraph/workspace_remote/config_remote.rb
@@ -3,7 +3,7 @@ module Solargraph
     class ConfigRemote < Solargraph::Workspace::Config
 
       def initialize workspace = nil, files = nil
-      	@files = files
+        @files = files
         @workspace = workspace
         include_globs = ['**/*.rb', '**.rb']
         exclude_globs = [
@@ -20,7 +20,9 @@ module Solargraph
         @raw_data['reporters'] ||= %w[rubocop require_not_found]
         @raw_data['plugins'] ||= []
         @raw_data['max_files'] ||= Workspace::MAX_WORKSPACE_SIZE
+        # initialize @included files from include_globs
         included
+        # initialize @excluded files from exclude_globs
         excluded
       end
 
@@ -28,44 +30,43 @@ module Solargraph
       #
       # @return [Array<String>]
       def included
-      	return @included unless @included.nil?
+        return @included unless @included.nil?
         @included = []
         return @included if @files.nil?
         @files.each do |file|
-        	@included.push(file) if file_included(file, @raw_data['include'])
+          @included.push(file) if file_included(file, @raw_data['include'])
         end
         @included
       end
 
       def file_included file, include_globs
-      	file = file.gsub(/^[^:]+:\/\/\/?/, "")
-      	include_globs.each do |include_glob|
-      		return true if File.fnmatch(include_glob, file)
-      	end
-      	return false
+        file = file.gsub(/^[^:]+:\/\/\/?/, "")
+        include_globs.each do |include_glob|
+          return true if File.fnmatch(include_glob, file)
+        end
+        return false
       end
 
       # An array of files excluded from the workspace.
       #
       # @return [Array<String>]
       def excluded
-      	return @excluded unless @excluded.nil?
+        return @excluded unless @excluded.nil?
         @excluded = []
         return @excluded if @files.nil?
         @files.each do |file|
-        	@excluded.push(file) if file_excluded(file, @raw_data['exclude'])
+          @excluded.push(file) if file_excluded(file, @raw_data['exclude'])
         end
         @excluded
       end
 
       def file_excluded file, exclude_globs
-      	file = file.gsub(/^[^:]+:\/\/\/?/, "")
-      	exclude_globs.each do |exclude_glob|
-      		return true if File.fnmatch(exclude_glob, file)
-      	end
-      	return false
+        file = file.gsub(/^[^:]+:\/\/\/?/, "")
+        exclude_globs.each do |exclude_glob|
+          return true if File.fnmatch(exclude_glob, file)
+        end
+        return false
       end
-
     end
   end
 end

--- a/lib/solargraph/workspace_remote/config_remote.rb
+++ b/lib/solargraph/workspace_remote/config_remote.rb
@@ -1,0 +1,71 @@
+module Solargraph
+  class Workspace
+    class ConfigRemote < Solargraph::Workspace::Config
+
+      def initialize workspace = nil, files = nil
+      	@files = files
+        @workspace = workspace
+        include_globs = ['**/*.rb', '**.rb']
+        exclude_globs = [
+          'spec/**/*', 'spec/**',
+          'test/**/*', 'test/**',
+          'vendor/**/*', 'vendor/**',
+          '.bundle/**/*', '.bundle/**'
+        ]
+        @raw_data ||= {}
+        @raw_data['include'] ||= include_globs
+        @raw_data['exclude'] ||= exclude_globs
+        @raw_data['require'] ||= []
+        @raw_data['domains'] ||= []
+        @raw_data['reporters'] ||= %w[rubocop require_not_found]
+        @raw_data['plugins'] ||= []
+        @raw_data['max_files'] ||= Workspace::MAX_WORKSPACE_SIZE
+        included
+        excluded
+      end
+
+      # An array of files included in the workspace (before calculating excluded files).
+      #
+      # @return [Array<String>]
+      def included
+      	return @included unless @included.nil?
+        @included = []
+        return @included if @files.nil?
+        @files.each do |file|
+        	@included.push(file) if file_included(file, @raw_data['include'])
+        end
+        @included
+      end
+
+      def file_included file, include_globs
+      	file = file.gsub(/^[^:]+:\/\/\/?/, "")
+      	include_globs.each do |include_glob|
+      		return true if File.fnmatch(include_glob, file)
+      	end
+      	return false
+      end
+
+      # An array of files excluded from the workspace.
+      #
+      # @return [Array<String>]
+      def excluded
+      	return @excluded unless @excluded.nil?
+        @excluded = []
+        return @excluded if @files.nil?
+        @files.each do |file|
+        	@excluded.push(file) if file_excluded(file, @raw_data['exclude'])
+        end
+        @excluded
+      end
+
+      def file_excluded file, exclude_globs
+      	file = file.gsub(/^[^:]+:\/\/\/?/, "")
+      	exclude_globs.each do |exclude_glob|
+      		return true if File.fnmatch(exclude_glob, file)
+      	end
+      	return false
+      end
+
+    end
+  end
+end

--- a/spec/library_remote_spec.rb
+++ b/spec/library_remote_spec.rb
@@ -63,5 +63,4 @@ describe Solargraph::LibraryRemote do
       end
     end
   end
-
 end

--- a/spec/library_remote_spec.rb
+++ b/spec/library_remote_spec.rb
@@ -1,0 +1,67 @@
+describe Solargraph::LibraryRemote do
+
+  before(:each) {
+    @host = instance_double Solargraph::LanguageServer::Host
+    allow(@host).to receive(:send_request)
+    allow(@host).to receive(:initialized)
+  }
+
+  describe "api_map" do
+    before(:each) {
+      @library = Solargraph::LibraryRemote.load @host, "/foo"
+    }
+
+    describe "when api map not set" do
+      it "should set host initialized" do
+        @library.api_map
+        expect(@host).to have_received(:initialized).with(true)
+      end
+    end
+
+    describe "when api map set" do
+      it "should return api map" do
+        api_map = @library.api_map
+        api_map_new = @library.api_map
+        expect(api_map).to equal(api_map_new)
+      end
+    end
+  end
+
+  describe "load" do
+    before(:each) {
+      allow(Solargraph::LibraryRemote).to receive(:new).and_return Solargraph::LibraryRemote.new @host
+      allow(Solargraph::LibraryRemote).to receive(:api_map)
+      Solargraph::LibraryRemote.load @host, "/foo"
+    }
+
+    it "should create new instance" do
+      expect(Solargraph::LibraryRemote).to have_received(:new)
+    end
+
+    it "should not call api_map" do
+      expect(Solargraph::LibraryRemote).to_not have_received(:api_map)
+    end
+  end
+
+  describe "workspace" do
+    before(:each) {
+      @library = Solargraph::LibraryRemote.load @host, "/foo"
+    }
+
+    describe "when no workspace passed" do
+      it "should return workspace" do
+        expect(@library.workspace).to be_kind_of(Solargraph::WorkspaceRemote)
+      end
+    end
+
+    describe "when workspace passed" do
+      it "should set workspace" do
+        set_workspace = instance_double Solargraph::WorkspaceRemote
+        new_workspace = @library.workspace set_workspace
+        expect(new_workspace).to equal(set_workspace)
+        expect(@library.workspace).to equal(set_workspace)
+      end
+    end
+  end
+
+end

--- a/spec/source_remote_spec.rb
+++ b/spec/source_remote_spec.rb
@@ -12,5 +12,4 @@ describe Solargraph::SourceRemote do
       expect(source).to be_kind_of(Solargraph::SourceRemote)
     end
   end
-
 end

--- a/spec/source_remote_spec.rb
+++ b/spec/source_remote_spec.rb
@@ -1,0 +1,16 @@
+describe Solargraph::SourceRemote do
+
+  describe "load" do
+    it "should raise error" do
+      expect { Solargraph::SourceRemote.load "foo" }.to raise_error(NoMethodError)
+    end
+  end
+
+  describe "load_string" do
+    it "should return new instance" do
+      source = Solargraph::SourceRemote.load_string "foo", "bar"
+      expect(source).to be_kind_of(Solargraph::SourceRemote)
+    end
+  end
+
+end

--- a/spec/workspace_remote/config_remote_spec.rb
+++ b/spec/workspace_remote/config_remote_spec.rb
@@ -1,0 +1,43 @@
+describe Solargraph::WorkspaceRemote::ConfigRemote do
+
+  before(:each) {
+    @config = Solargraph::WorkspaceRemote::ConfigRemote.new nil, [
+      "file:///foo.rb",
+      "file:///foo/bar.rb",
+      "file:///spec/foo_spec.rb",
+      "file:///spec/foo/bar_spec.rb",
+      "file:///.bundle/foo.rb",
+    ]
+  }
+
+  describe "initialize" do
+    it "should apply include and exclude globs to files" do
+      expect(@config.calculated).to eq [
+        "file:///foo.rb",
+        "file:///foo/bar.rb",
+      ]
+    end
+  end
+
+  describe "included" do
+    it "should include files that match globs" do
+      expect(@config.included).to eq [
+        "file:///foo.rb",
+        "file:///foo/bar.rb",
+        "file:///spec/foo_spec.rb",
+        "file:///spec/foo/bar_spec.rb",
+      ]
+    end
+  end
+
+  describe "excluded" do
+    it "should exclude files that match globs" do
+      expect(@config.excluded).to eq [
+        "file:///spec/foo_spec.rb",
+        "file:///spec/foo/bar_spec.rb",
+        "file:///.bundle/foo.rb",
+      ]
+    end
+  end
+
+end

--- a/spec/workspace_remote/config_remote_spec.rb
+++ b/spec/workspace_remote/config_remote_spec.rb
@@ -39,5 +39,4 @@ describe Solargraph::WorkspaceRemote::ConfigRemote do
       ]
     end
   end
-
 end

--- a/spec/workspace_remote_spec.rb
+++ b/spec/workspace_remote_spec.rb
@@ -88,5 +88,4 @@ describe Solargraph::WorkspaceRemote do
       end
     end
   end
-
 end

--- a/spec/workspace_remote_spec.rb
+++ b/spec/workspace_remote_spec.rb
@@ -1,0 +1,92 @@
+describe Solargraph::WorkspaceRemote do
+
+  before(:each) {
+    @host = instance_double Solargraph::LanguageServer::Host
+    allow(@host).to receive(:send_request)
+    allow(@host).to receive(:initialized)
+    @library = instance_double Solargraph::LibraryRemote
+  }
+
+  describe "initalize" do
+    describe "without directory" do
+      it "should not load files" do
+        workspace = Solargraph::WorkspaceRemote.new @host, @library
+        expect(@host).to_not have_received(:send_request)
+      end
+    end
+
+    describe "with directory" do
+      it "should load files" do
+        workspace = Solargraph::WorkspaceRemote.new @host, @library, ["/foo"]
+        expect(@host).to have_received(:send_request).with("workspace/xfiles", {"base"=>"file://[\"/foo\"]"})
+      end
+    end
+  end
+
+  describe "config" do
+    before(:each) {
+      @workspace = Solargraph::WorkspaceRemote.new @host, @library, ["/foo"]
+    }
+
+    describe "with no files and no config" do
+      it "should create config" do
+        config = @workspace.config
+        expect(config).to be_kind_of(Solargraph::WorkspaceRemote::ConfigRemote)
+      end
+    end
+
+    describe "with config and no files" do
+      it "should return existing config" do
+        config = @workspace.config
+        config_new = @workspace.config
+        expect(config).to equal(config_new)
+      end
+    end
+
+    describe "with config and files" do
+      it "should return new config" do
+        config = @workspace.config
+        config_new = @workspace.config ["/bar"]
+        expect(config).to_not equal(config_new)
+      end
+    end
+  end
+
+  describe "load_file_list" do
+    before(:each) {
+      @workspace = Solargraph::WorkspaceRemote.new @host, @library
+    }
+
+    it "should load files" do
+      @workspace.load_file_list
+      expect(@host).to have_received(:send_request).with("workspace/xfiles", {"base"=>"file://"})
+    end
+  end
+
+  describe "load_sources" do
+    before(:each) {
+      @workspace = Solargraph::WorkspaceRemote.new @host, @library, ["/foo"]
+    }
+
+    describe "without files" do
+      it "should set host initialized" do
+        @workspace.load_sources
+        expect(@host).to have_received(:initialized).with(true)
+      end
+    end
+
+    describe "with files" do
+
+      before(:each) {
+        @workspace.config ["/foo.rb", "/bar.rb"]
+      }
+
+      it "should request files" do
+        @workspace.load_sources
+        expect(@host).to have_received(:send_request).with("textDocument/xcontent", {'textDocument' => {'uri' => "/foo.rb"}})
+        expect(@host).to have_received(:send_request).with("textDocument/xcontent", {'textDocument' => {'uri' => "/bar.rb"}})
+      end
+    end
+  end
+
+end


### PR DESCRIPTION
This PR has a working implementation of sourcegraph's files extension: https://sourcegraph.com/github.com/sourcegraph/language-server-protocol/-/blob/extension-files.md

The implementation method is to:
* enter "remote" mode using files extension if client advertises support
* set a global initialized flag on host and defer all requests until initialized
* defer some operations (e.g. Library api_map) until files are loaded
* modify Config to take list of files along with directory and load those files from the LSP client

Not dealt with:
* anything dealing with editing files

Pending discussion on whether or not this is something that could be merged upstream and whether or not the implementation approach makes sense for the code base I can modify and flesh out as needed.