### PR TITLE
Eclipse plugin information

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,10 @@ Plug-ins and extensions are available for the following editors:
 * **Emacs**
     * GitHub: https://github.com/guskovd/emacs-solargraph
 
+* **Eclipse**
+    * Plugin: https://marketplace.eclipse.org/content/ruby-solargraph
+    * GitHub: https://github.com/PyvesB/eclipse-solargraph
+
 ### Gem Support
 
 Solargraph is capable of providing code completion and documentation for gems that have YARD documentation. You can make sure your gems are documented by running `yard gems` from the command line. (The first time you run it might take a while if you have a lot of gems installed).


### PR DESCRIPTION
As mentioned in #174, I've recently been working on an Eclipse plugin to integrate Solargraph within the IDE. The code is available [here](https://github.com/PyvesB/eclipse-solargraph) and the plugin can be downloaded from the [Eclipse marketplace](https://marketplace.eclipse.org/content/ruby-solargraph).

This pull request simply adds the relevant links to the Readme.

As far as attribution is concerned, I linked to this repo as well as to your GitHub profile in the [acknowledgements section](https://github.com/PyvesB/eclipse-solargraph#acknowledgements), stating usages and licenses. There are also a few other links pointing back here lying around.

Let's bring Solargraph functionality to more and more users! 👍 