### PR TITLE
Add require diff algo using Trie

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,3 +5,7 @@ gemspec name: 'solargraph'
 # Local gemfile for development tools, etc.
 local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile
+
+platforms :mri do
+  gem 'fast_trie', '~> 0.5.1'
+end

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -4,7 +4,6 @@ require 'rubygems'
 require 'set'
 require 'pathname'
 require 'yard'
-require 'trie'
 require 'yard-solargraph'
 
 module Solargraph
@@ -16,6 +15,7 @@ module Solargraph
     autoload :SourceToYard,   'solargraph/api_map/source_to_yard'
     autoload :Store,          'solargraph/api_map/store'
     autoload :BundlerMethods, 'solargraph/api_map/bundler_methods'
+    autoload :ReqDiff,        'solargraph/api_map/req_diff'
 
     include SourceToYard
     include BundlerMethods
@@ -26,6 +26,7 @@ module Solargraph
     # @param pins [Array<Solargraph::Pin::Base>]
     def initialize pins: []
       @source_map_hash = {}
+      @require_diff = ReqDiff.new
       @cache = Cache.new
       @method_alias_stack = []
       index pins
@@ -101,7 +102,7 @@ module Solargraph
       reqs.merge bundle.workspace.config.required
       local_path_hash.clear
       unless bundle.workspace.require_paths.empty?
-        reqs = require_diff(bundle, reqs.clone, new_map_hash)
+        reqs = @require_diff.unresolved_requires(bundle, reqs.clone, new_map_hash)
       end
       reqs.merge implicit.requires
       pins.concat implicit.overrides
@@ -118,104 +119,6 @@ module Solargraph
       @rebindable_method_names = nil
       store.block_pins.each { |blk| blk.rebind(self) }
       self
-    end
-
-    # Determine the diff for requires that don't need to be calculated control
-    #
-    # @param bundle [Bundle]
-    # @param reqs [Array<String>]
-    # @param new_map_hash [Hash<String, String>]
-    # @return [Array<String>]
-    def require_diff_control bundle, reqs, new_map_hash
-      reqs.reject do |r|
-        result = false
-        bundle.workspace.require_paths.each do |l|
-          pn = Pathname.new(bundle.workspace.directory).join(l, "#{r}.rb")
-          if new_map_hash.keys.include?(pn.to_s)
-            local_path_hash[r] = pn.to_s
-            result = true
-            break
-          end
-        end
-        result
-      end
-    end
-
-    # Determine the diff for requires that don't need to be calculated
-    #
-    # @param bundle [Bundle]
-    # @param reqs [Array<String>]
-    # @param new_map_hash [Hash<String, String>]
-    # @return [Array<String>]
-    def require_diff bundle, reqs, new_map_hash
-      # convert new map hash to a trie
-      source_trie = Trie.new
-      new_map_hash.keys.each do |key|
-        source_trie.add(key) unless key.nil?
-      end
-
-      # add eagerly add trailing separator to directories
-      ws_path = Pathname.new(bundle.workspace.directory)
-      req_paths = bundle.workspace.require_paths.map do |req_path|
-        req_path + File::SEPARATOR
-      end
-      all_paths = req_paths.concat([ws_path.to_s])
-
-      # determine the longest shared prefix, likely the repo root directory
-      longest_prefix = longest_prefix(all_paths)
-
-      # navigate down trie to longest shared prefix
-      prefix_node = source_trie.root
-      longest_prefix.each_char do |c|
-        prefix_node = prefix_node.walk(c)
-        break if prefix_node.nil?
-      end
-      return reqs if prefix_node.nil?
-
-      all_paths.each do |req_path|
-        break if reqs.empty?
-        remaining_path = req_path[longest_prefix.size..-1]
-
-        # navigate down require path
-        node = prefix_node
-        remaining_path.each_char do |c|
-          node = node.walk(c)
-          break if node.nil?
-        end
-        next unless node
-
-        # remove all requires that are found in new_map_hash
-        reqs = reqs.delete_if do |req|
-          req_node = node
-
-          (req + '.rb').each_char do |c|
-            req_node = req_node.walk(c)
-            break if req_node.nil?
-          end
-
-          !req_node.nil?
-        end
-      end
-
-      reqs
-    end
-
-    # Find the longest prefix in an array of strings
-    #
-    # @params paths: [Array<String>]
-    # @returns String
-    def longest_prefix paths
-      return '' if paths.nil? || paths.empty?
-      sorted_paths = paths
-
-      first = sorted_paths[0]
-      last = sorted_paths[sorted_paths.size - 1]
-      min_length = [first.size, last.size].min
-
-      i = 0
-      i += 1 while i < min_length && first[i] == last[i]
-
-      first[0...i]
     end
 
     # @return [Environ]

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -4,6 +4,7 @@ require 'rubygems'
 require 'set'
 require 'pathname'
 require 'yard'
+require 'trie'
 require 'yard-solargraph'
 
 module Solargraph
@@ -100,19 +101,7 @@ module Solargraph
       reqs.merge bundle.workspace.config.required
       local_path_hash.clear
       unless bundle.workspace.require_paths.empty?
-        file_keys = new_map_hash.keys
-        workspace_path = Pathname.new(bundle.workspace.directory)
-        reqs.delete_if do |r|
-          bundle.workspace.require_paths.any? do |base|
-            pn = workspace_path.join(base, "#{r}.rb").to_s
-            if file_keys.include? pn
-              local_path_hash[r] = pn
-              true
-            else
-              false
-            end
-          end
-        end
+        reqs = require_diff(bundle, reqs.clone, new_map_hash)
       end
       reqs.merge implicit.requires
       pins.concat implicit.overrides
@@ -129,6 +118,104 @@ module Solargraph
       @rebindable_method_names = nil
       store.block_pins.each { |blk| blk.rebind(self) }
       self
+    end
+
+    # Determine the diff for requires that don't need to be calculated control
+    #
+    # @param bundle [Bundle]
+    # @param reqs [Array<String>]
+    # @param new_map_hash [Hash<String, String>]
+    # @return [Array<String>]
+    def require_diff_control bundle, reqs, new_map_hash
+      reqs.reject do |r|
+        result = false
+        bundle.workspace.require_paths.each do |l|
+          pn = Pathname.new(bundle.workspace.directory).join(l, "#{r}.rb")
+          if new_map_hash.keys.include?(pn.to_s)
+            local_path_hash[r] = pn.to_s
+            result = true
+            break
+          end
+        end
+        result
+      end
+    end
+
+    # Determine the diff for requires that don't need to be calculated
+    #
+    # @param bundle [Bundle]
+    # @param reqs [Array<String>]
+    # @param new_map_hash [Hash<String, String>]
+    # @return [Array<String>]
+    def require_diff bundle, reqs, new_map_hash
+      # convert new map hash to a trie
+      source_trie = Trie.new
+      new_map_hash.keys.each do |key|
+        source_trie.add(key) unless key.nil?
+      end
+
+      # add eagerly add trailing separator to directories
+      ws_path = Pathname.new(bundle.workspace.directory)
+      req_paths = bundle.workspace.require_paths.map do |req_path|
+        req_path + File::SEPARATOR
+      end
+      all_paths = req_paths.concat([ws_path.to_s])
+
+      # determine the longest shared prefix, likely the repo root directory
+      longest_prefix = longest_prefix(all_paths)
+
+      # navigate down trie to longest shared prefix
+      prefix_node = source_trie.root
+      longest_prefix.each_char do |c|
+        prefix_node = prefix_node.walk(c)
+        break if prefix_node.nil?
+      end
+      return reqs if prefix_node.nil?
+
+      all_paths.each do |req_path|
+        break if reqs.empty?
+        remaining_path = req_path[longest_prefix.size..-1]
+
+        # navigate down require path
+        node = prefix_node
+        remaining_path.each_char do |c|
+          node = node.walk(c)
+          break if node.nil?
+        end
+        next unless node
+
+        # remove all requires that are found in new_map_hash
+        reqs = reqs.delete_if do |req|
+          req_node = node
+
+          (req + '.rb').each_char do |c|
+            req_node = req_node.walk(c)
+            break if req_node.nil?
+          end
+
+          !req_node.nil?
+        end
+      end
+
+      reqs
+    end
+
+    # Find the longest prefix in an array of strings
+    #
+    # @params paths: [Array<String>]
+    # @returns String
+    def longest_prefix paths
+      return '' if paths.nil? || paths.empty?
+      sorted_paths = paths
+
+      first = sorted_paths[0]
+      last = sorted_paths[sorted_paths.size - 1]
+      min_length = [first.size, last.size].min
+
+      i = 0
+      i += 1 while i < min_length && first[i] == last[i]
+
+      first[0...i]
     end
 
     # @return [Environ]

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -102,7 +102,7 @@ module Solargraph
       reqs.merge bundle.workspace.config.required
       local_path_hash.clear
       unless bundle.workspace.require_paths.empty?
-        reqs = @require_diff.unresolved_requires(bundle, reqs.clone, new_map_hash)
+        local_path_hash.merge! @require_diff.unresolved_requires(bundle, reqs, new_map_hash)
       end
       reqs.merge implicit.requires
       pins.concat implicit.overrides

--- a/lib/solargraph/api_map/req_diff.rb
+++ b/lib/solargraph/api_map/req_diff.rb
@@ -34,7 +34,7 @@ module Solargraph
       # @return [Array<String>]
       def diff_native bundle, reqs, new_map_hash
         local_path_hash = {}
-        
+
         # convert new map hash to a trie
         source_trie = Trie.new
         new_map_hash.keys.each do |key|
@@ -81,10 +81,10 @@ module Solargraph
             end
 
             if req_node.nil?
-              true
+              false
             else
               local_path_hash[req] = req_node.full_state
-              false
+              true
             end
           end
         end

--- a/lib/solargraph/api_map/req_diff.rb
+++ b/lib/solargraph/api_map/req_diff.rb
@@ -1,0 +1,127 @@
+# frozen_string_literal: true
+
+module Solargraph
+  class ApiMap
+    class ReqDiff
+      def initialize
+        require 'trie'
+        @native = true
+      rescue LoadError
+        @native = false
+      end
+
+      # Determine requires that still need processing
+      #
+      # @param bundle [Bundle]
+      # @param reqs [Array<String>]
+      # @param new_map_hash [Hash<String, String>]
+      # @return [Array<String>]
+      def unresolved_requires bundle, reqs, new_map_hash
+        if @native
+          diff_native bundle, reqs, new_map_hash
+        else
+          diff_pure bundle, reqs, new_map_hash
+        end
+      end
+
+      private
+
+      # Determine requires that still need processing using trie_fast
+      #
+      # @param bundle [Bundle]
+      # @param reqs [Array<String>]
+      # @param new_map_hash [Hash<String, String>]
+      # @return [Array<String>]
+      def diff_native bundle, reqs, new_map_hash
+        # convert new map hash to a trie
+        source_trie = Trie.new
+        new_map_hash.keys.each do |key|
+          source_trie.add(key) unless key.nil?
+        end
+
+        # add eagerly add trailing separator to directories
+        ws_path = Pathname.new(bundle.workspace.directory)
+        req_paths = bundle.workspace.require_paths.map do |req_path|
+          req_path + File::SEPARATOR
+        end
+        all_paths = req_paths.concat([ws_path.to_s])
+
+        # determine the longest shared prefix, likely the repo root directory
+        longest_prefix = longest_prefix(all_paths)
+
+        # navigate down trie to longest shared prefix
+        prefix_node = source_trie.root
+        longest_prefix.each_char do |c|
+          prefix_node = prefix_node.walk(c)
+          break if prefix_node.nil?
+        end
+        return reqs if prefix_node.nil?
+
+        all_paths.each do |req_path|
+          break if reqs.empty?
+          remaining_path = req_path[longest_prefix.size..-1]
+
+          # navigate down require path
+          node = prefix_node
+          remaining_path.each_char do |c|
+            node = node.walk(c)
+            break if node.nil?
+          end
+          next unless node
+
+          # remove all requires that are found in new_map_hash
+          reqs = reqs.delete_if do |req|
+            req_node = node
+
+            (req + '.rb').each_char do |c|
+              req_node = req_node.walk(c)
+              break if req_node.nil?
+            end
+
+            !req_node.nil?
+          end
+        end
+
+        reqs
+      end
+
+      # Determine requires that still need processing using trie_fast
+      #
+      # @param bundle [Bundle]
+      # @param reqs [Array<String>]
+      # @param new_map_hash [Hash<String, String>]
+      # @return [Array<String>]
+      def diff_pure bundle, reqs, new_map_hash
+        reqs.reject do |r|
+          result = false
+          bundle.workspace.require_paths.each do |l|
+            pn = Pathname.new(bundle.workspace.directory).join(l, "#{r}.rb")
+            next unless new_map_hash.keys.include?(pn.to_s)
+            local_path_hash[r] = pn.to_s
+            result = true
+            break
+          end
+          result
+        end
+      end
+
+      # Find the longest prefix in an array of strings
+      #
+      # @params paths: [Array<String>]
+      # @returns String
+      def longest_prefix paths
+        return '' if paths.nil? || paths.empty?
+        sorted_paths = paths
+
+        first = sorted_paths[0]
+        last = sorted_paths[sorted_paths.size - 1]
+        min_length = [first.size, last.size].min
+
+        i = 0
+        i += 1 while i < min_length && first[i] == last[i]
+
+        first[0...i]
+      end
+    end
+  end
+end

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -23,6 +23,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'benchmark'
   s.add_runtime_dependency 'bundler', '>= 1.17.2'
   s.add_runtime_dependency 'e2mmap'
+  s.add_runtime_dependency 'fast_trie', '~> 0.5.1'
   s.add_runtime_dependency 'jaro_winkler', '~> 1.5'
   s.add_runtime_dependency 'maruku', '~> 0.7', '>= 0.7.3'
   s.add_runtime_dependency 'nokogiri', '~> 1.9', '>= 1.9.1'

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -23,7 +23,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'benchmark'
   s.add_runtime_dependency 'bundler', '>= 1.17.2'
   s.add_runtime_dependency 'e2mmap'
-  s.add_runtime_dependency 'fast_trie', '~> 0.5.1'
   s.add_runtime_dependency 'jaro_winkler', '~> 1.5'
   s.add_runtime_dependency 'maruku', '~> 0.7', '>= 0.7.3'
   s.add_runtime_dependency 'nokogiri', '~> 1.9', '>= 1.9.1'


### PR DESCRIPTION
The PR is in relation to issue #261. Initial profiling looks promising as seen here:

|master|this pr|
|--|--|
|<img width="1605" alt="Screen Shot 2020-01-10 at 4 34 49 PM" src="https://user-images.githubusercontent.com/5347312/72187975-27f38280-33c7-11ea-90a2-deb0b1cef613.png">|<img width="1608" alt="Screen Shot 2020-01-10 at 4 35 49 PM" src="https://user-images.githubusercontent.com/5347312/72188029-4eb1b900-33c7-11ea-9fc7-4188c3a8dd06.png">|

The rbspy reports its flamegraph in svg which github doesn't support unfortunately. Both of these profiles were ~8 minutes of `solargraph scan` on our main repo. The main take away from the current master branch is the wide flat region of the chart corresponding the determine the correct requires is essentially gone in this PR. While this is only one repo, a deep dive into the data shows this snippet went from 31599 profile samples to 174 a ~170X speedup. 

Currently this PR doesn't pass a test in `spec/language_server/message/text_document/definition_spec.rb`. It appears that it doesn't correctly resolve a require. I've been trying to track down the reason but have not been successful so far. The current suite of api_map_spec test pass so there seems to be an edge case that I haven't covered yet. Any help would be appreciated.

