### PR TITLE
Make SourceMap#query_symbols use fuzzy matching.

### DIFF
--- a/lib/solargraph/source_map.rb
+++ b/lib/solargraph/source_map.rb
@@ -1,3 +1,5 @@
+require 'jaro_winkler'
+
 module Solargraph
   # An index of pins and other ApiMap-related data for a Source.
   #
@@ -66,7 +68,7 @@ module Solargraph
     # @param query [String]
     # @return [Array<Pin::Base>]
     def query_symbols query
-      document_symbols.select{|pin| pin.path.include?(query)}
+      document_symbols.select{ |pin| fuzzy_string_match(pin.path, query) || fuzzy_string_match(pin.name, query) }
     end
 
     # @param position [Position]
@@ -155,6 +157,13 @@ module Solargraph
       end
       # @todo Assuming the root pin is always valid
       found || pins.first
+    end
+
+    # @param s1 [String]
+    # @param s2 [String]
+    # @return [Boolean]
+    def fuzzy_string_match str1, str2
+      JaroWinkler.distance(str1, str2) > 0.6
     end
   end
 end

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'thor', '~> 0.19', '>= 0.19.4'
   s.add_runtime_dependency 'tilt', '~> 2.0'
   s.add_runtime_dependency 'yard', '~> 0.9'
+  s.add_runtime_dependency 'jaro_winkler', '~> 1.5'
 
   s.add_development_dependency 'pry', '~> 0.11.3'
   s.add_development_dependency 'rspec', '~> 3.5', '>= 3.5.0'

--- a/spec/source_map_spec.rb
+++ b/spec/source_map_spec.rb
@@ -9,6 +9,17 @@ describe Solargraph::SourceMap do
     expect(pin.path).to eq('Foo#bar')
   end
 
+  it "queries symbols using fuzzy matching" do
+    map = Solargraph::SourceMap.load_string(%(
+      class FooBar
+        def baz_qux; end
+      end
+    ))
+    expect(map.query_symbols("foo")).to eq(map.document_symbols)
+    expect(map.query_symbols("foobar")).to eq(map.document_symbols)
+    expect(map.query_symbols("bazqux")).to eq(map.document_symbols.select{ |pin_namespace| pin_namespace.name == "baz_qux" })
+  end
+
   it "locates block pins" do
     map = Solargraph::SourceMap.load_string(%(
       class Foo


### PR DESCRIPTION
Fixes #44.

I made it fuzzy match either on the path or the name, since trying to fuzzy match a method name on a long path will typically fail.