### PR TITLE
Ignore Bundler warnings when parsing JSON

### DIFF
--- a/lib/solargraph/documentor.rb
+++ b/lib/solargraph/documentor.rb
@@ -61,7 +61,7 @@ module Solargraph
           ]
           o, e, s = Open3.capture3(*cmd)
           if s.success?
-            o && !o.empty? ? JSON.parse(o) : {}
+            o && !o.empty? ? JSON.parse(o.split("\n").last) : {}
           else
             Solargraph.logger.warn e
             raise BundleNotFoundError, "Failed to load gems from bundle at #{directory}"


### PR DESCRIPTION
This PR attempts to address https://github.com/castwide/solargraph/issues/272 by splitting the output from Bundler when executing `Documentor.specs_from_bundle` and ignoring all lines but the last one. The last one is the only one that we care about since that contains the Bundler specs in JSON, and everything else can be assumed to be a Bundler warning.