### PR TITLE
Host libraries

### DIFF
--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -240,7 +240,7 @@ module Solargraph
       # @param name [String, nil]
       # @return [void]
       def prepare directory, name = nil
-        # No need to create a library without a directory. The orphan library
+        # No need to create a library without a directory. The generic library
         # will handle it.
         return if directory.nil?
         logger.info "Preparing library for #{directory}"
@@ -282,7 +282,7 @@ module Solargraph
           next false if lib.workspace.directory != directory
           # @todo Since we're using Sources, this might not be necessary
           # lib.open_sources.each do |src|
-          #   orphan_library.open(src.filename, src.code, src.version)
+          #   generic_library.open(src.filename, src.code, src.version)
           # end
           true
         end
@@ -510,7 +510,7 @@ module Solargraph
       # @return [Array<Solargraph::Pin::Base>]
       def query_symbols query
         result = []
-        (libraries + [orphan_library]).each { |lib| result.concat lib.query_symbols(query) }
+        (libraries + [generic_library]).each { |lib| result.concat lib.query_symbols(query) }
         result.uniq
       end
 
@@ -655,13 +655,13 @@ module Solargraph
       # @param uri [String]
       # @return [Library]
       def generic_library_for uri
-        orphan_library.attach sources.find(uri)
-        orphan_library
+        generic_library.attach sources.find(uri)
+        generic_library
       end
 
       # @return [Library]
-      def orphan_library
-        @orphan_library ||= Solargraph::Library.new
+      def generic_library
+        @generic_library ||= Solargraph::Library.new
       end
 
       # @return [Diagnoser]

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -344,6 +344,7 @@ module Solargraph
       # that were not flagged for dynamic registration by the client.
       #
       # @param methods [Array<String>] The methods to register
+      # @return [void]
       def register_capabilities methods
         logger.debug "Registering capabilities: #{methods}"
         @register_semaphore.synchronize do
@@ -365,6 +366,7 @@ module Solargraph
       # that were not flagged for dynamic registration by the client.
       #
       # @param methods [Array<String>] The methods to unregister
+      # @return [void]
       def unregister_capabilities methods
         logger.debug "Unregistering capabilities: #{methods}"
         @register_semaphore.synchronize do
@@ -383,6 +385,7 @@ module Solargraph
       # Flag a method as available for dynamic registration.
       #
       # @param method [String] The method name, e.g., 'textDocument/completion'
+      # @return [void]
       def allow_registration method
         @register_semaphore.synchronize do
           @dynamic_capabilities.add method
@@ -409,6 +412,7 @@ module Solargraph
         cataloger.synchronizing?
       end
 
+      # @return [void]
       def stop
         @stopped = true
         cataloger.stop
@@ -537,6 +541,7 @@ module Solargraph
       #
       # @param text [String]
       # @param type [Integer] A MessageType constant
+      # @return [void]
       def show_message text, type = LanguageServer::MessageTypes::INFO
         send_notification 'window/showMessage', {
           type: type,
@@ -551,6 +556,7 @@ module Solargraph
       # @param actions [Array<String>] Response options for the client
       # @param &block The block that processes the response
       # @yieldparam [String] The action received from the client
+      # @return [void]
       def show_message_request text, type, actions, &block
         send_request 'window/showMessageRequest', {
           type: type,
@@ -591,6 +597,8 @@ module Solargraph
         lib.catalog
       end
 
+      # @param uri [String]
+      # @return [Array<Range>]
       def folding_ranges uri
         library = library_for(uri)
         file = uri_to_file(uri)
@@ -609,12 +617,16 @@ module Solargraph
         @sources ||= Sources.new
       end
 
+      # @param uri [String]
+      # @return [Library]
       def library_for uri
         explicit_library_for(uri) ||
           implicit_library_for(uri) ||
           generic_library_for(uri)
       end
 
+      # @param uri [String]
+      # @return [Library, nil]
       def explicit_library_for uri
         filename = uri_to_file(uri)
         libraries.each do |lib|
@@ -626,6 +638,8 @@ module Solargraph
         nil
       end
 
+      # @param uri [String]
+      # @return [Library, nil]
       def implicit_library_for uri
         filename = uri_to_file(uri)
         libraries.each do |lib|
@@ -638,8 +652,9 @@ module Solargraph
         nil
       end
 
+      # @param uri [String]
+      # @return [Library]
       def generic_library_for uri
-        # orphan_library.merge sources.find(uri)
         orphan_library.attach sources.find(uri)
         orphan_library
       end

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -632,7 +632,8 @@ module Solargraph
       end
 
       def generic_library_for uri
-        orphan_library.merge sources.find(uri)
+        # orphan_library.merge sources.find(uri)
+        orphan_library.attach sources.find(uri)
         orphan_library
       end
 

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -94,8 +94,8 @@ module Solargraph
       end
 
       # Respond to a notification that a file was created in the workspace.
-      # The library will determine whether the file should be added to the
-      # workspace; see Solargraph::Library#create_from_disk.
+      # The libraries will determine whether the file should be merged; see
+      # Solargraph::Library#create_from_disk.
       #
       # @param uri [String] The file uri.
       # @return [Boolean] True if a library accepted the file.
@@ -618,7 +618,10 @@ module Solargraph
       def explicit_library_for uri
         filename = uri_to_file(uri)
         libraries.each do |lib|
-          return lib if lib.contain?(filename) || lib.open?(filename)
+          if lib.contain?(filename) #|| lib.open?(filename)
+            lib.attach nil
+            return lib
+          end
         end
         nil
       end
@@ -626,7 +629,11 @@ module Solargraph
       def implicit_library_for uri
         filename = uri_to_file(uri)
         libraries.each do |lib|
-          return lib if filename.start_with?(lib.workspace.directory)
+          # return lib if filename.start_with?(lib.workspace.directory)
+          if lib.open?(filename) || filename.start_with?(lib.workspace.directory)
+            lib.attach sources.find(uri)
+            return lib
+          end
         end
         nil
       end

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -10,6 +10,7 @@ module Solargraph
     class Host
       autoload :Diagnoser, 'solargraph/language_server/host/diagnoser'
       autoload :Cataloger, 'solargraph/language_server/host/cataloger'
+      autoload :Sources,   'solargraph/language_server/host/sources'
 
       include Solargraph::LanguageServer::UriHelpers
       include Logging
@@ -575,6 +576,11 @@ module Solargraph
       # @return [Array<Library>]
       def libraries
         @libraries ||= []
+      end
+
+      # @return [Sources]
+      def sources
+        @sources ||= Sources.new
       end
 
       # @param uri [String]

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -127,6 +127,12 @@ module Solargraph
       def open uri, text, version
         library = library_for(uri)
         library.open uri_to_file(uri), text, version
+        # @todo Deprecate the above
+        src = sources.open(uri, text, version)
+        # @todo Merge the source with applicable libraries
+        libraries.each do |lib|
+          lib.merge src
+        end
         diagnoser.schedule uri
       end
 
@@ -141,7 +147,8 @@ module Solargraph
       # @param uri [String]
       # @return [Boolean]
       def open? uri
-        unsafe_open?(uri)
+        # unsafe_open?(uri)
+        sources.include? uri
       end
 
       # Close the file specified by the URI.
@@ -151,6 +158,8 @@ module Solargraph
       def close uri
         library = library_for(uri)
         library.close uri_to_file(uri)
+        # @todo Deprecate the above
+        sources.close uri
         diagnoser.schedule uri
       end
 

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -100,9 +100,6 @@ module Solargraph
       # @param uri [String] The file uri.
       # @return [Boolean] True if a library accepted the file.
       def create uri
-        # library = library_for(uri)
-        # filename = uri_to_file(uri)
-        # result = library.create_from_disk(filename)
         filename = uri_to_file(uri)
         result = false
         libraries.each do |lib|
@@ -116,9 +113,6 @@ module Solargraph
       #
       # @param uri [String] The file uri.
       def delete uri
-        # library = library_for(uri)
-        # filename = uri_to_file(uri)
-        # library.delete filename
         sources.close uri
         filename = uri_to_file(uri)
         libraries.each do |lib|
@@ -136,11 +130,7 @@ module Solargraph
       # @param text [String] The contents of the file.
       # @param version [Integer] A version number.
       def open uri, text, version
-        # library = library_for(uri)
-        # library.open uri_to_file(uri), text, version
-        # @todo Deprecate the above
         src = sources.open(uri, text, version)
-        # @todo Merge the source with applicable libraries
         libraries.each do |lib|
           lib.merge src
         end
@@ -158,7 +148,6 @@ module Solargraph
       # @param uri [String]
       # @return [Boolean]
       def open? uri
-        # unsafe_open?(uri)
         sources.include? uri
       end
 
@@ -167,9 +156,6 @@ module Solargraph
       # @param uri [String]
       # @return [void]
       def close uri
-        library = library_for(uri)
-        library.close uri_to_file(uri)
-        # @todo Deprecate the above
         sources.close uri
         diagnoser.schedule uri
       end
@@ -201,11 +187,6 @@ module Solargraph
       # @param params [Hash]
       # @return [void]
       def change params
-        # library = library_for(params['textDocument']['uri'])
-        # updater = generate_updater(params)
-        # library.update updater
-        # cataloger.ping(library)
-        # diagnoser.schedule params['textDocument']['uri']
         updater = generate_updater(params)
         src = sources.update(params['textDocument']['uri'], updater)
         libraries.each do |lib|
@@ -280,10 +261,6 @@ module Solargraph
         # @param lib [Library]
         libraries.delete_if do |lib|
           next false if lib.workspace.directory != directory
-          # @todo Since we're using Sources, this might not be necessary
-          # lib.open_sources.each do |src|
-          #   generic_library.open(src.filename, src.code, src.version)
-          # end
           true
         end
       end

--- a/lib/solargraph/language_server/host/sources.rb
+++ b/lib/solargraph/language_server/host/sources.rb
@@ -10,12 +10,22 @@ module Solargraph
           open_source_hash[uri] = source
         end
 
+        def update uri, updater
+          src = find(uri)
+          open_source_hash[uri] = src.synchronize(updater)
+        end
+
+        # @return [Source]
         def find uri
-          open_source_hash[uri]
+          open_source_hash[uri] || raise(Solargraph::FileNotFoundError, "Host could not find #{uri}")
         end
 
         def close uri
           open_source_hash.delete uri
+        end
+
+        def include? uri
+          open_source_hash.key? uri
         end
 
         private

--- a/lib/solargraph/language_server/host/sources.rb
+++ b/lib/solargraph/language_server/host/sources.rb
@@ -1,0 +1,29 @@
+module Solargraph
+  module LanguageServer
+    class Host
+      class Sources
+        include UriHelpers
+
+        def open uri, text, version
+          filename = uri_to_file(uri)
+          source = Solargraph::Source.new(text, filename, version)
+          open_source_hash[uri] = source
+        end
+
+        def find uri
+          open_source_hash[uri]
+        end
+
+        def close uri
+          open_source_hash.delete uri
+        end
+
+        private
+
+        def open_source_hash
+          @open_source_hash ||= {}
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/language_server/message/initialize.rb
+++ b/lib/solargraph/language_server/message/initialize.rb
@@ -113,12 +113,6 @@ module Solargraph
           }
         end
 
-        def static_references
-          {
-            referencesProvider: true
-          }
-        end
-
         def static_folding_range
           {
             foldingRangeProvider: true

--- a/lib/solargraph/language_server/message/initialize.rb
+++ b/lib/solargraph/language_server/message/initialize.rb
@@ -5,7 +5,6 @@ module Solargraph
         def process
           host.configure params['initializationOptions']
           if support_workspace_folders?
-            # @todo Prepare multiple folders
             host.prepare_folders params['workspaceFolders']
           elsif params['rootUri']
             host.prepare UriHelpers.uri_to_file(params['rootUri'])
@@ -42,7 +41,8 @@ module Solargraph
         def support_workspace_folders?
           params['capabilities'] &&
             params['capabilities']['workspace'] &&
-            params['capabilities']['workspace']['workspaceFolders']
+            params['capabilities']['workspace']['workspaceFolders'] &&
+            params['workspaceFolders']
         end
 
         def static_completion

--- a/lib/solargraph/language_server/uri_helpers.rb
+++ b/lib/solargraph/language_server/uri_helpers.rb
@@ -18,7 +18,7 @@ module Solargraph
       # @param file [String]
       # @return [String]
       def file_to_uri file
-        "file://#{URI.encode(file.gsub(/^([a-z]\:)/i, '/\1'))}"
+        "file://#{URI.encode(file.gsub(/^([a-z]\:)/i, '/\1')).gsub(/\:/, '%3A')}"
       end
     end
   end

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -58,6 +58,15 @@ module Solargraph
       end
     end
 
+    def attach source
+      mutex.synchronize do
+        @synchronized = (@current == source)
+        # @todo open_file_hash might not be necessary anymore
+        open_file_hash[source.filename] = source
+        @current = source
+      end
+    end
+
     # True if the specified file is currently open.
     #
     # @param filename [String]

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -39,7 +39,7 @@ module Solargraph
     # @param version [Integer]
     # @return [void]
     def open filename, text, version
-      STDERR.puts "WARNING: Library#open is deprecated"
+      logger.warn "Library#open is deprecated"
       source = Solargraph::Source.load_string(text, filename, version)
       merge source
       attach source
@@ -315,7 +315,7 @@ module Solargraph
     # @param updater [Solargraph::Source::Updater]
     # @return [void]
     def update updater
-      STDERR.puts "WARNING: Library#update is deprecated"
+      logger.warn 'Library#update is deprecated'
       mutex.synchronize do
         if workspace.has_file?(updater.filename)
           workspace.synchronize!(updater)
@@ -380,7 +380,7 @@ module Solargraph
     #
     # @return [Array<Source>]
     def open_sources
-      STDERR.puts 'WARNING: Library#open_sources is deprecated'
+      logger.warn 'Library#open_sources is deprecated'
       @current ? [@current] : []
     end
 

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -30,11 +30,15 @@ module Solargraph
     # Open a file in the library. Opening a file will make it available for
     # checkout and merge it into the workspace if applicable.
     #
+    # @deprecated The library should not be responsible for this. Instead, it
+    #   should accept a source and determine whether or not to merge it.
+    #
     # @param filename [String]
     # @param text [String]
     # @param version [Integer]
     # @return [void]
     def open filename, text, version
+      STDERR.puts "WARNING: Library#open is deprecated"
       mutex.synchronize do
         @synchronized = false
         source = Solargraph::Source.load_string(text, filename, version)
@@ -297,11 +301,14 @@ module Solargraph
     # @note This method will not update the library's ApiMap. See
     #   Library#synchronized? and Library#catalog for more information.
     #
+    # @deprecated The library should not be responsible for this. Instead, it
+    #   should accept a source and determine whether or not to merge it.
     #
     # @raise [FileNotFoundError] if the updater's file is not available.
     # @param updater [Solargraph::Source::Updater]
     # @return [void]
     def update updater
+      STDERR.puts "WARNING: Library#update is deprecated"
       mutex.synchronize do
         if workspace.has_file?(updater.filename)
           workspace.synchronize!(updater)

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -372,6 +372,17 @@ module Solargraph
       Solargraph::Library.new(Solargraph::Workspace.new(directory), name)
     end
 
+    def merge source
+      # STDERR.puts "TODO: Merge the source!"
+      mutex.synchronize do
+        @synchronized = false
+        workspace.merge source
+        # TODO: Is the below really necessary? hmm...
+        open_file_hash[source.filename] = source
+        checkout source.filename
+      end
+    end
+
     private
 
     # @return [Mutex]

--- a/lib/solargraph/version.rb
+++ b/lib/solargraph/version.rb
@@ -1,3 +1,3 @@
 module Solargraph
-  VERSION = '0.30.1'
+  VERSION = '0.30.2'
 end

--- a/spec/language_server/host_spec.rb
+++ b/spec/language_server/host_spec.rb
@@ -130,4 +130,27 @@ describe Solargraph::LanguageServer::Host do
       host.document_symbols(file_uri)
     }.not_to raise_error
   end
+
+  describe "Host variations" do
+    before :each do
+      @host = Solargraph::LanguageServer::Host.new
+    end
+
+    after :each do
+      @host.stop
+    end
+
+    it "creates a library for a file without a workspace" do
+      @host.open('file:///file.rb', 'class Foo; end', 1)
+      symbols = @host.document_symbols('file:///file.rb')
+      expect(symbols).not_to be_empty
+    end
+
+    it "opens a file outside of prepared libraries" do
+      @host.prepare(File.absolute_path(File.join('spec', 'fixtures', 'workspace')))
+      @host.open('file:///file.rb', 'class Foo; end', 1)
+      symbols = @host.document_symbols('file:///file.rb')
+      expect(symbols).not_to be_empty
+    end
+  end
 end

--- a/spec/language_server/host_spec.rb
+++ b/spec/language_server/host_spec.rb
@@ -85,6 +85,7 @@ describe Solargraph::LanguageServer::Host do
     library = double(:Library)
     allow(library).to receive(:diagnose).and_raise(Solargraph::DiagnosticsError)
     allow(library).to receive(:contain?).and_return(true)
+    allow(library).to receive(:attach)
     # @todo Smelly instance variable access
     host.instance_variable_set(:@libraries, [library])
     expect {

--- a/spec/language_server/message/initialize_spec.rb
+++ b/spec/language_server/message/initialize_spec.rb
@@ -1,0 +1,57 @@
+describe Solargraph::LanguageServer::Message::Initialize do
+  it "prepares workspace folders" do
+    host = Solargraph::LanguageServer::Host.new
+    dir = File.realpath(File.join('spec', 'fixtures', 'workspace'))
+    init = Solargraph::LanguageServer::Message::Initialize.new(host, {
+      'params' => {
+        'capabilities' => {
+          'workspace' => {
+            'workspaceFolders' => true
+          }
+        },
+        'workspaceFolders' => [
+          {
+            'uri' => Solargraph::LanguageServer::UriHelpers.file_to_uri(dir),
+            'name' => 'workspace'
+          }
+        ]
+      }
+    })
+    init.process
+    expect(host.folders.length).to eq(1)
+  end
+
+  it "prepares rootUri as a workspace" do
+    host = Solargraph::LanguageServer::Host.new
+    dir = File.realpath(File.join('spec', 'fixtures', 'workspace'))
+    init = Solargraph::LanguageServer::Message::Initialize.new(host, {
+      'params' => {
+        'capabilities' => {
+          'workspace' => {
+            'workspaceFolders' => true
+          }
+        },
+        'rootUri' => Solargraph::LanguageServer::UriHelpers.file_to_uri(dir)
+      }
+    })
+    init.process
+    expect(host.folders.length).to eq(1)
+  end
+
+  it "prepares rootPath as a workspace" do
+    host = Solargraph::LanguageServer::Host.new
+    dir = File.realpath(File.join('spec', 'fixtures', 'workspace'))
+    init = Solargraph::LanguageServer::Message::Initialize.new(host, {
+      'params' => {
+        'capabilities' => {
+          'workspace' => {
+            'workspaceFolders' => true
+          }
+        },
+        'rootPath' => dir
+      }
+    })
+    init.process
+    expect(host.folders.length).to eq(1)
+  end
+end

--- a/spec/language_server/uri_helpers_spec.rb
+++ b/spec/language_server/uri_helpers_spec.rb
@@ -1,0 +1,7 @@
+describe Solargraph::LanguageServer::UriHelpers do
+  it "escapes colons in file paths" do
+    file = "c:/one/two"
+    uri = Solargraph::LanguageServer::UriHelpers.file_to_uri(file)
+    expect(uri).to start_with('file:///c%3A')
+  end
+end


### PR DESCRIPTION
Bug fixes for multi-root workspaces. Responsibility for open sources is moved from libraries to hosts. Several Library methods are now candidates for deprecation.

Related issue: #124
