### PR TITLE
Don't escape colon in URI

### DIFF
--- a/lib/solargraph/language_server/uri_helpers.rb
+++ b/lib/solargraph/language_server/uri_helpers.rb
@@ -18,7 +18,7 @@ module Solargraph
       # @param file [String]
       # @return [String]
       def file_to_uri file
-        "file://#{URI.encode(file.gsub(/^([a-z]\:)/i, '/\1')).gsub(/\:/, '%3A')}"
+        "file://#{URI.encode(file.gsub(/^([a-z]\:)/i, '/\1'))}"
       end
     end
   end

--- a/spec/language_server/uri_helpers_spec.rb
+++ b/spec/language_server/uri_helpers_spec.rb
@@ -1,7 +1,7 @@
 describe Solargraph::LanguageServer::UriHelpers do
-  it "escapes colons in file paths" do
+  it "don't escapes colons in file paths" do
     file = "c:/one/two"
     uri = Solargraph::LanguageServer::UriHelpers.file_to_uri(file)
-    expect(uri).to start_with('file:///c%3A')
+    expect(uri).to start_with('file:///c:')
   end
 end


### PR DESCRIPTION
On Windows, Language Server Client send the URI to server with format like `file:///c:/path/to/the/file.rb` but solargraph return `file:///c%3A/path/to/the/file.rb`.

So `open_source_map` have keys if URIs which `:` is contained. But completion find the file on server with name which is contained `%3A`.

> [WARN] Error processing request: [Solargraph::FileNotFoundError] Host could not find file:///c%3A/path/to/the/file.rb

```
lib/solargraph/language_server/host/sources.rb:94:in `find'",
lib/solargraph/language_server/host/dispatch.rb:101:in `generic_library_for'",
lib/solargraph/language_server/host/dispatch.rb:44:in `library_for'",
lib/solargraph/language_server/host.rb:467:in `completions_at'",
lib/solargraph/language_server/message/text_document/completion.rb:11:in `process'",
lib/solargraph/language_server/host.rb:94:in `receive'",
lib/solargraph/language_server/transport/adapter.rb:33:in `process'",
lib/solargraph/language_server/transport/adapter.rb:14:in `block in opening'",
lib/solargraph/language_server/transport/data_reader.rb:53:in `parse_message_from_buffer'",
lib/solargraph/language_server/transport/data_reader.rb:31:in `block in receive'",
lib/solargraph/language_server/transport/data_reader.rb:26:in `each_char'",
lib/solargraph/language_server/transport/data_reader.rb:26:in `receive'",
lib/solargraph/language_server/transport/adapter.rb:25:in `sending'",
```
I think solargraph should NOT escape colon.