### PR TITLE
Drop dependency htmlentities

### DIFF
--- a/lib/solargraph/page.rb
+++ b/lib/solargraph/page.rb
@@ -3,7 +3,6 @@
 require 'ostruct'
 require 'tilt'
 require 'yard'
-require 'htmlentities'
 require 'cgi'
 
 module Solargraph
@@ -30,7 +29,7 @@ module Solargraph
       # @param text [String]
       # @return [String]
       def escape text
-        HTMLEntities.new.encode(text)
+        CGI.escapeHTML(text)
       end
 
       # @param code [String]

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -21,7 +21,6 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency 'backport', '~> 1.1'
   s.add_runtime_dependency 'bundler', '>= 1.17.2'
-  s.add_runtime_dependency 'htmlentities', '~> 4.3', '>= 4.3.4'
   s.add_runtime_dependency 'jaro_winkler', '~> 1.5'
   s.add_runtime_dependency 'nokogiri', '~> 1.9', '>= 1.9.1'
   s.add_runtime_dependency 'parser', '~> 2.3'


### PR DESCRIPTION
This gem has not been touched since 2015 and can be considered dead now. It is only used in a single place and can be replaced with a function from the `cgi` module.

I was unfortunately not able to figure out how to add tests for this, as my ruby knowledge is very much limited. If you can point me at the correct place, then I'll be more than happy to add some to ensure that there are no regressions due to this.