### PR TITLE
Avoid lazy initialization of Mutex

### DIFF
--- a/lib/solargraph/language_server/host/sources.rb
+++ b/lib/solargraph/language_server/host/sources.rb
@@ -12,6 +12,7 @@ module Solargraph
         include UriHelpers
 
         def initialize
+          @mutex = Mutex.new
           @stopped = true
         end
 
@@ -131,9 +132,7 @@ module Solargraph
         end
 
         # @return [Mutex]
-        def mutex
-          @mutex ||= Mutex.new
-        end
+        attr_reader :mutex
 
         # An array of source URIs that are waiting to finish synchronizing.
         #


### PR DESCRIPTION
Move initialization of the `Mutex` to the constructor.

  - this makes the code more robust on non-MRI platforms, where no GIL/GVL protects the individual line
  - _perhaps_ this is easier to follow for someone trying to understand the flow

(One could argue it'd be cheaper to refer to the instance variable `@mutex` directly, instead of calling a method. But this change is about avoiding the lazy init.)