### PR TITLE
Allow reverse_markdown 2

### DIFF
--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'maruku', '~> 0.7', '>= 0.7.3'
   s.add_runtime_dependency 'nokogiri', '~> 1.9', '>= 1.9.1'
   s.add_runtime_dependency 'parser', '~> 2.3'
-  s.add_runtime_dependency 'reverse_markdown', '~> 1.0', '>= 1.0.5'
+  s.add_runtime_dependency 'reverse_markdown', '>= 1.0.5', '< 3'
   s.add_runtime_dependency 'rubocop', '~> 0.52'
   s.add_runtime_dependency 'thor', '~> 1.0'
   s.add_runtime_dependency 'tilt', '~> 2.0'


### PR DESCRIPTION
The only breaking change was dropping Ruby 1.9 supports, which solargraph
doesn't support anyway.
https://github.com/xijo/reverse_markdown/blob/master/CHANGELOG.md#200---march-2020