### PR TITLE
V0.31.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,6 @@ matrix:
 # Update RubyGems and Bundler due to error with Bundler 1.16.1 and RubyGems 2.7.3
 # See https://github.com/travis-ci/travis-ci/issues/8978
 before_install:
-- gem install bundler
 - bundle install
 before_script: bundle exec yard gems
 script: bundle exec rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ matrix:
 # Update RubyGems and Bundler due to error with Bundler 1.16.1 and RubyGems 2.7.3
 # See https://github.com/travis-ci/travis-ci/issues/8978
 before_install:
+- gem install bundler
 - bundle install
 before_script: bundle exec yard gems
 script: bundle exec rspec
-cache:
-  - bundler
+# cache:
+#   - bundler

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,7 @@ matrix:
 # Update RubyGems and Bundler due to error with Bundler 1.16.1 and RubyGems 2.7.3
 # See https://github.com/travis-ci/travis-ci/issues/8978
 before_install:
+- ruby ./travis-bundler.rb
 - bundle install
 before_script: bundle exec yard gems
 script: bundle exec rspec

--- a/lib/solargraph.rb
+++ b/lib/solargraph.rb
@@ -40,6 +40,13 @@ module Solargraph
   YARDOC_PATH = File.realpath(File.join(dir, '..', 'yardoc'))
   YARD_EXTENSION_FILE = File.join(dir, 'yard-solargraph.rb')
   VIEWS_PATH = File.join(dir, 'solargraph', 'views')
+
+  # A convenience method for Solargraph::Logging.logger.
+  #
+  # @return [Logger]
+  def self.logger
+    Solargraph::Logging.logger
+  end
 end
 
 Solargraph::YardMap::CoreDocs.require_minimum

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -637,7 +637,8 @@ module Solargraph
       false
     end
 
-    # @return [void]
+    # @param pins [Array<Pin::Base>]
+    # @return [Array<Pin::Base>]
     def resolve_method_aliases pins
       pins.map do |pin|
         next pin unless pin.kind == Pin::METHOD_ALIAS

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -65,29 +65,25 @@ module Solargraph
       new_map_hash = {}
       # Bundle always needs to be merged if it adds or removes sources
       merged = (bundle.sources.length == source_map_hash.values.length)
-      threads = []
       bundle.sources.each do |source|
-        threads << Thread.new do
-          if source_map_hash.has_key?(source.filename)
-            if source_map_hash[source.filename].code == source.code
-              new_map_hash[source.filename] = source_map_hash[source.filename]
-            else
-              map = Solargraph::SourceMap.map(source)
-              if source_map_hash[source.filename].try_merge!(map)
-                new_map_hash[source.filename] = source_map_hash[source.filename]
-              else
-                new_map_hash[source.filename] = map
-                merged = false
-              end
-            end
+        if source_map_hash.has_key?(source.filename)
+          if source_map_hash[source.filename].code == source.code
+            new_map_hash[source.filename] = source_map_hash[source.filename]
           else
             map = Solargraph::SourceMap.map(source)
-            new_map_hash[source.filename] = map
-            merged = false
+            if source_map_hash[source.filename].try_merge!(map)
+              new_map_hash[source.filename] = source_map_hash[source.filename]
+            else
+              new_map_hash[source.filename] = map
+              merged = false
+            end
           end
+        else
+          map = Solargraph::SourceMap.map(source)
+          new_map_hash[source.filename] = map
+          merged = false
         end
       end
-      threads.each(&:join)
       return self if merged
       pins = []
       reqs = []
@@ -554,7 +550,7 @@ module Solargraph
     # @return [void]
     def require_extensions
       Gem::Specification.all_names.select{|n| n.match(/^solargraph\-[a-z0-9_\-]*?\-ext\-[0-9\.]*$/)}.each do |n|
-        STDERR.puts "Loading extension #{n}"
+        Solargraph::Logging.logger.info "Loading extension #{n}"
         require n.match(/^(solargraph\-[a-z0-9_\-]*?\-ext)\-[0-9\.]*$/)[1]
       end
     end

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -66,9 +66,12 @@ module Solargraph
       # Bundle always needs to be merged if it adds or removes sources
       merged = (bundle.sources.length == source_map_hash.values.length)
       bundle.sources.each do |source|
-        if source_map_hash.has_key?(source.filename)
-          if source_map_hash[source.filename].code == source.code
+        if source_map_hash.key?(source.filename)
+          if source_map_hash[source.filename].code == source.code && source_map_hash[source.filename].source.synchronized? && source.synchronized?
             new_map_hash[source.filename] = source_map_hash[source.filename]
+          elsif !source.synchronized?
+            new_map_hash[source.filename] = source_map_hash[source.filename]
+            new_map_hash[source.filename].instance_variable_set(:@source, source)
           else
             map = Solargraph::SourceMap.map(source)
             if source_map_hash[source.filename].try_merge!(map)

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -223,11 +223,11 @@ module Solargraph
       return qualify(context) if namespace == 'self'
       cached = cache.get_qualified_namespace(namespace, context)
       return cached.clone unless cached.nil?
-      if namespace.start_with?('::')
-        result = inner_qualify(namespace[2..-1], '', [])
-      else
-        result = inner_qualify(namespace, context, [])
-      end
+      result = if namespace.start_with?('::')
+                 inner_qualify(namespace[2..-1], '', [])
+               else
+                 inner_qualify(namespace, context, [])
+               end
       cache.set_qualified_namespace(namespace, context, result)
       result
     end
@@ -463,6 +463,7 @@ module Solargraph
 
     private
 
+    # @return [YardMap]
     def yard_map
       @yard_map ||= YardMap.new
     end
@@ -579,7 +580,7 @@ module Solargraph
           return inner_qualify(root, '', skip)
         end
       else
-        if (root == '')
+        if root == ''
           return name if store.namespace_exists?(name)
         else
           roots = root.to_s.split('::')

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -71,6 +71,7 @@ module Solargraph
             new_map_hash[source.filename] = source_map_hash[source.filename]
           elsif !source.synchronized?
             new_map_hash[source.filename] = source_map_hash[source.filename]
+            # @todo Smelly instance variable access
             new_map_hash[source.filename].instance_variable_set(:@source, source)
           else
             map = Solargraph::SourceMap.map(source)

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -26,8 +26,9 @@ module Solargraph
       # @param visibility [Array<Symbol>]
       # @return [Array<Solargraph::Pin::Base>]
       def get_methods fqns, scope: :instance, visibility: [:public]
+        kinds = [Pin::METHOD, Pin::ATTRIBUTE]
         namespace_children(fqns).select{ |pin|
-          [Pin::METHOD, Pin::ATTRIBUTE].include?(pin.kind) && pin.scope == scope && visibility.include?(pin.visibility)
+          kinds.include?(pin.kind) && pin.scope == scope && visibility.include?(pin.visibility)
         }
       end
 

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -121,6 +121,11 @@ module Solargraph
         end
       end
 
+      def inspect
+        # Avoid insane dumps in specs
+        to_s
+      end
+
       private
 
       # @param fqns [String]

--- a/lib/solargraph/diagnostics/require_not_found.rb
+++ b/lib/solargraph/diagnostics/require_not_found.rb
@@ -5,9 +5,10 @@ module Solargraph
     #
     class RequireNotFound < Base
       def diagnose source, api_map
+        return [] unless source.parsed? && source.synchronized?
         result = []
         refs = {}
-        map = Solargraph::SourceMap.map(source)
+        map = api_map.source_map(source.filename)
         map.requires.each do |ref|
           refs[ref.name] = ref
         end

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -1,4 +1,3 @@
-require 'observer'
 require 'thread'
 require 'set'
 
@@ -17,7 +16,6 @@ module Solargraph
       include UriHelpers
       include Logging
       include Dispatch
-      include Observable
 
       def initialize
         @cancel_semaphore = Mutex.new
@@ -231,8 +229,6 @@ module Solargraph
         @buffer_semaphore.synchronize do
           @buffer += message
         end
-        changed
-        notify_observers(self)
       end
 
       # Clear the message buffer and return the most recent data.
@@ -424,8 +420,6 @@ module Solargraph
         @stopped = true
         cataloger.stop
         diagnoser.stop
-        changed
-        notify_observers self
       end
 
       def stopped?

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -1,3 +1,4 @@
+require 'observer'
 require 'thread'
 require 'set'
 
@@ -16,6 +17,7 @@ module Solargraph
       include Solargraph::LanguageServer::UriHelpers
       include Logging
       include Dispatch
+      include Observable
 
       def initialize
         @cancel_semaphore = Mutex.new
@@ -229,6 +231,8 @@ module Solargraph
         @buffer_semaphore.synchronize do
           @buffer += message
         end
+        changed
+        notify_observers(self)
       end
 
       # Clear the message buffer and return the most recent data.

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -14,7 +14,7 @@ module Solargraph
       autoload :Sources,   'solargraph/language_server/host/sources'
       autoload :Dispatch,  'solargraph/language_server/host/dispatch'
 
-      include Solargraph::LanguageServer::UriHelpers
+      include UriHelpers
       include Logging
       include Dispatch
       include Observable

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -23,10 +23,20 @@ module Solargraph
         @register_semaphore = Mutex.new
         @cancel = []
         @buffer = ''
-        @stopped = false
+        @stopped = true
         @next_request_id = 0
         @dynamic_capabilities = Set.new
         @registered_capabilities = Set.new
+      end
+
+      # Start asynchronous process handling.
+      #
+      # @return [void]
+      def start
+        return unless stopped?
+        @stopped = false
+        diagnoser.start
+        cataloger.start
       end
 
       # Update the configuration options with the provided hash.
@@ -64,6 +74,7 @@ module Solargraph
       # Delete the specified ID from the list of cancelled IDs if it exists.
       #
       # @param id [Integer]
+      # @return [void]
       def clear id
         @cancel_semaphore.synchronize { @cancel.delete id }
       end
@@ -114,6 +125,7 @@ module Solargraph
       # Delete the specified file from the library.
       #
       # @param uri [String] The file uri.
+      # @return [void]
       def delete uri
         sources.close uri
         filename = uri_to_file(uri)
@@ -132,6 +144,7 @@ module Solargraph
       # @param uri [String] The file uri.
       # @param text [String] The contents of the file.
       # @param version [Integer] A version number.
+      # @return [void]
       def open uri, text, version
         src = sources.open(uri, text, version)
         libraries.each do |lib|
@@ -250,8 +263,9 @@ module Solargraph
           lib = Solargraph::Library.new('', name)
         end
         libraries.push lib
-        diagnoser.start
-        cataloger.start
+        # @todo Asynchronous processes are optional. Use Host#start to run them.
+        # diagnoser.start
+        # cataloger.start
       end
 
       # Prepare multiple folders.

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -73,7 +73,7 @@ module Solargraph
       #
       # @param request [Hash] The contents of the message.
       # @return [Solargraph::LanguageServer::Message::Base] The message handler.
-      def start request
+      def receive request
         if request['method']
           logger.info "Server received #{request['method']}"
           logger.debug request

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -116,7 +116,8 @@ module Solargraph
         sources.close uri
         filename = uri_to_file(uri)
         libraries.each do |lib|
-          lib.delete filename
+          # lib.delete filename
+          lib.detach filename
         end
         send_notification "textDocument/publishDiagnostics", {
           uri: uri,

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -214,12 +214,14 @@ module Solargraph
       # @return [void]
       def change params
         updater = generate_updater(params)
+        # src = sources.update(params['textDocument']['uri'], updater)
         src = sources.update(params['textDocument']['uri'], updater)
-        libraries.each do |lib|
-          lib.merge src
-          cataloger.ping(lib) if lib.contain?(src.filename) || lib.open?(src.filename)
-        end
-        diagnoser.schedule params['textDocument']['uri']
+        # libraries.each do |lib|
+        #   lib.merge src
+        #   cataloger.ping(lib) if lib.contain?(src.filename) || lib.open?(src.filename)
+        # end
+        # diagnoser.schedule params['textDocument']['uri']
+        merge_into_libraries src
       end
 
       # Queue a message to be sent to the client.
@@ -601,6 +603,14 @@ module Solargraph
         # file = uri_to_file(uri)
         # library.folding_ranges(file)
         sources.find(uri).folding_ranges
+      end
+
+      def merge_into_libraries src
+        libraries.each do |lib|
+          lib.merge src
+          cataloger.ping(lib) if lib.contain?(src.filename) || lib.open?(src.filename)
+        end
+        diagnoser.schedule file_to_uri(src.filename)
       end
 
       private

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -93,7 +93,7 @@ module Solargraph
             message.process
           rescue Exception => e
             logger.warn "Error processing request: [#{e.class}] #{e.message}"
-            logger.debug e.backtrace
+            logger.warn e.backtrace
             message.set_error Solargraph::LanguageServer::ErrorCodes::INTERNAL_ERROR, "[#{e.class}] #{e.message}"
           end
           message
@@ -184,6 +184,7 @@ module Solargraph
         if sources.include?(uri)
           logger.info "Diagnosing #{uri}"
           library = library_for(uri)
+          library.catalog
           begin
             results = library.diagnose uri_to_file(uri)
             send_notification "textDocument/publishDiagnostics", {

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -429,7 +429,6 @@ module Solargraph
       # @param params [Hash] A hash representation of a completion item
       # @return [Pin::Base, nil]
       def locate_pin params
-        return nil # @todo Testing
         return nil unless params['data'] && params['data']['uri'] && params['data']['location']
         library = library_for(params['data']['uri'])
         location = Location.new(

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -37,6 +37,7 @@ module Solargraph
         @stopped = false
         diagnoser.start
         cataloger.start
+        sources.start
       end
 
       # Update the configuration options with the provided hash.
@@ -214,14 +215,7 @@ module Solargraph
       # @return [void]
       def change params
         updater = generate_updater(params)
-        # src = sources.update(params['textDocument']['uri'], updater)
-        src = sources.update(params['textDocument']['uri'], updater)
-        # libraries.each do |lib|
-        #   lib.merge src
-        #   cataloger.ping(lib) if lib.contain?(src.filename) || lib.open?(src.filename)
-        # end
-        # diagnoser.schedule params['textDocument']['uri']
-        merge_into_libraries src
+        sources.async_update params['textDocument']['uri'], updater
       end
 
       # Queue a message to be sent to the client.
@@ -422,6 +416,7 @@ module Solargraph
         @stopped = true
         cataloger.stop
         diagnoser.stop
+        sources.stop
       end
 
       def stopped?
@@ -603,14 +598,6 @@ module Solargraph
         # file = uri_to_file(uri)
         # library.folding_ranges(file)
         sources.find(uri).folding_ranges
-      end
-
-      def merge_into_libraries src
-        libraries.each do |lib|
-          lib.merge src
-          cataloger.ping(lib) if lib.contain?(src.filename) || lib.open?(src.filename)
-        end
-        diagnoser.schedule file_to_uri(src.filename)
       end
 
       private

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -420,9 +420,12 @@ module Solargraph
 
       # @return [void]
       def stop
+        return if @stopped
         @stopped = true
         cataloger.stop
         diagnoser.stop
+        changed
+        notify_observers self
       end
 
       def stopped?

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -438,6 +438,7 @@ module Solargraph
       # @param params [Hash] A hash representation of a completion item
       # @return [Pin::Base, nil]
       def locate_pin params
+        return nil # @todo Testing
         return nil unless params['data'] && params['data']['uri'] && params['data']['location']
         library = library_for(params['data']['uri'])
         location = Location.new(
@@ -602,9 +603,10 @@ module Solargraph
       # @param uri [String]
       # @return [Array<Range>]
       def folding_ranges uri
-        library = library_for(uri)
-        file = uri_to_file(uri)
-        library.folding_ranges(file)
+        # library = library_for(uri)
+        # file = uri_to_file(uri)
+        # library.folding_ranges(file)
+        sources.find(uri).folding_ranges
       end
 
       private

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -591,13 +591,6 @@ module Solargraph
         }
       end
 
-      # Catalog the library.
-      #
-      # @return [void]
-      def catalog lib
-        lib.catalog
-      end
-
       # @param uri [String]
       # @return [Array<Range>]
       def folding_ranges uri

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -202,6 +202,7 @@ module Solargraph
         src = sources.update(params['textDocument']['uri'], updater)
         libraries.each do |lib|
           lib.merge src
+          cataloger.ping(lib) if lib.contain?(src.filename) || lib.open?(src.filename)
         end
         diagnoser.schedule params['textDocument']['uri']
       end

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -11,9 +11,11 @@ module Solargraph
       autoload :Diagnoser, 'solargraph/language_server/host/diagnoser'
       autoload :Cataloger, 'solargraph/language_server/host/cataloger'
       autoload :Sources,   'solargraph/language_server/host/sources'
+      autoload :Dispatch,  'solargraph/language_server/host/dispatch'
 
       include Solargraph::LanguageServer::UriHelpers
       include Logging
+      include Dispatch
 
       def initialize
         @cancel_semaphore = Mutex.new
@@ -593,63 +595,6 @@ module Solargraph
       end
 
       private
-
-      # @return [Array<Library>]
-      def libraries
-        @libraries ||= []
-      end
-
-      # @return [Sources]
-      def sources
-        @sources ||= Sources.new
-      end
-
-      # @param uri [String]
-      # @return [Library]
-      def library_for uri
-        explicit_library_for(uri) ||
-          implicit_library_for(uri) ||
-          generic_library_for(uri)
-      end
-
-      # @param uri [String]
-      # @return [Library, nil]
-      def explicit_library_for uri
-        filename = uri_to_file(uri)
-        libraries.each do |lib|
-          if lib.contain?(filename) #|| lib.open?(filename)
-            lib.attach sources.find(uri) if sources.include?(uri)
-            return lib
-          end
-        end
-        nil
-      end
-
-      # @param uri [String]
-      # @return [Library, nil]
-      def implicit_library_for uri
-        filename = uri_to_file(uri)
-        libraries.each do |lib|
-          # return lib if filename.start_with?(lib.workspace.directory)
-          if lib.open?(filename) || filename.start_with?(lib.workspace.directory)
-            lib.attach sources.find(uri)
-            return lib
-          end
-        end
-        nil
-      end
-
-      # @param uri [String]
-      # @return [Library]
-      def generic_library_for uri
-        generic_library.attach sources.find(uri)
-        generic_library
-      end
-
-      # @return [Library]
-      def generic_library
-        @generic_library ||= Solargraph::Library.new
-      end
 
       # @return [Diagnoser]
       def diagnoser

--- a/lib/solargraph/language_server/host/cataloger.rb
+++ b/lib/solargraph/language_server/host/cataloger.rb
@@ -59,8 +59,7 @@ module Solargraph
           return if pings.empty?
           mutex.synchronize do
             lib = pings.shift
-            break if pings.include?(lib)
-            host.catalog lib
+            lib.catalog unless pings.include?(lib)
           end
         end
 

--- a/lib/solargraph/language_server/host/cataloger.rb
+++ b/lib/solargraph/language_server/host/cataloger.rb
@@ -1,6 +1,8 @@
 module Solargraph
   module LanguageServer
     class Host
+      # An asynchronous library cataloging handler.
+      #
       class Cataloger
         def initialize host
           @host = host
@@ -11,10 +13,12 @@ module Solargraph
 
         # Notify the Cataloger that changes are pending.
         #
+        # @param lib [Library] The library that needs cataloging
         # @return [void]
         def ping lib
           mutex.synchronize { pings.push lib }
         end
+        alias schedule ping
 
         def synchronizing?
           !pings.empty?
@@ -42,14 +46,21 @@ module Solargraph
           @stopped = false
           Thread.new do
             until stopped?
-              sleep 0.1
-              next if pings.empty?
-              mutex.synchronize do
-                lib = pings.shift
-                next if pings.include?(lib)
-                host.catalog lib
-              end
+              tick
+              sleep 0.01
             end
+          end
+        end
+
+        # Perform cataloging.
+        #
+        # @return [void]
+        def tick
+          return if pings.empty?
+          mutex.synchronize do
+            lib = pings.shift
+            break if pings.include?(lib)
+            host.catalog lib
           end
         end
 

--- a/lib/solargraph/language_server/host/dispatch.rb
+++ b/lib/solargraph/language_server/host/dispatch.rb
@@ -27,7 +27,7 @@ module Solargraph
         end
 
         # Find an explicit library match for the given URI. An explicit match
-        # means the libary already contains the file.
+        # means the libary's workspace includes the file.
         #
         # If a matching library is found, the source corresponding to the URI
         # gets attached to it.
@@ -48,8 +48,8 @@ module Solargraph
         end
 
         # Find an implicit library match for the given URI. An implicit match
-        # means the libary either has the file already attached (open) or it's
-        # a child of the library's workspace directory.
+        # means the file is located inside the library's workspace directory,
+        # regardless of whether the workspace is configured to include it.
         #
         # If a matching library is found, the source corresponding to the URI
         # gets attached to it.
@@ -61,7 +61,9 @@ module Solargraph
         def implicit_library_for uri
           filename = UriHelpers.uri_to_file(uri)
           libraries.each do |lib|
-            return lib if lib.open?(filename)
+            # @todo We probably shouldn't depend on attachments to select
+            #   a library.
+            # return lib if lib.open?(filename)
             if filename.start_with?(lib.workspace.directory)
               lib.attach sources.find(uri)
               return lib

--- a/lib/solargraph/language_server/host/dispatch.rb
+++ b/lib/solargraph/language_server/host/dispatch.rb
@@ -16,6 +16,8 @@ module Solargraph
           @libraries ||= []
         end
 
+        # Find the best libary match for the given URI.
+        #
         # @param uri [String]
         # @return [Library]
         def library_for uri
@@ -24,12 +26,20 @@ module Solargraph
             generic_library_for(uri)
         end
 
+        # Find an explicit library match for the given URI. An explicit match
+        # means the libary already contains the file.
+        #
+        # If a matching library is found, the source corresponding to the URI
+        # gets attached to it.
+        #
+        # @raise [FileNotFoundError] if the source could not be attached.
+        #
         # @param uri [String]
         # @return [Library, nil]
         def explicit_library_for uri
           filename = UriHelpers.uri_to_file(uri)
           libraries.each do |lib|
-            if lib.contain?(filename) #|| lib.open?(filename)
+            if lib.contain?(filename)
               lib.attach sources.find(uri) if sources.include?(uri)
               return lib
             end
@@ -37,13 +47,22 @@ module Solargraph
           nil
         end
 
+        # Find an implicit library match for the given URI. An implicit match
+        # means the libary either has the file already attached (open) or it's
+        # a child of the library's workspace directory.
+        #
+        # If a matching library is found, the source corresponding to the URI
+        # gets attached to it.
+        #
+        # @raise [FileNotFoundError] if the source could not be attached.
+        #
         # @param uri [String]
         # @return [Library, nil]
         def implicit_library_for uri
           filename = UriHelpers.uri_to_file(uri)
           libraries.each do |lib|
-            # return lib if filename.start_with?(lib.workspace.directory)
-            if lib.open?(filename) || filename.start_with?(lib.workspace.directory)
+            return lib if lib.open?(filename)
+            if filename.start_with?(lib.workspace.directory)
               lib.attach sources.find(uri)
               return lib
             end
@@ -51,6 +70,11 @@ module Solargraph
           nil
         end
 
+        # Get a generic library for the given URI and attach the corresponding
+        # source.
+        #
+        # @raise [FileNotFoundError] if the source could not be attached.
+        #
         # @param uri [String]
         # @return [Library]
         def generic_library_for uri

--- a/lib/solargraph/language_server/host/dispatch.rb
+++ b/lib/solargraph/language_server/host/dispatch.rb
@@ -4,16 +4,27 @@ module Solargraph
       # Methods for associating sources with libraries via URIs.
       #
       module Dispatch
-        module_function
-
         # @return [Sources]
         def sources
-          @sources ||= Sources.new
+          @sources ||= begin
+            src = Sources.new
+            src.add_observer self, :update_libraries
+            src
+          end
         end
 
         # @return [Array<Library>]
         def libraries
           @libraries ||= []
+        end
+
+        def update_libraries src
+          # @todo This module should not call cataloger and diagnoser
+          libraries.each do |lib|
+            lib.merge src
+            cataloger.ping(lib) if lib.contain?(src.filename) || lib.open?(src.filename)
+          end
+          diagnoser.schedule file_to_uri(src.filename)
         end
 
         # Find the best libary match for the given URI.

--- a/lib/solargraph/language_server/host/dispatch.rb
+++ b/lib/solargraph/language_server/host/dispatch.rb
@@ -18,6 +18,11 @@ module Solargraph
           @libraries ||= []
         end
 
+        # The Sources observer callback that merges a source into the host's
+        # libraries when it gets updated.
+        #
+        # @param src [Source]
+        # @return [void]
         def update_libraries src
           # @todo This module should not call cataloger and diagnoser
           libraries.each do |lib|

--- a/lib/solargraph/language_server/host/dispatch.rb
+++ b/lib/solargraph/language_server/host/dispatch.rb
@@ -1,0 +1,68 @@
+module Solargraph
+  module LanguageServer
+    class Host
+      # Methods for associating sources with libraries via URIs.
+      #
+      module Dispatch
+        module_function
+
+        # @return [Sources]
+        def sources
+          @sources ||= Sources.new
+        end
+
+        # @return [Array<Library>]
+        def libraries
+          @libraries ||= []
+        end
+
+        # @param uri [String]
+        # @return [Library]
+        def library_for uri
+          explicit_library_for(uri) ||
+            implicit_library_for(uri) ||
+            generic_library_for(uri)
+        end
+
+        # @param uri [String]
+        # @return [Library, nil]
+        def explicit_library_for uri
+          filename = UriHelpers.uri_to_file(uri)
+          libraries.each do |lib|
+            if lib.contain?(filename) #|| lib.open?(filename)
+              lib.attach sources.find(uri) if sources.include?(uri)
+              return lib
+            end
+          end
+          nil
+        end
+
+        # @param uri [String]
+        # @return [Library, nil]
+        def implicit_library_for uri
+          filename = UriHelpers.uri_to_file(uri)
+          libraries.each do |lib|
+            # return lib if filename.start_with?(lib.workspace.directory)
+            if lib.open?(filename) || filename.start_with?(lib.workspace.directory)
+              lib.attach sources.find(uri)
+              return lib
+            end
+          end
+          nil
+        end
+
+        # @param uri [String]
+        # @return [Library]
+        def generic_library_for uri
+          generic_library.attach sources.find(uri)
+          generic_library
+        end
+
+        # @return [Library]
+        def generic_library
+          @generic_library ||= Solargraph::Library.new
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/language_server/host/dispatch.rb
+++ b/lib/solargraph/language_server/host/dispatch.rb
@@ -29,7 +29,7 @@ module Solargraph
             lib.merge src
             cataloger.ping(lib) if lib.contain?(src.filename) || lib.open?(src.filename)
           end
-          diagnoser.schedule file_to_uri(src.filename)
+          diagnoser.schedule file_to_uri(src.filename) if src.synchronized?
         end
 
         # Find the best libary match for the given URI.

--- a/lib/solargraph/language_server/host/sources.rb
+++ b/lib/solargraph/language_server/host/sources.rb
@@ -24,7 +24,7 @@ module Solargraph
           Thread.new do
             until stopped?
               tick
-              sleep 0.25
+              sleep 0.25 if queue.empty?
             end
           end
         end
@@ -68,7 +68,6 @@ module Solargraph
         # @return [Source]
         def update uri, updater
           src = find(uri)
-          # open_source_hash[uri] = src.synchronize(updater)
           mutex.synchronize { open_source_hash[uri] = src.synchronize(updater) }
           changed
           notify_observers open_source_hash[uri]
@@ -80,7 +79,7 @@ module Solargraph
         def async_update uri, updater
           src = find(uri)
           mutex.synchronize { open_source_hash[uri] = src.start_synchronize(updater) }
-          mutex.synchronize {queue.push uri}
+          mutex.synchronize { queue.push uri }
           changed
           notify_observers open_source_hash[uri]
         end

--- a/lib/solargraph/language_server/host/sources.rb
+++ b/lib/solargraph/language_server/host/sources.rb
@@ -33,7 +33,7 @@ module Solargraph
           uri = mutex.synchronize { queue.shift }
           unless queue.include?(uri)
             mutex.synchronize do
-              nxt = open_source_hash[uri].other_synchronize
+              nxt = open_source_hash[uri].finish_synchronize
               open_source_hash[uri] = nxt
               changed
               notify_observers open_source_hash[uri]
@@ -77,7 +77,7 @@ module Solargraph
         # @return [Thread]
         def async_update uri, updater
           src = find(uri)
-          mutex.synchronize { open_source_hash[uri] = src.combine(updater) }
+          mutex.synchronize { open_source_hash[uri] = src.start_synchronize(updater) }
           mutex.synchronize {queue.push uri}
           changed
           notify_observers open_source_hash[uri]

--- a/lib/solargraph/language_server/host/sources.rb
+++ b/lib/solargraph/language_server/host/sources.rb
@@ -1,35 +1,68 @@
 module Solargraph
   module LanguageServer
     class Host
+      # A Host class for managing sources.
+      #
       class Sources
         include UriHelpers
 
+        # Open a source.
+        #
+        # @param uri [String]
+        # @param text [String]
+        # @param version [Integer]
+        # @return [Source]
         def open uri, text, version
           filename = uri_to_file(uri)
           source = Solargraph::Source.new(text, filename, version)
           open_source_hash[uri] = source
         end
 
+        # Update an existing source.
+        #
+        # @raise [FileNotFoundError] if the URI does not match an open source.
+        #
+        # @param uri [String]
+        # @param updater [Source::Updater]
+        # @return [Source]
         def update uri, updater
           src = find(uri)
           open_source_hash[uri] = src.synchronize(updater)
         end
 
+        # Find the source with the given URI.
+        #
+        # @raise [FileNotFoundError] if the URI does not match an open source.
+        #
+        # @param uri [String]
         # @return [Source]
         def find uri
           open_source_hash[uri] || raise(Solargraph::FileNotFoundError, "Host could not find #{uri}")
         end
 
+        # Close the source with the given URI.
+        #
+        # @param uri [String]
+        # @return [void]
         def close uri
           open_source_hash.delete uri
         end
 
+        # True if a source with given URI is currently open.
+        # @param uri [String]
+        # @return [Boolean]
         def include? uri
           open_source_hash.key? uri
         end
 
+        # @return [void]
+        def clear
+          open_source_hash.clear
+        end
+
         private
 
+        # @return [Array<Source>]
         def open_source_hash
           @open_source_hash ||= {}
         end

--- a/lib/solargraph/language_server/host/sources.rb
+++ b/lib/solargraph/language_server/host/sources.rb
@@ -17,6 +17,7 @@ module Solargraph
           @stopped
         end
 
+        # @return [void]
         def start
           return unless @stopped
           @stopped = false
@@ -28,19 +29,20 @@ module Solargraph
           end
         end
 
+        # @return [void]
         def tick
           return if queue.empty?
           uri = mutex.synchronize { queue.shift }
-          unless queue.include?(uri)
-            mutex.synchronize do
-              nxt = open_source_hash[uri].finish_synchronize
-              open_source_hash[uri] = nxt
-              changed
-              notify_observers open_source_hash[uri]
-            end
+          return if queue.include?(uri)
+          mutex.synchronize do
+            nxt = open_source_hash[uri].finish_synchronize
+            open_source_hash[uri] = nxt
+            changed
+            notify_observers open_source_hash[uri]
           end
         end
 
+        # @return [void]
         def stop
           @stopped = true
         end
@@ -125,6 +127,9 @@ module Solargraph
           @mutex ||= Mutex.new
         end
 
+        # An array of source URIs that are waiting to finish synchronizing.
+        #
+        # @return [Array<String>]
         def queue
           @queue ||= []
         end

--- a/lib/solargraph/language_server/host/sources.rb
+++ b/lib/solargraph/language_server/host/sources.rb
@@ -23,7 +23,7 @@ module Solargraph
           Thread.new do
             until stopped?
               tick
-              sleep 0.1
+              sleep 0.25
             end
           end
         end

--- a/lib/solargraph/language_server/host/sources.rb
+++ b/lib/solargraph/language_server/host/sources.rb
@@ -23,7 +23,7 @@ module Solargraph
           Thread.new do
             until stopped?
               tick
-              sleep 0.01
+              sleep 0.1
             end
           end
         end
@@ -35,10 +35,10 @@ module Solargraph
             mutex.synchronize do
               nxt = open_source_hash[uri].other_synchronize
               open_source_hash[uri] = nxt
+              changed
+              notify_observers open_source_hash[uri]
             end
           end
-          changed
-          notify_observers open_source_hash[uri]
         end
 
         def stop
@@ -79,6 +79,8 @@ module Solargraph
           src = find(uri)
           mutex.synchronize { open_source_hash[uri] = src.combine(updater) }
           mutex.synchronize {queue.push uri}
+          changed
+          notify_observers open_source_hash[uri]
         end
 
         # Find the source with the given URI.

--- a/lib/solargraph/language_server/message/base.rb
+++ b/lib/solargraph/language_server/message/base.rb
@@ -58,18 +58,22 @@ module Solargraph
 
         # @return [void]
         def send_response
-          unless id.nil? or host.cancel?(id)
-            response = {
-              jsonrpc: "2.0",
-              id: id,
-            }
-            response[:result] = result unless result.nil?
-            response[:error] = error unless error.nil?
-            response[:result] = nil if result.nil? and error.nil?
-            json = response.to_json
-            envelope = "Content-Length: #{json.bytesize}\r\n\r\n#{json}"
-            host.queue envelope
+          return if id.nil?
+          if host.cancel?(id)
+            Solargraph::Logging.logger.info "Cancelled response to #{method}"
+            return
           end
+          Solargraph::Logging.logger.info "Sending response to #{method}"
+          response = {
+            jsonrpc: "2.0",
+            id: id,
+          }
+          response[:result] = result unless result.nil?
+          response[:error] = error unless error.nil?
+          response[:result] = nil if result.nil? and error.nil?
+          json = response.to_json
+          envelope = "Content-Length: #{json.bytesize}\r\n\r\n#{json}"
+          host.queue envelope
           host.clear id
         end
       end

--- a/lib/solargraph/language_server/message/extended/check_gem_version.rb
+++ b/lib/solargraph/language_server/message/extended/check_gem_version.rb
@@ -36,7 +36,7 @@ module Solargraph
                 host.show_message "The Solargraph gem is up to date (version #{Solargraph::VERSION})."
               end
             elsif fetched?
-              STDERR.puts error
+              Solargraph::Logging.logger.warn error
               host.show_message(error, MessageTypes::ERROR) if params['verbose']
             end
             set_result({

--- a/lib/solargraph/language_server/message/text_document/completion.rb
+++ b/lib/solargraph/language_server/message/text_document/completion.rb
@@ -39,7 +39,7 @@ module Solargraph
                 items: items
               )
             rescue InvalidOffsetError => e
-              STDERR.puts "Skipping invalid offset: #{filename}, line #{line}, character #{col}"
+              Logging.logger.info "Completion ignored invalid offset: #{filename}, line #{line}, character #{col}"
               set_result empty_result
             end
           end

--- a/lib/solargraph/language_server/message/text_document/completion.rb
+++ b/lib/solargraph/language_server/message/text_document/completion.rb
@@ -4,13 +4,6 @@ module Solargraph
       module TextDocument
         class Completion < Base
           def process
-            inner_process
-          end
-
-          private
-
-          # @return [void]
-          def inner_process
             filename = uri_to_file(params['textDocument']['uri'])
             line = params['position']['line']
             col = params['position']['character']

--- a/lib/solargraph/language_server/message/text_document/hover.rb
+++ b/lib/solargraph/language_server/message/text_document/hover.rb
@@ -27,9 +27,6 @@ module Solargraph::LanguageServer::Message::TextDocument
           value: contents.join("\n\n")
         }
       )
-    rescue InvalidOffsetError
-      Logging.logger.info "Hover ignored invalid offset: #{filename}, line #{line}, character #{col}"
-      set_result nil
     end
   end
 end

--- a/lib/solargraph/language_server/message/text_document/hover.rb
+++ b/lib/solargraph/language_server/message/text_document/hover.rb
@@ -27,6 +27,9 @@ module Solargraph::LanguageServer::Message::TextDocument
           value: contents.join("\n\n")
         }
       )
+    rescue InvalidOffsetError
+      Logging.logger.info "Hover ignored invalid offset: #{filename}, line #{line}, character #{col}"
+      set_result nil
     end
   end
 end

--- a/lib/solargraph/language_server/transport/adapter.rb
+++ b/lib/solargraph/language_server/transport/adapter.rb
@@ -8,7 +8,6 @@ module Solargraph
 
         def opening
           @host = Solargraph::LanguageServer::Host.new
-          @host.add_observer self, :update
           @host.start
           @data_reader = Solargraph::LanguageServer::Transport::DataReader.new
           @data_reader.set_message_handler do |message|
@@ -26,15 +25,6 @@ module Solargraph
           @data_reader.receive data
         end
 
-        def update subject
-          # if @host.stopped?
-          #   shutdown
-          # else
-          #   tmp = @host.flush
-          #   write tmp unless tmp.empty?
-          # end
-        end
-
         private
 
         # @param request [String]
@@ -50,6 +40,7 @@ module Solargraph
           Backport.prepare_interval 0.1 do |server|
             if @host.stopped?
               server.stop
+              shutdown
             else
               tmp = @host.flush
               write tmp unless tmp.empty?

--- a/lib/solargraph/language_server/transport/adapter.rb
+++ b/lib/solargraph/language_server/transport/adapter.rb
@@ -18,7 +18,6 @@ module Solargraph
 
         def closing
           @host.stop
-          Backport.stop unless @host.options['transport'] == 'external'
         end
 
         # @param data [String]
@@ -27,8 +26,12 @@ module Solargraph
         end
 
         def update subject
-          tmp = @host.flush
-          write tmp unless tmp.empty?
+          if @host.stopped?
+            shutdown
+          else
+            tmp = @host.flush
+            write tmp unless tmp.empty?
+          end
         end
 
         private
@@ -40,6 +43,10 @@ module Solargraph
           message.send_response
           tmp = @host.flush
           write tmp unless tmp.empty?
+        end
+
+        def shutdown
+          Backport.stop unless @host.options['transport'] == 'external'
         end
       end
     end

--- a/lib/solargraph/language_server/transport/adapter.rb
+++ b/lib/solargraph/language_server/transport/adapter.rb
@@ -14,6 +14,7 @@ module Solargraph
           @data_reader.set_message_handler do |message|
             process message
           end
+          start_timer
         end
 
         def closing
@@ -26,12 +27,12 @@ module Solargraph
         end
 
         def update subject
-          if @host.stopped?
-            shutdown
-          else
-            tmp = @host.flush
-            write tmp unless tmp.empty?
-          end
+          # if @host.stopped?
+          #   shutdown
+          # else
+          #   tmp = @host.flush
+          #   write tmp unless tmp.empty?
+          # end
         end
 
         private
@@ -43,6 +44,17 @@ module Solargraph
           message.send_response
           tmp = @host.flush
           write tmp unless tmp.empty?
+        end
+
+        def start_timer
+          Backport.prepare_interval 0.1 do |server|
+            if @host.stopped?
+              server.stop
+            else
+              tmp = @host.flush
+              write tmp unless tmp.empty?
+            end
+          end
         end
 
         def shutdown

--- a/lib/solargraph/language_server/transport/adapter.rb
+++ b/lib/solargraph/language_server/transport/adapter.rb
@@ -25,7 +25,7 @@ module Solargraph
         # @param request [String]
         # @return [void]
         def process request
-          message = @host.start(request)
+          message = @host.receive(request)
           message.send_response
           tmp = @host.flush
           write tmp unless tmp.empty?

--- a/lib/solargraph/language_server/transport/adapter.rb
+++ b/lib/solargraph/language_server/transport/adapter.rb
@@ -31,7 +31,6 @@ module Solargraph
         # @return [void]
         def process request
           message = @host.receive(request)
-          Solargraph::Logging.logger.info "Sending response to #{request['method']}"
           message.send_response
           tmp = @host.flush
           write tmp unless tmp.empty?

--- a/lib/solargraph/language_server/transport/adapter.rb
+++ b/lib/solargraph/language_server/transport/adapter.rb
@@ -8,6 +8,7 @@ module Solargraph
 
         def opening
           @host = Solargraph::LanguageServer::Host.new
+          @host.add_observer self, :update
           @host.start
           @data_reader = Solargraph::LanguageServer::Transport::DataReader.new
           @data_reader.set_message_handler do |message|
@@ -23,6 +24,11 @@ module Solargraph
         # @param data [String]
         def sending data
           @data_reader.receive data
+        end
+
+        def update subject
+          tmp = @host.flush
+          write tmp unless tmp.empty?
         end
 
         private

--- a/lib/solargraph/language_server/transport/adapter.rb
+++ b/lib/solargraph/language_server/transport/adapter.rb
@@ -31,6 +31,7 @@ module Solargraph
         # @return [void]
         def process request
           message = @host.receive(request)
+          Solargraph::Logging.logger.info "Sending response to #{request['method']}"
           message.send_response
           tmp = @host.flush
           write tmp unless tmp.empty?

--- a/lib/solargraph/language_server/transport/adapter.rb
+++ b/lib/solargraph/language_server/transport/adapter.rb
@@ -20,13 +20,6 @@ module Solargraph
           Backport.stop unless @host.options['transport'] == 'external'
         end
 
-        def process request
-          message = @host.start(request)
-          message.send_response
-          tmp = @host.flush
-          write tmp unless tmp.empty?
-        end
-
         # @param data [String]
         def sending data
           @data_reader.receive data

--- a/lib/solargraph/language_server/transport/adapter.rb
+++ b/lib/solargraph/language_server/transport/adapter.rb
@@ -8,6 +8,7 @@ module Solargraph
 
         def opening
           @host = Solargraph::LanguageServer::Host.new
+          @host.start
           @data_reader = Solargraph::LanguageServer::Transport::DataReader.new
           @data_reader.set_message_handler do |message|
             process message

--- a/lib/solargraph/language_server/transport/data_reader.rb
+++ b/lib/solargraph/language_server/transport/data_reader.rb
@@ -52,8 +52,8 @@ module Solargraph
             msg = JSON.parse(@buffer)
             @message_handler.call msg unless @message_handler.nil?
           rescue JSON::ParserError => e
-            STDERR.puts "Failed to parse request: #{e.message}"
-            STDERR.puts "Buffer: #{@buffer}"
+            Solargraph::Logging.logger.info "Failed to parse request: #{e.message}"
+            Solargraph::Logging.logger.debug "Buffer: #{@buffer}"
           ensure
             @buffer.clear
             @in_header = true

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -348,6 +348,9 @@ module Solargraph
 
     # Get an array of foldable ranges for the specified file.
     #
+    # @deprecated The library should not need to handle folding ranges. The
+    #   source itself has all the information it needs.
+    #
     # @param filename [String]
     # @return [Array<Range>]
     def folding_ranges filename

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -20,6 +20,11 @@ module Solargraph
       @catalog_mutex = Mutex.new
     end
 
+    def inspect
+      # Let's not deal with insane data dumps in spec failures
+      to_s
+    end
+
     # True if the ApiMap is up to date with the library's workspace and open
     # files.
     #

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -203,7 +203,7 @@ module Solargraph
       return [] if pins.empty?
       result = []
       pins.uniq.each do |pin|
-        (workspace.sources + (@current ? [@current] : [])).uniq.each do |source|
+        (workspace.sources + (@current ? [@current] : [])).uniq(&:filename).each do |source|
           found = source.references(pin.name)
           found.select! do |loc|
             referenced = definitions_at(loc.filename, loc.range.ending.line, loc.range.ending.character)
@@ -220,7 +220,7 @@ module Solargraph
           end)
         end
       end
-      result
+      result.uniq
     end
 
     # Get the pin at the specified location or nil if the pin does not exist.
@@ -342,7 +342,7 @@ module Solargraph
         logger.info "Cataloging #{workspace.directory.empty? ? 'generic workspace' : workspace.directory}"
         api_map.catalog bundle
         @synchronized = true
-        logger.info "Catalog complete"
+        logger.info "Catalog complete (#{api_map.pins.length} pins)"
       end
     end
 

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -334,11 +334,13 @@ module Solargraph
     #
     # @return [void]
     def catalog
-      @catalog_mutex.synchronize do
-        break if synchronized?
-        logger.info "Cataloging #{workspace.directory.empty? ? 'generic workspace' : workspace.directory}"
-        api_map.catalog bundle
-        @synchronized = true
+      Thread.new do
+        @catalog_mutex.synchronize do
+          break if synchronized?
+          logger.info "Cataloging #{workspace.directory.empty? ? 'generic workspace' : workspace.directory}"
+          api_map.catalog bundle
+          @synchronized = true
+        end
       end
     end
 

--- a/lib/solargraph/live_map.rb
+++ b/lib/solargraph/live_map.rb
@@ -89,7 +89,7 @@ module Solargraph
         changed ||= p.refresh
       end
       if changed
-        STDERR.puts "Resetting LiveMap cache"
+        Solargraph::Logging.logger.debug "Resetting LiveMap cache"
         cache.clear
         get_constants('')
         get_methods('', '', 'class')

--- a/lib/solargraph/pin.rb
+++ b/lib/solargraph/pin.rb
@@ -43,6 +43,7 @@ module Solargraph
     SUPERCLASS_REFERENCE = 14
     INCLUDE_REFERENCE = 15
     EXTEND_REFERENCE = 16
+    METHOD_ALIAS = 17
 
     ROOT_PIN = Pin::Namespace.new(nil, '', '', '', :class, :public)
   end

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -167,7 +167,7 @@ module Solargraph
       # @param api_map [ApiMap]
       # @return [ComplexType]
       def infer api_map
-        STDERR.puts "WARNING: Pin #infer methods are deprecated. Use #typify or #probe instead."
+        Solargraph::Logging.logger.warn "WARNING: Pin #infer methods are deprecated. Use #typify or #probe instead."
         type = typify(api_map)
         return type unless type.undefined?
         probe api_map

--- a/lib/solargraph/pin/base_method.rb
+++ b/lib/solargraph/pin/base_method.rb
@@ -34,7 +34,7 @@ module Solargraph
         begin
           ComplexType.parse *tag.types
         rescue Solargraph::ComplexTypeError => e
-          STDERR.puts e.message
+          Solargraph::Logging.logger.warn e.message
           ComplexType::UNDEFINED
         end
       end

--- a/lib/solargraph/pin/conversions.rb
+++ b/lib/solargraph/pin/conversions.rb
@@ -71,8 +71,8 @@ module Solargraph
       def generate_link
         this_path = path || return_type.tag
         return nil if this_path.nil? || this_path == 'undefined'
-        return this_path if comments.empty?
-        "[#{this_path.gsub('_', '\\\\_')}](solargraph:/document?query=#{URI.encode(this_path)})"
+        # return this_path if comments.empty?
+        "[#{this_path.gsub('_', '\\\\_')}](solargraph:/document?query=#{URI.escape(this_path)})"
       end
     end
   end

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -82,7 +82,7 @@ module Solargraph
 
       # @deprecated Use #typify and/or #probe instead
       def infer api_map
-        STDERR.puts 'WARNING: Pin #infer methods are deprecated. Use #typify or #probe instead.'
+        Solargraph::Logging.logger.warn 'WARNING: Pin #infer methods are deprecated. Use #typify or #probe instead.'
         type = typify(api_map)
         return type unless type.undefined?
         probe api_map

--- a/lib/solargraph/pin/method_alias.rb
+++ b/lib/solargraph/pin/method_alias.rb
@@ -1,18 +1,29 @@
 module Solargraph
   module Pin
     # Use this class to track method aliases for later remapping. Common
-    # examples are aliases for superclass methods or methods from included
-    # modules.
+    # examples that defer mapping are aliases for superclass methods or
+    # methods from included modules.
     #
-    class MethodAlias < Method
+    class MethodAlias < Base
+      attr_reader :scope
+
       attr_reader :original
 
       def initialize location, namespace, name, scope, original
         # @todo Determine how to handle these parameters. Among other things,
         #   determine if the visibility is defined by the location of the
         #   alias call or the original method.
-        super(location, namespace, name, '', scope, :public, [])
+        super(location, namespace, name, '')
+        @scope = scope
         @original = original
+      end
+
+      def kind
+        Pin::METHOD_ALIAS
+      end
+
+      def path
+        @path ||= namespace + (scope == :instance ? '#' : '.') + name
       end
     end
   end

--- a/lib/solargraph/plugin/process.rb
+++ b/lib/solargraph/plugin/process.rb
@@ -48,7 +48,7 @@ module Solargraph
             require p
             @required.push p
           rescue Exception => e
-            STDERR.puts "Failed to require #{p}: #{e.message}"
+            Solargraph::Logging.logger.info "Failed to require #{p}: #{e.message}"
             errors.push "Failed to require #{p}: #{e.class} #{e.message}"
           end
         end

--- a/lib/solargraph/position.rb
+++ b/lib/solargraph/position.rb
@@ -44,7 +44,6 @@ module Solargraph
       column = position.character
       text.lines.each do |l|
         line_length = l.length
-        char_length = l.chomp.length
         if feed == line
           result += column
           break

--- a/lib/solargraph/position.rb
+++ b/lib/solargraph/position.rb
@@ -85,7 +85,7 @@ module Solargraph
         cursor += line_length
         line += 1
       end
-      character = 0 if character.nil? and offset == cursor
+      character = 0 if character.nil? and (cursor - offset).between?(0, 1)
       raise InvalidOffsetError if character.nil?
       Position.new(line, character)
     end

--- a/lib/solargraph/server_methods.rb
+++ b/lib/solargraph/server_methods.rb
@@ -2,6 +2,7 @@ require 'socket'
 
 module Solargraph
   module ServerMethods
+    # @return [Integer]
     def available_port
       socket = Socket.new(:INET, :STREAM, 0)
       socket.bind(Addrinfo.tcp("127.0.0.1", 0))

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -48,34 +48,6 @@ module Solargraph
       end
     end
 
-    desc 'suggest', 'Get code suggestions for the provided input'
-    long_desc <<-LONGDESC
-      Analyze a Ruby file and output a list of code suggestions in JSON format.
-    LONGDESC
-    option :line, type: :numeric, aliases: :l, desc: 'Zero-based line number', required: true
-    option :column, type: :numeric, aliases: [:c, :col], desc: 'Zero-based column number', required: true
-    option :filename, type: :string, aliases: :f, desc: 'File name', required: false
-    def suggest(*filenames)
-      STDERR.puts "WARNING: The `solargraph suggest` command is a candidate for deprecation. It will either change drastically or not exist in a future version."
-      # HACK: The ARGV array needs to be manipulated for ARGF.read to work
-      ARGV.clear
-      ARGV.concat filenames
-      text = ARGF.read
-      filename = options[:filename] || filenames[0]
-      begin
-        code_map = CodeMap.new(code: text, filename: filename)
-        offset = code_map.get_offset(options[:line], options[:column])
-        sugg = code_map.suggest_at(offset, filtered: true)
-        result = { "status" => "ok", "suggestions" => sugg }.to_json
-        STDOUT.puts result
-      rescue Exception => e
-        STDERR.puts e
-        STDERR.puts e.backtrace.join("\n")
-        result = { "status" => "err", "message" => e.message + "\n" + e.backtrace.join("\n") }.to_json
-        STDOUT.puts result
-      end
-    end
-
     desc 'config [DIRECTORY]', 'Create or overwrite a default configuration file'
     option :extensions, type: :boolean, aliases: :e, desc: 'Add installed extensions', default: true
     def config(directory = '.')

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -64,10 +64,16 @@ module Solargraph
     end
 
     # @param range [Solargraph::Range]
+    # @return [String]
     def at range
       from_to range.start.line, range.start.character, range.ending.line, range.ending.character
     end
 
+    # @param l1 [Integer]
+    # @param c1 [Integer]
+    # @param l2 [Integer]
+    # @param c2 [Integer]
+    # @return [String]
     def from_to l1, c1, l2, c2
       b = Solargraph::Position.line_char_to_offset(@code, l1, c1)
       e = Solargraph::Position.line_char_to_offset(@code, l2, c2)
@@ -222,11 +228,9 @@ module Solargraph
       @error_ranges ||= []
     end
 
+    # @param node [Parser::AST::Node]
+    # @return [String]
     def code_for(node)
-      # @todo Using node locations on code with converted EOLs seems
-      #   slightly more efficient than calculating offsets.
-      # b = node.location.expression.begin.begin_pos
-      # e = node.location.expression.end.end_pos
       b = Position.line_char_to_offset(@code, node.location.line, node.location.column)
       e = Position.line_char_to_offset(@code, node.location.last_line, node.location.last_column)
       frag = code[b..e-1].to_s
@@ -337,6 +341,9 @@ module Solargraph
       ctxt
     end
 
+    # A hash of line numbers and their associated comments.
+    #
+    # @return [Hash{Integer => Array<String>}]
     def stringified_comments
       @stringified_comments ||= {}
     end
@@ -407,12 +414,13 @@ module Solargraph
       end
     end
 
+    # @param name [String]
+    # @param top [AST::Node]
+    # @return [Array<AST::Node>]
     def inner_node_references name, top
       result = []
-      if top.kind_of?(AST::Node)
-        if top.children.any?{|c| c.to_s == name}
-          result.push top
-        end
+      if top.is_a?(AST::Node)
+        result.push top if top.children.any? { |c| c.to_s == name }
         top.children.each { |c| result.concat inner_node_references(name, c) }
       end
       result
@@ -478,7 +486,8 @@ module Solargraph
       end
 
       # @param code [String]
-      # @param filename [String]
+      # @param filename [String, nil]
+      # @param line [Integer]
       # @return [Parser::AST::Node]
       def parse code, filename = nil, line = 0
         buffer = Parser::Source::Buffer.new(filename, line)

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -108,7 +108,6 @@ module Solargraph
       src.synchronized = false
       src.node = @node
       src.comments = @comments
-      STDERR.puts "***** #{src.code.lines.last}"
       src
     end
 

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -103,9 +103,12 @@ module Solargraph
       src.filename = filename
       src.code = real_code
       src.version = updater.version
+      src.parsed = parsed?
       src.repaired = updater.repair(@repaired)
       src.synchronized = false
       src.node = @node
+      src.comments = @comments
+      STDERR.puts "***** #{src.code.lines.last}"
       src
     end
 
@@ -113,13 +116,14 @@ module Solargraph
       return self if synchronized?
       synced = Source.new(@code, filename)
       if synced.parsed?
-        synced.version = updater.version
+        synced.version = version
         return synced
       end
       synced = Source.new(@repaired, filename)
-      synced.error_ranges.concat (error_ranges + updater.changes.map(&:range))
-      synced.code = real_code
-      synced.version = updater.version
+      # synced.error_ranges.concat (error_ranges + updater.changes.map(&:range))
+      synced.code = @code
+      synced.synchronized = true
+      synced.version = version
       synced
     end
 
@@ -248,6 +252,11 @@ module Solargraph
         result.concat foldable_comment_block_ranges
         result
       end
+    end
+
+    def synchronized?
+      @synchronized = true if @synchronized.nil?
+      @synchronized
     end
 
     private
@@ -384,11 +393,6 @@ module Solargraph
       result
     end
 
-    def synchronized?
-      @synchronized = true if @synchronized.nil?
-      @synchronized
-    end
-
     protected
 
     # @return [String]
@@ -409,6 +413,10 @@ module Solargraph
     # @return [Boolean]
     attr_writer :parsed
 
+    # @return [Array<Parser::Source::Comment>]
+    attr_writer :comments
+
+    # @return [Boolean]
     attr_writer :synchronized
 
     class << self

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -308,14 +308,14 @@ module Solargraph
           if grouped.empty? || cmnt.loc.expression.line == grouped.last.loc.expression.line + 1
             grouped.push cmnt
           else
-            result.push Range.from_to(grouped.first.loc.expression.line, 0, grouped.last.loc.expression.line, 0) unless grouped.empty?
+            result.push Range.from_to(grouped.first.loc.expression.line, 0, grouped.last.loc.expression.line, 0) unless grouped.length < 3
             grouped = [cmnt]
           end
         else
           unless grouped.length < 3
             result.push Range.from_to(grouped.first.loc.expression.line, 0, grouped.last.loc.expression.line, 0)
-            grouped.clear
           end
+          grouped.clear
         end
       end
       result.push Range.from_to(grouped.first.loc.expression.line, 0, grouped.last.loc.expression.line, 0) unless grouped.length < 3

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -219,7 +219,7 @@ module Solargraph
       @folding_ranges ||= begin
         result = []
         inner_folding_ranges node, result
-        result.concat comment_block_ranges
+        result.concat foldable_comment_block_ranges
         result
       end
     end
@@ -293,7 +293,11 @@ module Solargraph
       end
     end
 
-    def comment_block_ranges
+    # Get an array of foldable comment block ranges. Blocks are excluded if
+    # they are less than 3 lines long.
+    #
+    # @return [Array<Range>]
+    def foldable_comment_block_ranges
       result = []
       grouped = []
       # @param cmnt [Parser::Source::Comment]
@@ -308,9 +312,13 @@ module Solargraph
             grouped = [cmnt]
           end
         else
-          result.push Range.from_to(grouped.first.loc.expression.line, 0, grouped.last.loc.expression.line, 0) unless grouped.empty?
+          unless grouped.length < 3
+            result.push Range.from_to(grouped.first.loc.expression.line, 0, grouped.last.loc.expression.line, 0)
+            grouped.clear
+          end
         end
       end
+      result.push Range.from_to(grouped.first.loc.expression.line, 0, grouped.last.loc.expression.line, 0) unless grouped.length < 3
       result
     end
 

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -365,6 +365,7 @@ module Solargraph
     #
     # @return [Array<Range>]
     def foldable_comment_block_ranges
+      return [] unless synchronized?
       result = []
       grouped = []
       # @param cmnt [Parser::Source::Comment]

--- a/lib/solargraph/source/encoding_fixes.rb
+++ b/lib/solargraph/source/encoding_fixes.rb
@@ -12,7 +12,7 @@ module Solargraph
           string.dup.force_encoding('UTF-8')
         rescue ::Encoding::CompatibilityError, ::Encoding::UndefinedConversionError, ::Encoding::InvalidByteSequenceError => e
           # @todo Improve error handling
-          STDERR.puts "Normalize error: #{e.message}"
+          Solargraph::Logging.logger.warn "Normalize error: #{e.message}"
           string
         end
       end

--- a/lib/solargraph/source/source_chainer.rb
+++ b/lib/solargraph/source/source_chainer.rb
@@ -45,7 +45,7 @@ module Solargraph
         end
         return Chain.new([Chain::UNDEFINED_CALL]) if node.nil? || (node.type == :sym && !phrase.start_with?(':'))
         chain = NodeChainer.chain(node, source.filename)
-        if source.repaired? || !source.parsed?
+        if source.repaired? || !source.parsed? || !source.synchronized?
           if end_of_phrase.strip == '.'
             chain.links.push Chain::UNDEFINED_CALL
           elsif end_of_phrase.strip == '::'

--- a/lib/solargraph/source_map.rb
+++ b/lib/solargraph/source_map.rb
@@ -1,3 +1,5 @@
+require 'jaro_winkler'
+
 module Solargraph
   # An index of pins and other ApiMap-related data for a Source.
   #
@@ -66,7 +68,7 @@ module Solargraph
     # @param query [String]
     # @return [Array<Pin::Base>]
     def query_symbols query
-      document_symbols.select{|pin| pin.path.include?(query)}
+      document_symbols.select{ |pin| fuzzy_string_match(pin.path, query) || fuzzy_string_match(pin.name, query) }
     end
 
     # @param position [Position]
@@ -155,6 +157,13 @@ module Solargraph
       end
       # @todo Assuming the root pin is always valid
       found || pins.first
+    end
+
+    # @param s1 [String]
+    # @param s2 [String]
+    # @return [Boolean]
+    def fuzzy_string_match str1, str2
+      JaroWinkler.distance(str1, str2) > 0.6
     end
   end
 end

--- a/lib/solargraph/source_map.rb
+++ b/lib/solargraph/source_map.rb
@@ -87,7 +87,7 @@ module Solargraph
     # @return [Solargraph::Pin::Base]
     def locate_pin location
       # return nil unless location.start_with?("#{filename}:")
-      pins.select{|pin| pin.location == location}.first
+      pins.select { |pin| pin.location == location }.first
     end
 
     def locate_named_path_pin line, character
@@ -159,8 +159,8 @@ module Solargraph
       found || pins.first
     end
 
-    # @param s1 [String]
-    # @param s2 [String]
+    # @param str1 [String]
+    # @param str2 [String]
     # @return [Boolean]
     def fuzzy_string_match str1, str2
       JaroWinkler.distance(str1, str2) > 0.6

--- a/lib/solargraph/source_map/clip.rb
+++ b/lib/solargraph/source_map/clip.rb
@@ -15,7 +15,7 @@ module Solargraph
       def define
         return [] if cursor.comment? || cursor.chain.literal?
         result = cursor.chain.define(api_map, context_pin, locals)
-        result.concat(source_map.pins.select{ |p| p.location.range.start.line == cursor.position.line }) if result.empty?
+        result.concat((source_map.pins + source_map.locals).select{ |p| p.name == cursor.word && p.location.range.contain?(cursor.position) }) if result.empty?
         result
       end
 

--- a/lib/solargraph/source_map/mapper.rb
+++ b/lib/solargraph/source_map/mapper.rb
@@ -12,6 +12,7 @@ module Solargraph
 
       # Generate the data.
       #
+      # @param source [Source]
       # @return [Array]
       def map source
         @source = source
@@ -108,10 +109,10 @@ module Solargraph
         comment.lines.each { |l|
           # Trim the comment and minimum leading whitespace
           p = l.gsub(/^#/, '')
-          if num.nil? and !p.strip.empty?
+          if num.nil? && !p.strip.empty?
             num = p.index(/[^ ]/)
             started = true
-          elsif started and !p.strip.empty?
+          elsif started && !p.strip.empty?
             cur = p.index(/[^ ]/)
             num = cur if cur < num
           end

--- a/lib/solargraph/source_map/mapper.rb
+++ b/lib/solargraph/source_map/mapper.rb
@@ -72,7 +72,8 @@ module Solargraph
         when 'method'
           namespace = namespace_at(position)
           gen_src = Solargraph::SourceMap.load_string("def #{directive.tag.name};end")
-          gen_pin = gen_src.pins.last # Method is last pin after root namespace
+          gen_pin = gen_src.pins.select{ |p| p.kind == Pin::METHOD }.first
+          return if gen_pin.nil?
           @pins.push Solargraph::Pin::Method.new(location, namespace.path, gen_pin.name, docstring.all, :instance, :public, gen_pin.parameters, nil)
         when 'attribute'
           namespace = namespace_at(position)

--- a/lib/solargraph/source_map/mapper.rb
+++ b/lib/solargraph/source_map/mapper.rb
@@ -57,8 +57,8 @@ module Solargraph
       end
 
       def process_comment position, comment
+        return unless comment =~ /(@\!method|@\!attribute|@\!domain|@\!macro|@\!parse)/
         cmnt = remove_inline_comment_hashes(comment)
-        return unless cmnt =~ /(@\!method|@\!attribute|@\!domain|@\!macro|@\!parse)/
         parse = YARD::Docstring.parser.parse(cmnt)
         parse.directives.each { |d| process_directive(position, d) }
       end
@@ -121,6 +121,7 @@ module Solargraph
       end
 
       def process_comment_directives
+        return unless @code =~ /(@\!method|@\!attribute|@\!domain|@\!macro|@\!parse)/
         current = []
         last_line = nil
         @comments.each do |cmnt|

--- a/lib/solargraph/source_map/mapper.rb
+++ b/lib/solargraph/source_map/mapper.rb
@@ -96,7 +96,7 @@ module Solargraph
           end
         when 'domain'
           namespace = namespace_at(position)
-          namespace.domains.push directive.tag.text
+          namespace.domains.concat directive.tag.types unless directive.tag.types.nil?
         end
       end
 

--- a/lib/solargraph/version.rb
+++ b/lib/solargraph/version.rb
@@ -1,3 +1,3 @@
 module Solargraph
-  VERSION = '0.30.2'
+  VERSION = '0.31.0'
 end

--- a/lib/solargraph/views/environment.erb
+++ b/lib/solargraph/views/environment.erb
@@ -30,6 +30,9 @@
       Core Documentation Version: <%= Solargraph::YardMap::CoreDocs.best_match %>
     </li>
     <li>
+      Core Cache Directory: <%= Solargraph::YardMap::CoreDocs.cache_dir %>
+    </li>
+    <li>
       Parser Target Version: <%= Solargraph::Source.parser.version %>
     </li>
     <li>

--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -10,6 +10,7 @@ module Solargraph
     attr_reader :directory
 
     # @param directory [String]
+    # @param config [Config, nil]
     def initialize directory = '', config = nil
       @directory = directory
       @config = config
@@ -28,7 +29,7 @@ module Solargraph
     # @param source [Solargraph::Source]
     # @return [Boolean] True if the source was added to the workspace
     def merge source
-      unless directory == '*' || source_hash.has_key?(source.filename)
+      unless directory == '*' || source_hash.key?(source.filename)
         # Reload the config to determine if a new source should be included
         @config = Solargraph::Workspace::Config.new(directory)
         return false unless config.calculated.include?(source.filename)
@@ -68,13 +69,15 @@ module Solargraph
       source_hash.values
     end
 
+    # @param filename [String]
     # @return [Boolean]
     def has_file? filename
-      source_hash.has_key?(filename)
+      source_hash.key?(filename)
     end
 
     # Get a source by its filename.
     #
+    # @param filename [String]
     # @return [Solargraph::Source]
     def source filename
       source_hash[filename]
@@ -109,13 +112,13 @@ module Solargraph
     #
     # @return [Array<String>]
     def gemspecs
-      return [] if directory.empty?
+      return [] if directory.empty? || directory == '*'
       @gemspecs ||= Dir[File.join(directory, '**/*.gemspec')]
     end
 
     # Synchronize the workspace from the provided updater.
     #
-    # @param [Source::Updater]
+    # @param updater [Source::Updater]
     # @return [void]
     def synchronize! updater
       source_hash[updater.filename] = source_hash[updater.filename].synchronize(updater)
@@ -128,6 +131,7 @@ module Solargraph
       @source_hash ||= {}
     end
 
+    # @return [void]
     def load_sources
       source_hash.clear
       unless directory.empty? || directory == '*'
@@ -144,7 +148,7 @@ module Solargraph
     #
     # @return [Array<String>]
     def generate_require_paths
-      return configured_require_paths if directory.empty? || !gemspec?
+      return configured_require_paths unless gemspec?
       result = []
       gemspecs.each do |file|
         base = File.dirname(file)
@@ -152,15 +156,15 @@ module Solargraph
         #   workspace code, but this is how Gem::Specification.load does it
         #   anyway.
         begin
-           spec = eval(File.read(file), binding, file)
-           next unless Gem::Specification === spec
-           result.concat spec.require_paths.map{ |path| File.join(base, path) } unless spec.nil?
+          spec = eval(File.read(file), binding, file)
+          next unless Gem::Specification === spec
+          result.concat(spec.require_paths.map { |path| File.join(base, path) })
         rescue Exception => e
-           # Don't die if we have an error during eval-ing a gem spec.
-           # Concat the default lib directory instead.
-           # @todo Should the client be informed of the error through
-           #   diagnostics or some other mechanism?
-           result.push File.join(base, 'lib')
+          # Don't die if we have an error during eval-ing a gem spec.
+          # Concat the default lib directory instead.
+          # @todo Should the client be informed of the error through
+          #   diagnostics or some other mechanism?
+          result.push File.join(base, 'lib')
         end
       end
       result.concat config.require_paths

--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -162,8 +162,7 @@ module Solargraph
         rescue Exception => e
           # Don't die if we have an error during eval-ing a gem spec.
           # Concat the default lib directory instead.
-          # @todo Should the client be informed of the error through
-          #   diagnostics or some other mechanism?
+          Solargraph.logger.warn "Error reading #{file}: [#{e.class}] #{e.message}"
           result.push File.join(base, 'lib')
         end
       end

--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -53,7 +53,7 @@ module Solargraph
     # @param filename [String]
     # @return [Boolean] True if the source was removed from the workspace
     def remove filename
-      return false unless source_hash.has_key?(filename)
+      return false unless source_hash.key?(filename)
       source_hash.delete filename
       true
     end

--- a/lib/solargraph/workspace/config.rb
+++ b/lib/solargraph/workspace/config.rb
@@ -15,7 +15,7 @@ module Solargraph
       # @return [Hash]
       attr_reader :raw_data
 
-      # @param workspace [String]
+      # @param directory [String]
       def initialize directory = ''
         @directory = directory
         include_globs = ['**/*.rb']

--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -7,9 +7,10 @@ module Solargraph
   class YardMap
     autoload :Cache,    'solargraph/yard_map/cache'
     autoload :CoreDocs, 'solargraph/yard_map/core_docs'
+    autoload :CoreGen,  'solargraph/yard_map/core_gen'
 
     CoreDocs.require_minimum
-    @@stdlib_yardoc = CoreDocs.yard_stdlib_file
+    @@stdlib_yardoc = CoreDocs.yardoc_stdlib_file
     @@stdlib_paths = {}
     YARD::Registry.load! @@stdlib_yardoc
     YARD::Registry.all(:class, :module).each do |ns|

--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -80,7 +80,7 @@ module Solargraph
         YARD::Registry.load! y
       end
     rescue Exception => e
-      STDERR.puts "Error loading yardoc '#{y}' #{e.class} #{e.message}"
+      Solargraph::Logging.logger.warn "Error loading yardoc '#{y}' #{e.class} #{e.message}"
       yardocs.delete y
       nil
     end
@@ -253,7 +253,7 @@ module Solargraph
           end
         rescue Gem::LoadError
           # This error probably indicates a bug in an installed gem
-          STDERR.puts "Warning: failed to resolve #{dep.name} gem dependency for #{spec.name}"
+          Solargraph::Logging.logger.warn "Failed to resolve #{dep.name} gem dependency for #{spec.name}"
         end
       end
       result
@@ -267,7 +267,7 @@ module Solargraph
         .map{ |f| File.size(f) }
         .inject(:+)
       if !size.nil? && size > 20_000_000
-        STDERR.puts "Warning: yardoc at #{y} is too large to process (#{size} bytes)"
+        Solargraph::Logging.logger.warn "Yardoc at #{y} is too large to process (#{size} bytes)"
         return []
       end
       result = []

--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -27,7 +27,7 @@ module Solargraph
     attr_writer :with_dependencies
 
     # @param required [Array<String>]
-    # @param skip_dependencies [Boolean]
+    # @param with_dependencies [Boolean]
     def initialize(required: [], with_dependencies: true)
       # HACK: YardMap needs its own copy of this array
       @required = required.clone

--- a/lib/solargraph/yard_map/core_docs.rb
+++ b/lib/solargraph/yard_map/core_docs.rb
@@ -86,13 +86,15 @@ module Solargraph
         # Get the version number of core documentation available for download
         # that is the closest match for the current Ruby version.
         #
+        # @param current [String] The version to compare
         # @return [String] The version number of the best match
-        def best_download
-          rv = Gem::Version.new(RUBY_VERSION)
-          available.each do |ver|
+        def best_download current = RUBY_VERSION
+          rv = Gem::Version.new(current)
+          found = available
+          found.each do |ver|
             return ver if Gem::Version.new(ver) <= rv
           end
-          obj['cores'].last
+          found.last
         end
 
         # Get the path to a yardoc file for Ruby core documentation.

--- a/lib/solargraph/yard_map/core_docs.rb
+++ b/lib/solargraph/yard_map/core_docs.rb
@@ -8,25 +8,37 @@ module Solargraph
     # Tools for managing core documentation.
     #
     module CoreDocs
+      # The URL for downloading core documentation
       SOURCE = 'https://solargraph.org/download'
 
+      # The default core documentation version
+      DEFAULT = '2.2.2'
+
       class << self
+        # The directory where core documentation is installed.
+        #
+        # @return [String]
         def cache_dir
-          @cache_dir ||= File.join(Dir.home, '.solargraph', 'cache')
+          # The directory is not stored in a variable so it can be overridden
+          # in specs.
+          ENV['SOLARGRAPH_CACHE'] || File.join(Dir.home, '.solargraph', 'cache')
         end
 
         # Ensure installation of minimum documentation.
         #
+        # @return [void]
         def require_minimum
           return unless best_match.nil?
           FileUtils.mkdir_p cache_dir
-          version_dir = File.join(cache_dir, '2.2.2')
-          unless File.exist?(version_dir)
-            FileUtils.cp File.join(Solargraph::YARDOC_PATH, '2.2.2.tar.gz'), cache_dir
-            install_archive File.join(cache_dir, '2.2.2.tar.gz')
-          end
+          FileUtils.cp File.join(Solargraph::YARDOC_PATH, "#{DEFAULT}.tar.gz"), cache_dir
+          install_archive File.join(cache_dir, "#{DEFAULT}.tar.gz")
         end
 
+        # True if core documentation is installed for the specified version
+        # number.
+        #
+        # @param ver [String] The version number to check
+        # @return [Boolean]
         def valid?(ver)
           dir = File.join(cache_dir, ver)
           return false unless File.directory?(dir)
@@ -35,6 +47,10 @@ module Solargraph
           true
         end
 
+        # Get a list of version numbers for currently installed core
+        # documentation.
+        #
+        # @return [Array<String>] The installed version numbers
         def versions
           dirs = Dir[File.join(cache_dir, '*')].map{|d| File.basename(d)}
           dirs.keep_if{|d| valid?(d)}
@@ -42,22 +58,35 @@ module Solargraph
           dirs
         end
 
+        # Get the version number of the installed core documentation that is
+        # the closest match for the current Ruby version.
+        #
+        # @return [String] The closest match
         def best_match
-          available = versions
-          available.each do |v|
-            return v if Gem::Version.new(v) <= Gem::Version.new(RUBY_VERSION)
+          avail = versions
+          cur = Gem::Version.new(RUBY_VERSION)
+          avail.each do |v|
+            return v if Gem::Version.new(v) <= cur
           end
-          return available.last
+          avail.last
         end
 
+        # Get a list of core documentation versions that are available for
+        # download.
+        #
+        # @return [Array<String>] The version numbers
         def available
           uri = URI.parse("#{SOURCE}/versions.json")
           response = Net::HTTP.get_response(uri)
           obj = JSON.parse(response.body)
-          raise SourceNotAvailableError.new("Error connecting to #{SOURCE}") unless obj['status'] == 'ok'
+          raise SourceNotAvailableError, "Error connecting to #{SOURCE}" unless obj['status'] == 'ok'
           obj['cores']
         end
 
+        # Get the version number of core documentation available for download
+        # that is the closest match for the current Ruby version.
+        #
+        # @return [String] The version number of the best match
         def best_download
           rv = Gem::Version.new(RUBY_VERSION)
           available.each do |ver|
@@ -66,16 +95,28 @@ module Solargraph
           obj['cores'].last
         end
 
+        # Get the path to a yardoc file for Ruby core documentation.
+        #
+        # @param ver [String] The version number (best match is default)
+        # @return [String] The path to the yardoc
         def yardoc_file(ver = best_match)
-          raise ArgumentError.new("Invalid core yardoc version #{ver}") unless valid?(ver)
+          raise ArgumentError, "Invalid core yardoc version #{ver}" unless valid?(ver)
           File.join(cache_dir, ver, 'yardoc')
         end
 
-        def yard_stdlib_file(ver = best_match)
-          raise ArgumentError.new("Invalid core yardoc version #{ver}") unless valid?(ver)
+        # Get the path to a yardoc file for Ruby stdlib documentation.
+        #
+        # @param ver [String] The version number (best match is default)
+        # @return [String] The path to the yardoc
+        def yardoc_stdlib_file(ver = best_match)
+          raise ArgumentError, "Invalid core yardoc version #{ver}" unless valid?(ver)
           File.join(cache_dir, ver, 'yardoc-stdlib')
         end
 
+        # Download the specified version of core documentation.
+        #
+        # @param version [String]
+        # @return [void]
         def download version
           FileUtils.mkdir_p cache_dir
           uri = URI.parse("#{SOURCE}/#{version}.tar.gz")
@@ -85,6 +126,9 @@ module Solargraph
           install_archive zipfile
         end
 
+        # Reset the core documentation cache to the minimum requirement.
+        #
+        # @return [void]
         def clear
           FileUtils.rm_rf cache_dir, secure: true
           require_minimum
@@ -92,6 +136,10 @@ module Solargraph
 
         private
 
+        # Extract the specified archive to the core cache directory.
+        #
+        # @param filename [String]
+        # @return [void]
         def install_archive filename
           tar_extract = Gem::Package::TarReader.new(Zlib::GzipReader.open(filename))
           tar_extract.rewind

--- a/lib/solargraph/yard_map/core_gen.rb
+++ b/lib/solargraph/yard_map/core_gen.rb
@@ -22,7 +22,7 @@ module Solargraph
             `yardoc -b #{File.join(path_name, 'yardoc-stdlib')} -n lib ext`
             raise 'An error occurred generating the stdlib yardoc.' unless $?.success?
           end
-        endgene
+        end
 
         # Generate a gzip of documentation from the specified Ruby source directory.
         #

--- a/lib/solargraph/yard_map/core_gen.rb
+++ b/lib/solargraph/yard_map/core_gen.rb
@@ -13,15 +13,16 @@ module Solargraph
         # @param ruby_dir [String] The Ruby source directory
         # @param dest_dir [String] The destination directory for the yardocs
         # @return [void]
-        def generate_core ruby_dir, dest_dir
-          FileUtils.mkdir_p dest_dir
+        def generate_docs ruby_dir, dest_dir
+          path_name = Pathname.new(Dir.pwd).join(dest_dir).to_s
+          FileUtils.mkdir_p path_name
           Dir.chdir(ruby_dir) do
-            `yardoc -b #{File.join(dest_dir, 'yardoc')} -n *.c`
+            `yardoc --plugin coregen -b #{File.join(path_name, 'yardoc')} -n *.c`
             raise 'An error occurred generating the core yardoc.' unless $?.success?
-            `yardoc -b #{File.join(dest_dir, 'yardoc-stdlib')} -n lib ext`
+            `yardoc -b #{File.join(path_name, 'yardoc-stdlib')} -n lib ext`
             raise 'An error occurred generating the stdlib yardoc.' unless $?.success?
           end
-        end
+        endgene
 
         # Generate a gzip of documentation from the specified Ruby source directory.
         #
@@ -33,7 +34,7 @@ module Solargraph
             gzip_name += '.tar.gz' unless gzip_name.end_with?('.tar.gz')
             base_name = gzip_name[0..-8]
             path_name = Pathname.new(Dir.pwd).join(base_name).to_s
-            generate_core ruby_dir, tmp
+            generate_docs ruby_dir, tmp
             `cd #{tmp} && tar -cf #{path_name}.tar *`
             raise 'An error occurred generating the documentation tar.' unless $?.success?
             `gzip #{path_name}.tar`

--- a/lib/solargraph/yard_map/core_gen.rb
+++ b/lib/solargraph/yard_map/core_gen.rb
@@ -1,0 +1,46 @@
+require 'fileutils'
+require 'tmpdir'
+require 'pathname'
+
+module Solargraph
+  class YardMap
+    # Tools for generating core documentation.
+    #
+    module CoreGen
+      class << self
+        # Generate documentation from the specified Ruby source directory.
+        #
+        # @param ruby_dir [String] The Ruby source directory
+        # @param dest_dir [String] The destination directory for the yardocs
+        # @return [void]
+        def generate_core ruby_dir, dest_dir
+          FileUtils.mkdir_p dest_dir
+          Dir.chdir(ruby_dir) do
+            `yardoc -b #{File.join(dest_dir, 'yardoc')} -n *.c`
+            raise 'An error occurred generating the core yardoc.' unless $?.success?
+            `yardoc -b #{File.join(dest_dir, 'yardoc-stdlib')} -n lib ext`
+            raise 'An error occurred generating the stdlib yardoc.' unless $?.success?
+          end
+        end
+
+        # Generate a gzip of documentation from the specified Ruby source directory.
+        #
+        # @param ruby_dir [String] The Ruby source directory
+        # @param gzip_name [String] The gzip file name
+        # @return [void]
+        def generate_gzip ruby_dir, gzip_name
+          Dir.mktmpdir do |tmp|
+            gzip_name += '.tar.gz' unless gzip_name.end_with?('.tar.gz')
+            base_name = gzip_name[0..-8]
+            path_name = Pathname.new(Dir.pwd).join(base_name).to_s
+            generate_core ruby_dir, tmp
+            `cd #{tmp} && tar -cf #{path_name}.tar *`
+            raise 'An error occurred generating the documentation tar.' unless $?.success?
+            `gzip #{path_name}.tar`
+            raise 'An error occurred generating the documentation gzip.' unless $?.success?
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/yard-coregen.rb
+++ b/lib/yard-coregen.rb
@@ -1,0 +1,16 @@
+require 'yard'
+
+class CoreMethodHandler < YARD::Handlers::C::Base
+  MATCH = /define_filetest_function\s*\(
+			\s*"([^"]+)",
+			\s*(?:RUBY_METHOD_FUNC\(|VALUEFUNC\(|\(\w+\))?(\w+)\)?,
+			\s*(-?\w+)\s*\)/xm
+  handles MATCH
+  statement_class BodyStatement
+
+  process do
+    statement.source.scan(MATCH) do |name, func_name, _param_count|
+      handle_method("singleton_method", "rb_cFile", name, func_name)
+    end
+  end
+end

--- a/lib/yard-solargraph.rb
+++ b/lib/yard-solargraph.rb
@@ -1,7 +1,16 @@
 require 'yard'
 
+module Solargraph
+  # A placeholder for the @!domain directive. It doesn't need to do anything
+  # for yardocs. It's only used for Solargraph API maps.
+  class DomainDirective < YARD::Tags::Directive
+    def call; end
+  end
+end
+
 # Define a @type tag for documenting variables
 YARD::Tags::Library.define_tag("Type", :type, :with_types_and_name)
 # Define a @yieldself tag for documenting block contexts
 YARD::Tags::Library.define_tag("Yieldself", :yieldself, :with_types)
-YARD::Tags::Library.define_directive("domain", YARD::Tags::MacroDirective)
+# Define a @!domain directive for documenting DSLs
+YARD::Tags::Library.define_directive("domain", :with_types, Solargraph::DomainDirective)

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'thor', '~> 0.19', '>= 0.19.4'
   s.add_runtime_dependency 'tilt', '~> 2.0'
   s.add_runtime_dependency 'yard', '~> 0.9'
+  s.add_runtime_dependency 'jaro_winkler', '~> 1.5'
 
   s.add_development_dependency 'pry', '~> 0.11.3'
   s.add_development_dependency 'rspec', '~> 3.5', '>= 3.5.0'

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = '>= 2.1'
 
-  s.add_runtime_dependency 'backport', '~> 0.2'
+  s.add_runtime_dependency 'backport', '~> 0.3'
   s.add_runtime_dependency 'htmlentities', '~> 4.3', '>= 4.3.4'
   s.add_runtime_dependency 'kramdown', '~> 1.16'
   s.add_runtime_dependency 'parser', '~> 2.3'

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -494,4 +494,26 @@ describe Solargraph::ApiMap do
     pins = api_map.get_methods('MyClass', scope: :class)
     expect(pins.map(&:path)).to include('MyModule#foo')
   end
+
+  it "merges source maps" do
+    source1 = Solargraph::Source.load_string(%(
+      class Foo
+        def bar
+        end
+      end
+    ))
+    source2 = Solargraph::Source.load_string(%(
+      class Foo
+        def bar
+          puts 'hello'
+        end
+      end
+    ))
+    api_map = Solargraph::ApiMap.new
+    api_map.map source1
+    first = api_map.source_map(nil)
+    api_map.map source2
+    second = api_map.source_map(nil)
+    expect(first).to eq(second)
+  end
 end

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -516,4 +516,40 @@ describe Solargraph::ApiMap do
     second = api_map.source_map(nil)
     expect(first).to eq(second)
   end
+
+  it "catalogs unsynchronized sources without rebuilding" do
+    # @todo This spec determines whether the ApiMap merged without rebuilding
+    #   by inspecting the internal #store attribute. See if there's a better
+    #   way.
+    source1 = Solargraph::Source.load_string(%(
+      class Foo
+        def bar; end
+      end
+      f
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source1
+    store1 = api_map.send(:store)
+    # This update should require a rebuild after it's synchronized because it
+    # adds a local variable pin to the source map
+    source2 = source1.start_synchronize Solargraph::Source::Updater.new(
+      'test.rb',
+      2,
+      [
+        Solargraph::Source::Change.new(
+          Solargraph::Range.from_to(4, 7, 4, 7),
+          'oo = Foo.new'
+        )
+      ]
+    )
+    api_map.map source2
+    store2 = api_map.send(:store)
+    # The unsynchronized source does not rebuild the store
+    expect(store1).to be(store2)
+    source3 = source2.finish_synchronize
+    api_map.map source3
+    store3 = api_map.send(:store)
+    # The synchronized source rebuilds the store
+    expect(store3).not_to be(store2)
+  end
 end

--- a/spec/diagnostics/rubocop_helpers_spec.rb
+++ b/spec/diagnostics/rubocop_helpers_spec.rb
@@ -5,4 +5,16 @@ describe Solargraph::Diagnostics::RubocopHelpers do
     found = Solargraph::Diagnostics::RubocopHelpers.find_rubocop_file(file)
     expect(found).to eq(conf)
   end
+
+  it "converts lower-case drive letters to upper-case" do
+    input = 'c:/one/two'
+    output = Solargraph::Diagnostics::RubocopHelpers.fix_drive_letter(input)
+    expect(output).to eq('C:/one/two')
+  end
+
+  it "ignores paths without drive letters" do
+    input = 'one/two'
+    output = Solargraph::Diagnostics::RubocopHelpers.fix_drive_letter(input)
+    expect(output).to eq('one/two')
+  end
 end

--- a/spec/diagnostics/type_not_defined_spec.rb
+++ b/spec/diagnostics/type_not_defined_spec.rb
@@ -87,7 +87,7 @@ describe Solargraph::Diagnostics::TypeNotDefined do
         end
       end
       class Second < First
-        def foo
+        def foo bar
         end
       end
     ))

--- a/spec/language_server/host/cataloger_spec.rb
+++ b/spec/language_server/host/cataloger_spec.rb
@@ -4,7 +4,7 @@ describe Solargraph::LanguageServer::Host::Cataloger do
     lib = double(Solargraph::Library)
     cataloger = Solargraph::LanguageServer::Host::Cataloger.new(host)
     cataloger.ping lib
-    expect(host).to receive(:catalog).with(lib)
+    expect(lib).to receive(:catalog)
     cataloger.tick
   end
 end

--- a/spec/language_server/host/cataloger_spec.rb
+++ b/spec/language_server/host/cataloger_spec.rb
@@ -1,0 +1,10 @@
+describe Solargraph::LanguageServer::Host::Cataloger do
+  it "catalogs on ticks" do
+    host = double(Solargraph::LanguageServer::Host)
+    lib = double(Solargraph::Library)
+    cataloger = Solargraph::LanguageServer::Host::Cataloger.new(host)
+    cataloger.ping lib
+    expect(host).to receive(:catalog).with(lib)
+    cataloger.tick
+  end
+end

--- a/spec/language_server/host/diagnoser_spec.rb
+++ b/spec/language_server/host/diagnoser_spec.rb
@@ -1,0 +1,9 @@
+describe Solargraph::LanguageServer::Host::Diagnoser do
+  it "diagnoses on ticks" do
+    host = double(Solargraph::LanguageServer::Host, options: { 'diagnostics' => true }, synchronizing?: false)
+    diagnoser = Solargraph::LanguageServer::Host::Diagnoser.new(host)
+    diagnoser.schedule 'file.rb'
+    expect(host).to receive(:diagnose).with('file.rb')
+    diagnoser.tick
+  end
+end

--- a/spec/language_server/host/dispatch_spec.rb
+++ b/spec/language_server/host/dispatch_spec.rb
@@ -1,0 +1,38 @@
+describe Solargraph::LanguageServer::Host::Dispatch do
+  before :all do
+    @dispatch = Solargraph::LanguageServer::Host::Dispatch
+  end
+
+  after :each do
+    @dispatch.libraries.clear
+    @dispatch.sources.clear
+  end
+
+  it "finds an explicit library" do
+    @dispatch.libraries.push Solargraph::Library.load('*')
+    src = @dispatch.sources.open('file:///file.rb', 'a=b', 0)
+    @dispatch.libraries.first.merge src
+    lib = @dispatch.library_for('file:///file.rb')
+    expect(lib).to be(@dispatch.libraries.first)
+  end
+
+  it "finds an implicit library" do
+    dir = File.realpath(File.join('spec', 'fixtures', 'workspace'))
+    file = File.join(dir, 'new.rb')
+    uri = Solargraph::LanguageServer::UriHelpers.file_to_uri(file)
+    @dispatch.libraries.push Solargraph::Library.load(dir)
+    @dispatch.sources.open uri, 'a=b', 0
+    lib = @dispatch.library_for(uri)
+    expect(lib).to be(@dispatch.libraries.first)
+  end
+
+  it "finds a generic library" do
+    dir = File.realpath(File.join('spec', 'fixtures', 'workspace'))
+    file = '/external.rb'
+    uri = Solargraph::LanguageServer::UriHelpers.file_to_uri(file)
+    @dispatch.libraries.push Solargraph::Library.load(dir)
+    @dispatch.sources.open uri, 'a=b', 0
+    lib = @dispatch.library_for(uri)
+    expect(lib).to be(@dispatch.generic_library)
+  end
+end

--- a/spec/language_server/host/dispatch_spec.rb
+++ b/spec/language_server/host/dispatch_spec.rb
@@ -1,6 +1,8 @@
 describe Solargraph::LanguageServer::Host::Dispatch do
   before :all do
-    @dispatch = Solargraph::LanguageServer::Host::Dispatch
+    # @dispatch = Solargraph::LanguageServer::Host::Dispatch
+    @dispatch = Object.new
+    @dispatch.extend Solargraph::LanguageServer::Host::Dispatch
   end
 
   after :each do

--- a/spec/language_server/host_spec.rb
+++ b/spec/language_server/host_spec.rb
@@ -20,7 +20,7 @@ describe Solargraph::LanguageServer::Host do
       done_somethings += 1 if response == 'Do something'
     end
     expect(host.pending_requests.length).to eq(1)
-    host.start({
+    host.receive({
       'id' => host.pending_requests.first,
       'result' => 'Do something'
     })

--- a/spec/language_server/host_spec.rb
+++ b/spec/language_server/host_spec.rb
@@ -64,6 +64,7 @@ describe Solargraph::LanguageServer::Host do
       host.configure({ 'diagnostics' => true })
       file = File.join(dir, 'test.rb')
       File.write(file, "foo = 'foo'")
+      host.start
       host.prepare dir
       uri = Solargraph::LanguageServer::UriHelpers.file_to_uri(file)
       host.open(file, File.read(file), 1)
@@ -71,12 +72,13 @@ describe Solargraph::LanguageServer::Host do
       times = 0
       # @todo Weak timeout for waiting until the diagnostics thread
       #   sends a notification
-      while buffer.empty? and times < 10
+      while buffer.empty? && times < 10
         sleep 1
         times += 1
         buffer = host.flush
       end
       expect(buffer).to include('textDocument/publishDiagnostics')
+      host.stop
     end
   end
 

--- a/spec/language_server/host_spec.rb
+++ b/spec/language_server/host_spec.rb
@@ -134,7 +134,43 @@ describe Solargraph::LanguageServer::Host do
     }.not_to raise_error
   end
 
-  describe "Host variations" do
+  it "pings the cataloger for library changes" do
+    host = Solargraph::LanguageServer::Host.new
+    dir = File.absolute_path('spec/fixtures/workspace')
+    file = File.join(dir, 'app.rb')
+    file_uri = Solargraph::LanguageServer::UriHelpers.uri_to_file(file)
+    host.prepare dir
+    host.open file_uri, File.read(file), 0
+    host.stop
+    params = {
+      'textDocument' => {
+        'uri' => file_uri,
+        'version' => 1
+      },
+      'contentChanges' => [
+        {
+          'range' => {
+            'start' => {
+              'line' => 2,
+              'character' => 0
+            },
+            'end' => {
+              'line' => 2,
+              'character' => 0
+            }
+          },
+          'text' => ';'
+        }
+      ]
+    }
+    cataloger = double()
+    # @todo Smelly instance variable access
+    host.instance_variable_set(:@cataloger, cataloger)
+    expect(cataloger).to receive(:ping)
+    host.change params
+  end
+
+  describe "Workspace variations" do
     before :each do
       @host = Solargraph::LanguageServer::Host.new
     end

--- a/spec/language_server/host_spec.rb
+++ b/spec/language_server/host_spec.rb
@@ -89,6 +89,7 @@ describe Solargraph::LanguageServer::Host do
     allow(library).to receive(:contain?).and_return(true)
     allow(library).to receive(:attach)
     allow(library).to receive(:merge)
+    allow(library).to receive(:catalog)
     # @todo Smelly instance variable access
     host.instance_variable_set(:@libraries, [library])
     host.open('file:///test.rb', '', 0)

--- a/spec/language_server/message/extended/check_gem_version_spec.rb
+++ b/spec/language_server/message/extended/check_gem_version_spec.rb
@@ -38,7 +38,7 @@ describe Solargraph::LanguageServer::Message::Extended::CheckGemVersion do
         "id" => response['id'],
         "result" => response['params']['actions'].first
       }
-      host.start action
+      host.receive action
     }.not_to raise_error
   end
 end

--- a/spec/language_server/message/text_document/rename_spec.rb
+++ b/spec/language_server/message/text_document/rename_spec.rb
@@ -1,0 +1,27 @@
+describe Solargraph::LanguageServer::Message::TextDocument::Rename do
+  it "renames a symbol" do
+    host = Solargraph::LanguageServer::Host.new
+    host.start
+    host.open('file:///file.rb', %(
+      class Foo
+      end
+      foo = Foo.new
+    ), 1)
+    rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
+      'id' => 1,
+      'method' => 'textDocument/rename',
+      'params' => {
+        'textDocument' => {
+          'uri' => 'file:///file.rb'
+        },
+        'position' => {
+          'line' => 1,
+          'character' => 12
+        },
+        'newName' => 'Bar'
+      }
+    })
+    rename.process
+    expect(rename.result[:changes]['file:///file.rb'].length).to eq(2)
+  end
+end

--- a/spec/language_server/protocol_spec.rb
+++ b/spec/language_server/protocol_spec.rb
@@ -23,7 +23,7 @@ class Protocol
       'params' => params
     }
     @message_id += 1
-    message = @host.start msg
+    message = @host.receive msg
     message.send_response
     @data_reader.receive @host.flush
   end

--- a/spec/language_server/protocol_spec.rb
+++ b/spec/language_server/protocol_spec.rb
@@ -8,6 +8,7 @@ class Protocol
 
   def initialize host
     @host = host
+    @host.start
     @data_reader = Solargraph::LanguageServer::Transport::DataReader.new
     @data_reader.set_message_handler do |message|
       @response = message

--- a/spec/language_server/protocol_spec.rb
+++ b/spec/language_server/protocol_spec.rb
@@ -179,6 +179,7 @@ describe Protocol do
   end
 
   it "handles textDocument/definition" do
+    sleep 0.5 # HACK: Give the Host::Sources thread time to work
     @protocol.request 'textDocument/definition', {
       'textDocument' => {
         'uri' => 'file:///file.rb'

--- a/spec/language_server/protocol_spec.rb
+++ b/spec/language_server/protocol_spec.rb
@@ -28,11 +28,19 @@ class Protocol
     message.send_response
     @data_reader.receive @host.flush
   end
+
+  def stop
+    @host.stop
+  end
 end
 
 describe Protocol do
   before :all do
     @protocol = Protocol.new(Solargraph::LanguageServer::Host.new)
+  end
+
+  after :all do
+    @protocol.stop
   end
 
   it "handles initialize" do

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -234,6 +234,7 @@ describe Solargraph::Library do
       Other.new.bar
     ), 'file2.rb', 0)
     library.merge src2
+    library.catalog
     locs = library.references_from('file2.rb', 2, 11)
     expect(locs.length).to eq(3)
     expect(locs.select{|l| l.filename == 'file2.rb' && l.range.start.line == 6}).to be_empty
@@ -257,6 +258,7 @@ describe Solargraph::Library do
       end
     ), 'file2.rb', 0)
     library.merge src2
+    library.catalog
     locs = library.references_from('file1.rb', 1, 12, strip: true)
     expect(locs.length).to eq(3)
     locs.each do |l|

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -316,4 +316,20 @@ describe Solargraph::Library do
     library.attach src.synchronize(updater)
     expect(library.checkout('test.rb').code).to eq(repl)
   end
+
+  it "finds unique references" do
+    library = Solargraph::Library.new(Solargraph::Workspace.new('*'))
+    src1 = Solargraph::Source.load_string(%(
+      class Foo
+      end
+    ), 'src1.rb', 1)
+    library.merge src1
+    src2 = Solargraph::Source.load_string(%(
+      foo = Foo.new
+    ), 'src2.rb', 1)
+    library.merge src2
+    library.catalog
+    refs = library.references_from('src2.rb', 1, 12)
+    expect(refs.length).to eq(2)
+  end
 end

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -43,20 +43,20 @@ describe Solargraph::Library do
     end
   end
 
-  it "opens a file" do
+  it "opens an attached file" do
     library = Solargraph::Library.new
-    library.open('file.rb', 'a = b', 0)
-    source = nil
+    library.attach Solargraph::Source.load_string('a = b', 'file.rb')
+    expect(library.open?('file.rb')).to be(true)
     expect {
       source = library.checkout('file.rb')
     }.not_to raise_error
-    expect(source.filename).to eq('file.rb')
   end
 
-  it "deletes an open file" do
+  it "closes a detached file" do
     library = Solargraph::Library.new
-    library.open('file.rb', 'a = b', 0)
-    library.delete 'file.rb'
+    library.attach(Solargraph::Source.load_string('a = b', 'file.rb', 0))
+    library.detach 'file.rb'
+    expect(library.open?('file.rb')).to be(false)
     expect {
       library.checkout 'file.rb'
     }.to raise_error(Solargraph::FileNotFoundError)
@@ -67,7 +67,7 @@ describe Solargraph::Library do
       file = File.join(dir, 'file.rb')
       File.write(file, 'a = b')
       library = Solargraph::Library.load(dir)
-      library.open file, File.read(file), 0
+      library.attach Solargraph::Source.load(file)
       expect {
         library.checkout file
       }.not_to raise_error
@@ -81,7 +81,7 @@ describe Solargraph::Library do
 
   it "makes a closed file unavailable if it doesn't exist on disk" do
     library = Solargraph::Library.new
-    library.open 'file.rb', 'a = b', 0
+    library.attach Solargraph::Source.load_string('a = b', 'file.rb', 0)
     expect {
       library.checkout 'file.rb'
     }.not_to raise_error
@@ -94,7 +94,7 @@ describe Solargraph::Library do
   it "keeps a closed file available if it exists in the workspace" do
     library = Solargraph::Library.load('spec/fixtures/workspace')
     file = 'spec/fixtures/workspace/app.rb'
-    library.open file, File.read(file), 0
+    library.attach Solargraph::Source.load(file)
     expect {
       library.checkout file
     }.not_to raise_error
@@ -109,7 +109,7 @@ describe Solargraph::Library do
       file = File.join(dir, 'file.rb')
       File.write file, 'a = b'
       library = Solargraph::Library.load(dir)
-      library.open file, File.read(file), 0
+      library.attach Solargraph::Source.load(file)
       expect {
         library.checkout file
       }.not_to raise_error
@@ -121,10 +121,10 @@ describe Solargraph::Library do
 
   it "returns a Completion" do
     library = Solargraph::Library.new
-    library.open 'file.rb', %(
+    library.attach Solargraph::Source.load_string(%(
       x = 1
       x
-    ), 0
+    ), 'file.rb', 0)
     completion = library.completions_at('file.rb', 2, 7)
     expect(completion).to be_a(Solargraph::SourceMap::Completion)
     expect(completion.pins.map(&:name)).to include('x')
@@ -132,25 +132,27 @@ describe Solargraph::Library do
 
   it "gets definitions from a file" do
     library = Solargraph::Library.new
-    library.open 'file.rb', %(
+    src = Solargraph::Source.load_string %(
       class Foo
         def bar
         end
       end
-    ), 0
+    ), 'file.rb', 0
+    library.attach src
     paths = library.definitions_at('file.rb', 2, 13).map(&:path)
     expect(paths).to include('Foo#bar')
   end
 
   it "signifies method arguments" do
     library = Solargraph::Library.new
-    library.open 'file.rb', %(
+    src = Solargraph::Source.load_string %(
       class Foo
         def bar baz, key: ''
         end
       end
       Foo.new.bar()
-    ), 0
+    ), 'file.rb', 0
+    library.attach src
     pins = library.signatures_at('file.rb', 5, 18)
     expect(pins.length).to eq(1)
     expect(pins.first.path).to eq('Foo#bar')
@@ -187,9 +189,10 @@ describe Solargraph::Library do
 
   it "diagnoses files" do
     library = Solargraph::Library.new
-    library.open('file.rb', %(
+    src = Solargraph::Source.load_string(%(
       puts 'hello'
-    ), 0)
+    ), 'file.rb', 0)
+    library.attach src
     result = library.diagnose 'file.rb'
     expect(result).to be_a(Array)
     # @todo More tests
@@ -197,12 +200,13 @@ describe Solargraph::Library do
 
   it "documents symbols" do
     library = Solargraph::Library.new
-    library.open('file.rb', %(
+    src = Solargraph::Source.load_string(%(
       class Foo
         def bar
         end
       end
-    ), 0)
+    ), 'file.rb', 0)
+    library.attach src
     pins = library.document_symbols 'file.rb'
     expect(pins.length).to eq(2)
     expect(pins.map(&:path)).to include('Foo')
@@ -212,22 +216,24 @@ describe Solargraph::Library do
   it "collects references to a method symbol" do
     workspace = Solargraph::Workspace.new('*')
     library = Solargraph::Library.new(workspace)
-    library.open('file1.rb', %(
+    src1 = Solargraph::Source.load_string(%(
       class Foo
         def bar
         end
       end
 
       Foo.new.bar
-    ), 0)
-    library.open('file2.rb', %(
+    ), 'file1.rb', 0)
+    library.merge src1
+    src2 = Solargraph::Source.load_string(%(
       foo = Foo.new
       foo.bar
       class Other
         def bar; end
       end
       Other.new.bar
-    ), 0)
+    ), 'file2.rb', 0)
+    library.merge src2
     locs = library.references_from('file2.rb', 2, 11)
     expect(locs.length).to eq(3)
     expect(locs.select{|l| l.filename == 'file2.rb' && l.range.start.line == 6}).to be_empty
@@ -236,19 +242,21 @@ describe Solargraph::Library do
   it "collects stripped references to constant symbols" do
     workspace = Solargraph::Workspace.new('*')
     library = Solargraph::Library.new(workspace)
-    library.open('file1.rb', %(
+    src1 = Solargraph::Source.load_string(%(
       class Foo
         def bar
         end
       end
       Foo.new.bar
-    ), 0)
-    library.open('file2.rb', %(
+    ), 'file1.rb', 0)
+    library.merge src1
+    src2 = Solargraph::Source.load_string(%(
       class Other
         foo = Foo.new
         foo.bar
       end
-    ), 0)
+    ), 'file2.rb', 0)
+    library.merge src2
     locs = library.references_from('file1.rb', 1, 12, strip: true)
     expect(locs.length).to eq(3)
     locs.each do |l|
@@ -274,12 +282,13 @@ describe Solargraph::Library do
 
   it "returns YARD documentation from sources" do
     library = Solargraph::Library.new
-    library.open('test.rb', %(
+    src = Solargraph::Source.load_string(%(
       class Foo
         # My bar method
         def bar; end
       end
-    ), 0)
+    ), 'test.rb', 0)
+    library.attach src
     result = library.document('Foo#bar')
     expect(result).not_to be_empty
     expect(result.first).to be_a(YARD::CodeObjects::Base)
@@ -287,10 +296,11 @@ describe Solargraph::Library do
 
   it "synchronizes sources from updaters" do
     library = Solargraph::Library.new
-    library.open('test.rb', %(
+    src = Solargraph::Source.load_string(%(
       class Foo
       end
-    ), 1)
+    ), 'test.rb', 1)
+    library.attach src
     repl = %(
       class Foo
         def bar; end
@@ -301,17 +311,7 @@ describe Solargraph::Library do
       2,
       [Solargraph::Source::Change.new(nil, repl)]
     )
-    library.update updater
+    library.attach src.synchronize(updater)
     expect(library.checkout('test.rb').code).to eq(repl)
-  end
-
-  it "synchronizes workspaces from updaters" do
-    library = Solargraph::Library.load('spec/fixtures/workspace')
-    updater = Solargraph::Source::Updater.new('spec/fixtures/workspace/app.rb', 1, [
-      Solargraph::Source::Change.new(nil, 'updated_from_updater')
-    ])
-    library.update updater
-    source = library.checkout('spec/fixtures/workspace/app.rb')
-    expect(source.code).to eq('updated_from_updater')
   end
 end

--- a/spec/source_map/mapper_spec.rb
+++ b/spec/source_map/mapper_spec.rb
@@ -922,4 +922,14 @@ describe Solargraph::SourceMap::Mapper do
     pro = smap.pins.select{|pin| pin.path == 'Foo#pro'}.first
     expect(pro.visibility).to eq(:protected)
   end
+
+  it "ignores errors in method directives" do
+    expect {
+      Solargraph::SourceMap.load_string(%[
+        class Foo
+          # @!method bar(
+        end
+      ])
+    }.not_to raise_error
+  end
 end

--- a/spec/source_map_spec.rb
+++ b/spec/source_map_spec.rb
@@ -9,6 +9,17 @@ describe Solargraph::SourceMap do
     expect(pin.path).to eq('Foo#bar')
   end
 
+  it "queries symbols using fuzzy matching" do
+    map = Solargraph::SourceMap.load_string(%(
+      class FooBar
+        def baz_qux; end
+      end
+    ))
+    expect(map.query_symbols("foo")).to eq(map.document_symbols)
+    expect(map.query_symbols("foobar")).to eq(map.document_symbols)
+    expect(map.query_symbols("bazqux")).to eq(map.document_symbols.select{ |pin_namespace| pin_namespace.name == "baz_qux" })
+  end
+
   it "locates block pins" do
     map = Solargraph::SourceMap.load_string(%(
       class Foo

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -160,6 +160,7 @@ describe Solargraph::Source do
   end
 
   it "finds foldable ranges" do
+    # Of the 7 possible ranges, 2 are too short to be foldable
     source = Solargraph::Source.load_string(%(
 =begin
 Range 1
@@ -172,10 +173,19 @@ end
 # Range 3.2
 # Range 3.3
 a = b
-# Range 4.1
+# Range 4.1 (too short)
 # Range 4.2
+c = b
+# Range 5.1 (too short)
+d = c # inline
+# Range 6.1
+# Range 6.2
+# Range 6.3
+e = d # inline
+# Range 7.1
+# Range 7.2
+# Range 7.3
     ))
-    source.folding_ranges
-    expect(source.folding_ranges.length).to eq(3)
+    expect(source.folding_ranges.length).to eq(5)
   end
 end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -188,4 +188,20 @@ e = d # inline
     ))
     expect(source.folding_ranges.length).to eq(5)
   end
+
+  it "returns unsynchronized sources for started synchronizations" do
+    source1 = Solargraph::Source.load_string('x = 1', 'test.rb')
+    source2 = source1.start_synchronize Solargraph::Source::Updater.new(
+      'test.rb',
+      2,
+      [
+        Solargraph::Source::Change.new(
+          Solargraph::Range.from_to(0, 5, 0, 5),
+          '2'
+        )
+      ]
+    )
+    expect(source2.code).to eq('x = 12')
+    expect(source2).not_to be_synchronized
+  end
 end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -158,4 +158,24 @@ describe Solargraph::Source do
     expect(source.node).to be_nil
     expect(source.parsed?).to be(false)
   end
+
+  it "finds foldable ranges" do
+    source = Solargraph::Source.load_string(%(
+=begin
+Range 1
+=end
+def range_2
+  x = y
+  puts z
+end
+# Range 3.1
+# Range 3.2
+# Range 3.3
+a = b
+# Range 4.1
+# Range 4.2
+    ))
+    source.folding_ranges
+    expect(source.folding_ranges.length).to eq(3)
+  end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,3 +2,5 @@ $LOAD_PATH.unshift File.realpath(File.join(File.dirname(__FILE__), '..', 'lib'))
 require 'simplecov'
 SimpleCov.start
 require 'solargraph'
+# Suppress logger output in specs (if possible)
+Solargraph::Logging.logger.reopen(File::NULL) if Solargraph::Logging.logger.respond_to?(:reopen)

--- a/spec/yard_map/core_docs_spec.rb
+++ b/spec/yard_map/core_docs_spec.rb
@@ -37,6 +37,11 @@ describe Solargraph::YardMap::CoreDocs do
     expect(available).to include(best_match)
   end
 
+  it "finds the best download for future versions" do
+    best_match = Solargraph::YardMap::CoreDocs.best_download('99.99.99')
+    expect(best_match).not_to be_nil
+  end
+
   it "downloads the best match" do
     best_match = Solargraph::YardMap::CoreDocs.best_download
     Solargraph::YardMap::CoreDocs.download best_match

--- a/spec/yard_map/core_docs_spec.rb
+++ b/spec/yard_map/core_docs_spec.rb
@@ -1,0 +1,52 @@
+require 'fileutils'
+require 'tmpdir'
+
+describe Solargraph::YardMap::CoreDocs do
+  before :all do
+    # Override the cache for testing
+    @tmp_dir = Dir.mktmpdir
+    @orig_env = ENV['SOLARGRAPH_CACHE']
+    ENV['SOLARGRAPH_CACHE'] = @tmp_dir
+  end
+
+  after :all do
+    # Delete the temp cache and reset
+    FileUtils.rm_rf @tmp_dir, secure: true
+    ENV['SOLARGRAPH_CACHE'] = @orig_env
+  end
+
+  it "detects nil available matches" do
+    expect(Solargraph::YardMap::CoreDocs.best_match).to be_nil
+  end
+
+  it "sets the minimum requirements" do
+    expect {
+      Solargraph::YardMap::CoreDocs.require_minimum
+    }.not_to raise_error
+    expect(Solargraph::YardMap::CoreDocs.best_match).to eq(Solargraph::YardMap::CoreDocs::DEFAULT)
+  end
+
+  it "finds available downloads" do
+    available = Solargraph::YardMap::CoreDocs.available
+    expect(available).not_to be_empty
+  end
+
+  it "finds the best download" do
+    available = Solargraph::YardMap::CoreDocs.available
+    best_match = Solargraph::YardMap::CoreDocs.best_download
+    expect(available).to include(best_match)
+  end
+
+  it "downloads the best match" do
+    best_match = Solargraph::YardMap::CoreDocs.best_download
+    Solargraph::YardMap::CoreDocs.download best_match
+    expect(Solargraph::YardMap::CoreDocs.valid?(best_match)).to be(true)
+  end
+
+  it "clears the cache" do
+    expect {
+      Solargraph::YardMap::CoreDocs.clear
+    }.not_to raise_error
+    expect(Solargraph::YardMap::CoreDocs.best_match).to eq(Solargraph::YardMap::CoreDocs::DEFAULT)
+  end
+end

--- a/travis-bundler.rb
+++ b/travis-bundler.rb
@@ -1,0 +1,10 @@
+#!/usr/bin/env ruby
+
+# Travis uses this script to select which version of bundler to install for
+# each job.
+
+if RUBY_VERSION =~ /^2\.(1|2)\./
+  exec "gem install bundler -v '< 2'"
+else
+  exec "gem install bundler"
+end


### PR DESCRIPTION
Removed deprecated Library methods
Tweaked foldable comment ranges
Host::Dispatch module for managing open sources and libraries
YardMap::CoreGen module for generating documentation from Ruby source
Improved communication between hosts and adapters
Refactored Host methods
`@!domain` directive uses [type] syntax
Make SourceMap#query_symbols use fuzzy matching. (#132)
Threaded ApiMap cataloging
Fixed fencepost error in Position.from_offset
Lazy method alias resolution
Library#references_from returns unique locations
Additional info logs
Asynchronous source parsing
Unsychronized source support for faster completion requests (castwide/vscode-solargraph#95)
Faster source comment parsing
Host only diagnoses synchronized sources
