### PR TITLE
Test if ns is nil to avoid exception

### DIFF
--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -20,7 +20,7 @@ module Solargraph
     @@stdlib_paths = {}
     YARD::Registry.load! @@stdlib_yardoc
     YARD::Registry.all(:class, :module).each do |ns|
-      next if ns.file.nil?
+      next if ns&.file.nil?
       path = ns.file.sub(/^(ext|lib)\//, '').sub(/\.(rb|c)$/, '')
       next if path.start_with?('-')
       @@stdlib_paths[path] ||= []


### PR DESCRIPTION
the variable ns is sometime nil which cause an exception on solargraph startup.
The & will return nil for ns&.file instead of a nil exception.