### PR TITLE
feat: treat prepend module as include module

### DIFF
--- a/lib/solargraph/parser/rubyvm/node_processors/send_node.rb
+++ b/lib/solargraph/parser/rubyvm/node_processors/send_node.rb
@@ -39,6 +39,8 @@ module Solargraph
               process_include
             elsif node.children[0] == :extend
               process_extend
+            elsif node.children[0] == :prepend
+              process_include
             elsif node.children[0] == :private_constant
               process_private_constant
             end

--- a/spec/source_map/mapper_spec.rb
+++ b/spec/source_map/mapper_spec.rb
@@ -32,6 +32,22 @@ describe Solargraph::SourceMap::Mapper do
     expect(names).not_to include('Indirect')
   end
 
+  it "ignores prepend calls that are not attached to the current namespace" do
+    # @todo The prepend call inside of xyz args is probably valid
+    source = Solargraph::Source.new(%(
+      class Foo
+        prepend Direct
+        xyz.prepend Indirect
+        # xyz(prepend Indirect)
+      end
+    ))
+    map = Solargraph::SourceMap.map(source)
+    pins = map.pins.select{|pin| pin.is_a?(Solargraph::Pin::Reference::Include) && pin.namespace == 'Foo'}
+    names = pins.map(&:name)
+    expect(names).to include('Direct')
+    expect(names).not_to include('Indirect')
+  end
+
   it "ignores extend calls that are not attached to the current namespace" do
     # @todo The include call inside of xyz args is probably valid
     source = Solargraph::Source.new(%(


### PR DESCRIPTION
I only add basic prepend support like include. I am not sure if the prepend order matters.