### PR TITLE
We cannot trust that nil has undefined?

### DIFF
--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -28,6 +28,7 @@ module Solargraph
     end
 
     def method_missing name, *args, &block
+      return if first == nil
       return first.send(name, *args, &block) if respond_to_missing?(name)
       super
     end


### PR DESCRIPTION
First can possibly be nil here. If so, we don't want to pass any messages to it, including undefined?