### PR TITLE
Allow configs for reporters; Rubocop can be passed additional args

### DIFF
--- a/LANGUAGE_SERVER.md
+++ b/LANGUAGE_SERVER.md
@@ -49,3 +49,21 @@ reporters:
 necessarily mean that the path is incorrect; only that Solargraph was unable to recognize it.
 
 Run `solargraph reporters` for a list of available reporters.
+
+### RuboCop Configuration
+
+Additional arguments can be passed to RuboCop commands by using a slightly
+different configuration. For example, the following will ignore reporting diagnostics
+on files that your RuboCop configuration excludes and only perform linting rules:
+
+```
+reporters:
+- rubocop:
+    arguments:
+    - --force-exclusion
+    - --lint
+- require_not_found
+```
+
+The json formatter and a path to the closest configuration file discovered are
+passed automatically by Solargraph and should not be added as additional arguments.

--- a/lib/solargraph/diagnostics/base.rb
+++ b/lib/solargraph/diagnostics/base.rb
@@ -11,8 +11,9 @@ module Solargraph
       #
       # @param source [Solargraph::Source]
       # @param api_map [Solargraph::ApiMap]
+      # @param config [Hash]
       # @return [Array<Hash>]
-      def diagnose source, api_map
+      def diagnose source, api_map, config = {}
         []
       end
     end

--- a/lib/solargraph/diagnostics/require_not_found.rb
+++ b/lib/solargraph/diagnostics/require_not_found.rb
@@ -4,7 +4,7 @@ module Solargraph
     # either a file in the workspace or a gem.
     #
     class RequireNotFound < Base
-      def diagnose source, api_map
+      def diagnose source, api_map, config = {}
         result = []
         refs = {}
         map = Solargraph::SourceMap.map(source)

--- a/lib/solargraph/diagnostics/rubocop.rb
+++ b/lib/solargraph/diagnostics/rubocop.rb
@@ -39,7 +39,7 @@ module Solargraph
         rubocop_file = find_rubocop_file(filename)
         args.push('-c', fix_drive_letter(rubocop_file)) unless rubocop_file.nil?
         args.push(filename)
-        args.push(*str_to_args(config['arguments'])) if config.key?('arguments')
+        args.concat(config['arguments']) if config.key?('arguments')
         options, paths = RuboCop::Options.new.parse(args)
         options[:stdin] = code
         [options, paths]
@@ -66,12 +66,6 @@ module Solargraph
         yield if block_given?
         $stdout = STDOUT
         redir.string
-      end
-
-      # @param arguments [String]
-      # @return [Array<String>]
-      def str_to_args(arguments)
-        arguments.split.map(&:strip)
       end
 
       # @param resp [Hash]

--- a/lib/solargraph/diagnostics/type_not_defined.rb
+++ b/lib/solargraph/diagnostics/type_not_defined.rb
@@ -4,7 +4,7 @@ module Solargraph
     # parameters, and invalid param tags.
     #
     class TypeNotDefined < Base
-      def diagnose source, api_map
+      def diagnose source, api_map, config = {}
         result = []
         api_map.document_symbols(source.filename).each do |pin|
           next unless pin.kind == Pin::METHOD or pin.kind == Pin::ATTRIBUTE

--- a/lib/solargraph/diagnostics/update_errors.rb
+++ b/lib/solargraph/diagnostics/update_errors.rb
@@ -1,7 +1,7 @@
 module Solargraph
   module Diagnostics
     class UpdateErrors < Base
-      def diagnose source, api_map
+      def diagnose source, api_map, config = {}
         result = []
         combine_ranges(source.code, source.error_ranges).each do |range|
           result.push(

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -298,10 +298,10 @@ module Solargraph
       return [] unless open?(filename)
       result = []
       source = read(filename)
-      workspace.config.reporters.each do |name|
+      workspace.config.reporters.each do |name, config|
         reporter = Diagnostics.reporter(name)
         raise DiagnosticsError, "Diagnostics reporter #{name} does not exist" if reporter.nil?
-        result.concat reporter.new.diagnose(source, api_map)
+        result.concat reporter.new.diagnose(source, api_map, config)
       end
       result
     end

--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -5,6 +5,7 @@ module Solargraph
   #
   class Workspace
     autoload :Config, 'solargraph/workspace/config'
+    autoload :ReporterConfigs, 'solargraph/workspace/reporter_configs'
 
     # @return [String]
     attr_reader :directory

--- a/lib/solargraph/workspace/config.rb
+++ b/lib/solargraph/workspace/config.rb
@@ -94,11 +94,11 @@ module Solargraph
         raw_data['plugins']
       end
 
-      # An array of reporters to use for diagnostics.
+      # A reporter config collection to use for diagnostics.
       #
-      # @return [Array<String>]
+      # @return [ReporterConfigs]
       def reporters
-        raw_data['reporters']
+        ReporterConfigs.new(raw_data['reporters'])
       end
 
       # The maximum number of files to parse from the workspace.

--- a/lib/solargraph/workspace/reporter_configs.rb
+++ b/lib/solargraph/workspace/reporter_configs.rb
@@ -1,0 +1,31 @@
+require 'yaml'
+
+module Solargraph
+  class Workspace
+    # Configuration data for a collection of reporters.
+    #
+    class ReporterConfigs
+      include Enumerable
+
+      # @param reporter_config [Array<String, Object>]
+      def initialize(reporter_config)
+        @reporter_config = reporter_config
+      end
+
+      # Enumerable method to allow iteration of values.
+      #
+      # @param &_block The block that processes the response
+      # @yieldparam [String] The string name of the reporter
+      # @yieldparam [Hash] The reporter configuration
+      # @return [Array<String, Hash>, Enumerator] Collection of reporters and their configs
+      def each(&_block)
+        return @reporter_config.each unless block_given?
+
+        @reporter_config.each do |reporter|
+          next yield(reporter, {}) if reporter.is_a?(String)
+          yield(reporter.keys.first, reporter.values.first)
+        end
+      end
+    end
+  end
+end

--- a/spec/diagnostics/rubocop_spec.rb
+++ b/spec/diagnostics/rubocop_spec.rb
@@ -31,7 +31,7 @@ AllCops:
 CONTENTS
 )
     rubocop = Solargraph::Diagnostics::Rubocop.new
-    result = rubocop.diagnose(@source, @api_map, { 'arguments' => '--force-exclusion --lint' })
+    result = rubocop.diagnose(@source, @api_map, { 'arguments' => ['--force-exclusion', '--lint'] })
     expect(result).to be_a(Array)
     expect(result).to be_empty
   end
@@ -45,11 +45,11 @@ AllCops:
 CONTENTS
 )
     rubocop = Solargraph::Diagnostics::Rubocop.new
-    result = rubocop.diagnose(@source, @api_map, { 'arguments' => '--force-exclusion' })
+    result = rubocop.diagnose(@source, @api_map, { 'arguments' => ['--force-exclusion'] })
     expect(result).to be_a(Array)
     expect(result.count).to eq(6)
 
-    result = rubocop.diagnose(@source, @api_map, { 'arguments' => '--force-exclusion --lint' })
+    result = rubocop.diagnose(@source, @api_map, { 'arguments' => ['--force-exclusion', '--lint'] })
     expect(result.count).to eq(1)
   end
 end

--- a/spec/diagnostics/rubocop_spec.rb
+++ b/spec/diagnostics/rubocop_spec.rb
@@ -6,15 +6,50 @@ describe Solargraph::Diagnostics::Rubocop do
         end
       end
       foo = Foo.new
-    ), 'file.rb')
+    ), "#{dir_path}/file.rb")
 
     @api_map = Solargraph::ApiMap.new
     @api_map.map @source
   end
 
+  let(:dir_path) { File.realpath(Dir.mktmpdir) }
+  after(:each) { FileUtils.remove_entry(dir_path) }
+
   it "diagnoses input" do
     rubocop = Solargraph::Diagnostics::Rubocop.new
     result = rubocop.diagnose(@source, @api_map)
     expect(result).to be_a(Array)
+    expect(result).not_to be_empty
+  end
+
+  it "ignores excluded files from diagnoses output" do
+    file = File.join(dir_path, '.rubocop.yml')
+    File.write(file, <<-CONTENTS
+AllCops:
+  Exclude:
+    - 'file.rb'
+CONTENTS
+)
+    rubocop = Solargraph::Diagnostics::Rubocop.new
+    result = rubocop.diagnose(@source, @api_map, { 'arguments' => '--force-exclusion --lint' })
+    expect(result).to be_a(Array)
+    expect(result).to be_empty
+  end
+
+  it "still reports non-excluded files in diagnoses output" do
+    file = File.join(dir_path, '.rubocop.yml')
+    File.write(file, <<-CONTENTS
+AllCops:
+  Exclude:
+    - 'file2.rb'
+CONTENTS
+)
+    rubocop = Solargraph::Diagnostics::Rubocop.new
+    result = rubocop.diagnose(@source, @api_map, { 'arguments' => '--force-exclusion' })
+    expect(result).to be_a(Array)
+    expect(result.count).to eq(6)
+
+    result = rubocop.diagnose(@source, @api_map, { 'arguments' => '--force-exclusion --lint' })
+    expect(result.count).to eq(1)
   end
 end

--- a/spec/workspace/config_spec.rb
+++ b/spec/workspace/config_spec.rb
@@ -56,12 +56,15 @@ describe Solargraph::Workspace::Config do
 ---
 reporters:
 - rubocop:
-    arguments: --force-exclusions
+    arguments:
+    - --force-exclusion
+    - --lint
 - require_not_found
 - type_not_defined
 HEREDOC
     File.write(file, solargraph_config)
     config = Solargraph::Workspace::Config.new(dir_path)
-    expect(config.reporters.to_a).to include(['rubocop', { 'arguments' => '--force-exclusions' }])
+    expected = ['rubocop', { 'arguments' => ['--force-exclusion', '--lint'] }]
+    expect(config.reporters.to_a).to include(expected)
   end
 end

--- a/spec/workspace/config_spec.rb
+++ b/spec/workspace/config_spec.rb
@@ -46,7 +46,22 @@ describe Solargraph::Workspace::Config do
 
   it "includes base reporters by default" do
     config = Solargraph::Workspace::Config.new(dir_path)
-    expect(config.reporters).to include('rubocop')
-    expect(config.reporters).to include('require_not_found')
+    expect(config.reporters.to_a).to include(['rubocop', {}])
+    expect(config.reporters.to_a).to include(['require_not_found', {}])
+  end
+
+  it "can include rubocop reporter options" do
+    file = File.join(dir_path, '.solargraph.yml')
+    solargraph_config = <<-HEREDOC
+---
+reporters:
+- rubocop:
+    arguments: --force-exclusions
+- require_not_found
+- type_not_defined
+HEREDOC
+    File.write(file, solargraph_config)
+    config = Solargraph::Workspace::Config.new(dir_path)
+    expect(config.reporters.to_a).to include(['rubocop', { 'arguments' => '--force-exclusions' }])
   end
 end

--- a/spec/workspace/reporter_configs_spec.rb
+++ b/spec/workspace/reporter_configs_spec.rb
@@ -1,0 +1,37 @@
+require 'fileutils'
+require 'tmpdir'
+
+describe Solargraph::Workspace::ReporterConfigs do
+  it "each calls block with reporter name and config" do
+    config = Solargraph::Workspace::ReporterConfigs.new([
+      'one',
+      'two',
+      { 'three' => { 'hello' => 'world' } },
+      'four'
+    ])
+
+    config.each do |reporter, reporter_config|
+      expect(reporter_config).to eq({}) if reporter == 'one'
+      expect(reporter_config).to eq({}) if reporter == 'two'
+      expect(reporter_config).to eq('hello' => 'world') if reporter == 'three'
+      expect(reporter_config).to eq({}) if reporter == 'four'
+    end
+  end
+
+  it "to_a returns array of two element arrays for reporters" do
+    config = Solargraph::Workspace::ReporterConfigs.new([
+      'one',
+      'two',
+      { 'three' => { 'hello' => 'world' } },
+      'four'
+    ])
+    expected = [
+      ['one', {}],
+      ['two', {}],
+      ['three', { 'hello' => 'world' }],
+      ['four', {}]
+    ]
+
+    expect(config.to_a).to eq(expected)
+  end
+end


### PR DESCRIPTION
This allows solargraph reporters to have configurations passed to them from a `.solargraph` config file. They are passed a hash of the options, which should all be empty hashes except for Rubocop which can now take an `arguments` param for additional parameters to add to commands ran.

It allows support for https://github.com/castwide/solargraph/issues/93.

For example:

```
---
reporters:
- require_not_found
- rubocop:
    arguments:
    - --force-exclusion
```

would run Rubocop with the [`--force-exclusion` option](https://docs.rubocop.org/en/latest/basic_usage/#other-useful-command-line-flags). The `arguments` portion of the reporter config should be an array of strings.

