### PR TITLE
Fix rspec deprecation warnings.

### DIFF
--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -101,7 +101,7 @@ describe Solargraph::Library do
     library.close file
     expect {
       library.checkout file
-    }.not_to raise_error(Solargraph::FileNotFoundError)
+    }.not_to raise_error
   end
 
   it "keeps a closed file in the workspace" do

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -58,11 +58,13 @@ describe Solargraph::Workspace do
   end
 
   it "allows for unlimited files in config" do
-    config = double(:config, calculated: Array.new(Solargraph::Workspace::Config::MAX_FILES + 1), max_files: 0)
-    # @todo Creating the workspace raises a TypeError because the filenames are nil
+    gemspec_file = File.join(dir_path, 'test.gemspec')
+    File.write(gemspec_file, '')
+    calculated = Array.new(Solargraph::Workspace::Config::MAX_FILES + 1) { gemspec_file }
+    config = double(:config, calculated: calculated, max_files: 0)
     expect {
       Solargraph::Workspace.new('.', config)
-    }.not_to raise_error(Solargraph::WorkspaceTooLargeError)
+    }.not_to raise_error
   end
 
   it "detects gemspecs in workspaces" do


### PR DESCRIPTION
This initializes the array to an object that `filename` can be called on. This will probably make the test run a bit slower since it is initializing data in the `Array`, though I'm not sure if there is a performance hit or not.

It could be replaced by making another `double` if desired, but I try to use as few of them as possible:

```
calculated = double(:calculated, each: [], length: Solargraph::Workspace::Config::MAX_FILES + 1)
config = double(:config, calculated: calculated, max_files: 0)
```