### PR TITLE
fix: multi-bytes encoding

### DIFF
--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -484,7 +484,7 @@ module Solargraph
       # @return [Array(Parser::AST::Node, Array<Parser::Source::Comment>)]
       def parse_with_comments code, filename = nil
         buffer = Parser::Source::Buffer.new(filename, 0)
-        buffer.source = code.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '_')
+        buffer.source = code.encode('UTF-8', invalid: :replace, undef: :replace, replace: '_')
         parser.parse_with_comments(buffer)
       end
 
@@ -494,7 +494,7 @@ module Solargraph
       # @return [Parser::AST::Node]
       def parse code, filename = nil, line = 0
         buffer = Parser::Source::Buffer.new(filename, line)
-        buffer.source = code.encode('UTF-8', 'binary', invalid: :replace, undef: :replace, replace: '_')
+        buffer.source = code.encode('UTF-8', invalid: :replace, undef: :replace, replace: '_')
         parser.parse(buffer)
       end
 

--- a/spec/api_map/source_to_yard_spec.rb
+++ b/spec/api_map/source_to_yard_spec.rb
@@ -19,7 +19,7 @@ describe Solargraph::ApiMap::SourceToYard do
 
   it "generates docstrings" do
     source = Solargraph::SourceMap.load_string(%(
-      # My foo class
+      # My foo class 描述
       class Foo
         # @return [Hash]
         def bar
@@ -33,7 +33,7 @@ describe Solargraph::ApiMap::SourceToYard do
     object.extend Solargraph::ApiMap::SourceToYard
     object.rake_yard Solargraph::ApiMap::Store.new(source.pins)
     class_object = object.code_object_at('Foo')
-    expect(class_object.docstring).to eq('My foo class')
+    expect(class_object.docstring).to eq('My foo class 描述')
     instance_method_object = object.code_object_at('Foo#bar')
     expect(instance_method_object.tag(:return).types).to eq(['Hash'])
     class_method_object = object.code_object_at('Foo.baz')


### PR DESCRIPTION
currently all utf-8 comment will be convert to _. I found that Utf-8 string was mistaken as binary. I think it is a good style to let the passed parameters guarantee that their encoding is correct.