### PR TITLE
FIX: Request textDocument/hover failed

### DIFF
--- a/lib/solargraph/source/fragment.rb
+++ b/lib/solargraph/source/fragment.rb
@@ -155,7 +155,7 @@ module Solargraph
       #
       # @return [String]
       def whole_word
-        @whole_word ||= word + remainder
+        @whole_word ||= word + remainder.to_s
       end
 
       # Get the whole signature at the current offset, including the final


### PR DESCRIPTION
Great news from #81! Looking forward to the improvement. In the meantime this PR attempts to ensure correct type for String addition:

VSCode log output
```
[Error] Request textDocument/definition failed.
  Message: [TypeError] no implicit conversion of nil into String
  Code: -32603 
```

and backtrace from VSCode DevTools
<img width="977" alt="screen shot 2018-08-19 at 22 55 36" src="https://user-images.githubusercontent.com/3710893/44309210-8f8de400-a406-11e8-8ad9-a6760472e9b6.png">

Cheers