### PR TITLE
Allow overriding core doc cache directory

### DIFF
--- a/lib/solargraph/yard_map/core_docs.rb
+++ b/lib/solargraph/yard_map/core_docs.rb
@@ -12,7 +12,7 @@ module Solargraph
 
       class << self
         def cache_dir
-          @cache_dir ||= File.join(Dir.home, '.solargraph', 'cache')
+          @cache_dir ||= ENV["SOLARGRAPH_CACHE"] || File.join(Dir.home, '.solargraph', 'cache')
         end
 
         # Ensure installation of minimum documentation.


### PR DESCRIPTION
The [XDG Base Directory Specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) aims to define single directories where all files of a similar nature are stored, rather than storing everything hidden in the home folder.

Following the specification, the location for the core docs should be at `$XDG_CACHE_HOME/solargraph`, defaulting to `$HOME/.cache/solargraph`. If not hard-coding the XDG directory by default (keeping in mind non-Linux users), it would be good to be able to override the cache directory location if the user desires.

Of course take this with a grain of salt as I'm a primary Linux user and don't know the experience for MacOS or Windows.