### PR TITLE
Recommend LanguageClient-neovim instead of vim-solargraph

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Plug-ins and extensions are available for the following editors:
     * GitHub: https://github.com/castwide/atom-solargraph
 
 * **Vim**
-    * GitHub: https://github.com/hackhowtofaq/vim-solargraph
+    * GitHub: https://github.com/autozimu/LanguageClient-neovim
 
 * **Emacs**
     * GitHub: https://github.com/guskovd/emacs-solargraph


### PR DESCRIPTION
LanguageClient-neovim seems better supported, per vim-solargraph README:

> Please consider this as a first prototype pre ALPHA version, just to prove that it can be done

I've created an PR to add an example about how to configure it with Solargraph: https://github.com/autozimu/LanguageClient-neovim/pull/799

Note also that there are some outstanding issues in vim-solargraph like the lack of support of [recent versions of solargraph](https://github.com/hackhowtofaq/vim-solargraph/issues/3) and [Language Server](https://github.com/hackhowtofaq/vim-solargraph/issues/1)

Note: Despite of the `neovim` suffix in the name of the library it supports vim as well.