### PR TITLE
Add ability to read from a global config file

### DIFF
--- a/lib/solargraph/workspace/config.rb
+++ b/lib/solargraph/workspace/config.rb
@@ -11,9 +11,6 @@ module Solargraph
       # The workspace's .solargraph.yml can override this value.
       MAX_FILES = 5000
         
-      # The directory that contains the global config file
-      GLOBAL_CONFIG_DIR = File.expand_path('~')
-
       # @return [String]
       attr_reader :directory
 
@@ -96,11 +93,23 @@ module Solargraph
       end
 
       private
+      
+      # @return [String]
+      def global_config_path
+        ENV['SOLARGRAPH_GLOBAL_CONFIG'] || 
+          File.join(Dir.home, '.config', 'solargraph', 'config.yml')
+      end
+
+      # @return [String]
+      def workspace_config_path
+        return '' if @directory.empty?
+        File.join(@directory, '.solargraph.yml')
+      end
 
       # @return [Hash]
       def config_data
-        workspace_config = read_config(@directory)
-        global_config = read_config(GLOBAL_CONFIG_DIR)
+        workspace_config = read_config(workspace_config_path)
+        global_config = read_config(global_config_path)
         
         defaults = default_config
         defaults.merge({'exclude' => []}) unless workspace_config.nil?
@@ -114,12 +123,10 @@ module Solargraph
       #
       # @param directory [String]
       # @return [Hash]
-      def read_config directory = ''
-        return nil if directory.empty?
-        sfile = File.join(directory, '.solargraph.yml')
-
-        return nil unless File.file?(sfile)
-        YAML.safe_load(File.read(sfile))
+      def read_config config_path = ''
+        return nil if config_path.empty?
+        return nil unless File.file?(config_path)
+        YAML.safe_load(File.read(config_path))
       end
       
       # @return [Hash]

--- a/spec/api_map/config_spec.rb
+++ b/spec/api_map/config_spec.rb
@@ -3,10 +3,19 @@ require 'tmpdir'
 describe Solargraph::Workspace::Config do
   let(:config) { described_class.new(workspace_path) }
   let(:workspace_path) { File.realpath(Dir.mktmpdir) }
-  let(:global_path) { File.realpath(Dir.mktmpdir) }
+  let(:global_path) { @global_path }
 
-  after(:each) { FileUtils.remove_entry(workspace_path) }
-  after(:each) { FileUtils.remove_entry(global_path) }
+  before(:each) do
+    @global_path = File.realpath(Dir.mktmpdir)
+    @orig_env = ENV['SOLARGRAPH_GLOBAL_CONFIG']
+    ENV['SOLARGRAPH_GLOBAL_CONFIG'] = File.join(@global_path, '.solargraph.yml')
+  end
+
+  after(:each) do
+    ENV['SOLARGRAPH_GLOBAL_CONFIG'] = @orig_env
+    FileUtils.remove_entry(workspace_path)
+    FileUtils.remove_entry(global_path)
+  end
 
   it "reads workspace files from config" do
     File.write(File.join(workspace_path, 'foo.rb'), 'test')
@@ -23,7 +32,6 @@ describe Solargraph::Workspace::Config do
   end
 
   it "reads workspace files from global config" do
-    stub_const('Solargraph::Workspace::Config::GLOBAL_CONFIG_DIR', global_path)
     File.write(File.join(workspace_path, 'foo.rb'), 'test')
     File.write(File.join(workspace_path, 'bar.rb'), 'test')
 
@@ -39,7 +47,6 @@ describe Solargraph::Workspace::Config do
   end
 
   it "overrides global config with workspace config" do
-    stub_const('Solargraph::Workspace::Config::GLOBAL_CONFIG_DIR', global_path)
     File.write(File.join(workspace_path, 'foo.rb'), 'test')
     File.write(File.join(workspace_path, 'bar.rb'), 'test')
     

--- a/spec/api_map/config_spec.rb
+++ b/spec/api_map/config_spec.rb
@@ -3,8 +3,10 @@ require 'tmpdir'
 describe Solargraph::Workspace::Config do
   let(:config) { described_class.new(workspace_path) }
   let(:workspace_path) { File.realpath(Dir.mktmpdir) }
+  let(:global_path) { File.realpath(Dir.mktmpdir) }
 
   after(:each) { FileUtils.remove_entry(workspace_path) }
+  after(:each) { FileUtils.remove_entry(global_path) }
 
   it "reads workspace files from config" do
     File.write(File.join(workspace_path, 'foo.rb'), 'test')
@@ -18,5 +20,44 @@ describe Solargraph::Workspace::Config do
 
     expect(config.included).to eq([File.join(workspace_path, 'foo.rb')])
     expect(config.excluded).to eq([File.join(workspace_path, 'bar.rb')])
+  end
+
+  it "reads workspace files from global config" do
+    stub_const('Solargraph::Workspace::Config::GLOBAL_CONFIG_DIR', global_path)
+    File.write(File.join(workspace_path, 'foo.rb'), 'test')
+    File.write(File.join(workspace_path, 'bar.rb'), 'test')
+
+    File.open(File.join(global_path, '.solargraph.yml'), 'w') do |file|
+      file.puts "include:"
+      file.puts "  - foo.rb"
+      file.puts "exclude:"
+      file.puts "  - bar.rb"
+    end
+
+    expect(config.included).to eq([File.join(workspace_path, 'foo.rb')])
+    expect(config.excluded).to eq([File.join(workspace_path, 'bar.rb')])
+  end
+
+  it "overrides global config with workspace config" do
+    stub_const('Solargraph::Workspace::Config::GLOBAL_CONFIG_DIR', global_path)
+    File.write(File.join(workspace_path, 'foo.rb'), 'test')
+    File.write(File.join(workspace_path, 'bar.rb'), 'test')
+    
+    File.open(File.join(workspace_path, '.solargraph.yml'), 'w') do |file|
+        file.puts "include:"
+        file.puts "  - foo.rb"
+        file.puts "max_files: 8000"
+    end
+    File.open(File.join(global_path, '.solargraph.yml'), 'w') do |file|
+      file.puts "include:"
+      file.puts "  - include.rb"
+      file.puts "exclude:"
+      file.puts "  - bar.rb"
+      file.puts "max_files: 1000"
+    end
+
+    expect(config.included).to eq([File.join(workspace_path, 'foo.rb')])
+    expect(config.excluded).to eq([File.join(workspace_path, 'bar.rb')])
+    expect(config.max_files).to eq(8000)
   end
 end


### PR DESCRIPTION
Allows the use of a global config file defined at ~/.solargraph.yml

https://github.com/castwide/solargraph/issues/197