### PR TITLE
Speed up Travis CI run

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.1
   - 2.2
@@ -23,6 +24,5 @@ matrix:
       
 before_install:
 - ruby ./travis-bundler.rb
-- bundle install
 before_script: yard gems
 script: rspec

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,5 +24,5 @@ matrix:
       
 before_install:
 - ruby ./travis-bundler.rb
-before_script: yard gems
-script: rspec
+before_script: bundle exec yard gems
+script: bundle exec rspec

--- a/lib/solargraph/documentor.rb
+++ b/lib/solargraph/documentor.rb
@@ -76,6 +76,7 @@ module Solargraph
     def self.specs_from_gemfile directory, name
       Solargraph.with_clean_env do
         Dir.chdir directory do
+          Solargraph.logger.warn Dir.entries(Dir.pwd)
           cmd = [
             'bundle', 'exec', 'ruby', '-e',
             "require 'bundler'; require 'json'; puts Bundler::Definition.build('#{name}', '#{name}.lock', false).specs_for([:default]).map { |spec| [spec.name, spec.version] }.to_h.to_json"

--- a/lib/solargraph/documentor.rb
+++ b/lib/solargraph/documentor.rb
@@ -77,18 +77,9 @@ module Solargraph
       Solargraph.with_clean_env do
         Dir.chdir directory do
           Solargraph.logger.warn Dir.entries(Dir.pwd)
-          cmd = [
-            'bundle', 'exec', 'ruby', '-e',
-            "require 'bundler'; require 'json'; puts Bundler::Definition.build('#{name}', '#{name}.lock', false).specs_for([:default]).map { |spec| [spec.name, spec.version] }.to_h.to_json"
-          ]
-          o, e, s = Open3.capture3(*cmd)
-          if s.success?
-            o && !o.empty? ? JSON.parse(o.split("\n").last) : {}
-          else
-            pp e
-            Solargraph.logger.warn e
-            raise BundleNotFoundError, "Failed to load gems from #{name} at #{directory}"
-          end
+          definition = Bundler::Definition.build(name, "#{name}.lock", false)
+          definition.specs_for([:default]).map { |spec| [spec.name, spec.version] }.to_h
+          # raise BundleNotFoundError, "Failed to load gems from #{name} at #{directory}"
         end
       end
     end

--- a/lib/solargraph/documentor.rb
+++ b/lib/solargraph/documentor.rb
@@ -72,5 +72,24 @@ module Solargraph
         end
       end
     end
+
+    def self.specs_from_gemfile directory, name
+      Solargraph.with_clean_env do
+        Dir.chdir directory do
+          cmd = [
+            'bundle', 'exec', 'ruby', '-e',
+            "require 'bundler'; require 'json'; puts Bundler::Definition.build('#{name}', '#{name}.lock', false).specs_for([:default]).map { |spec| [spec.name, spec.version] }.to_h.to_json"
+          ]
+          o, e, s = Open3.capture3(*cmd)
+          if s.success?
+            o && !o.empty? ? JSON.parse(o.split("\n").last) : {}
+          else
+            pp e
+            Solargraph.logger.warn e
+            raise BundleNotFoundError, "Failed to load gems from #{name} at #{directory}"
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/api_map/bundler_methods_spec.rb
+++ b/spec/api_map/bundler_methods_spec.rb
@@ -1,25 +1,9 @@
 require 'tmpdir'
 require 'fileutils'
-require 'open3'
 
 describe Solargraph::ApiMap::BundlerMethods do
   # @todo Skipping Bundler-related tests on JRuby
   next if RUBY_PLATFORM == 'java'
-
-  # Build the Gemfile.lock in specs so Travis jobs use the correct version of
-  # Bundler (e.g., Ruby 2.1 uses Bundler 1)
-  before :all do
-    Dir.chdir 'spec/fixtures/workspace' do
-      p Dir.pwd
-      p File.dirname __FILE__
-      o, e, s = Open3.capture3('bundle', 'install')
-      raise RuntimeError, e unless s.success?
-    end
-  end
-
-  after :all do
-    File.unlink 'spec/fixtures/workspace/Gemfile.lock'
-  end
 
   after :each do
     Solargraph::ApiMap::BundlerMethods.reset_require_from_bundle

--- a/spec/api_map/bundler_methods_spec.rb
+++ b/spec/api_map/bundler_methods_spec.rb
@@ -1,5 +1,6 @@
 require 'tmpdir'
 require 'fileutils'
+require 'open3'
 
 describe Solargraph::ApiMap::BundlerMethods do
   # @todo Skipping Bundler-related tests on JRuby
@@ -9,7 +10,10 @@ describe Solargraph::ApiMap::BundlerMethods do
   # Bundler (e.g., Ruby 2.1 uses Bundler 1)
   before :all do
     Dir.chdir 'spec/fixtures/workspace' do
-      `bundle install`
+      p Dir.pwd
+      p File.dirname __FILE__
+      o, e, s = Open3.capture3('bundle', 'install')
+      raise RuntimeError, e unless s.success?
     end
   end
 

--- a/spec/documentor_spec.rb
+++ b/spec/documentor_spec.rb
@@ -9,6 +9,11 @@ describe Solargraph::Documentor do
     expect(gemset.keys).to eq(['backport', 'bundler'])
   end
 
+  it 'returns gemsets for gemfiles' do
+    gemset = Solargraph::Documentor.specs_from_gemfile('spec/fixtures/workspace', 'Gemfile')
+    expect(gemset.keys).to eq(['backport', 'bundler'])
+  end
+
   it 'raises errors for directories without bundles' do
     Dir.mktmpdir do |tmp|
       expect {

--- a/spec/documentor_spec.rb
+++ b/spec/documentor_spec.rb
@@ -1,22 +1,8 @@
 require 'tmpdir'
-require 'open3'
 
 describe Solargraph::Documentor do
   # @todo Skipping Bundler-related tests on JRuby
   next if RUBY_PLATFORM == 'java'
-
-  # Build the Gemfile.lock in specs so Travis jobs use the correct version of
-  # Bundler (e.g., Ruby 2.1 uses Bundler 1)
-  before :all do
-    Dir.chdir 'spec/fixtures/workspace' do
-      o, e, s = Open3.capture3('bundle', 'install')
-      raise RuntimeError, e unless s.success?
-    end
-  end
-
-  after :all do
-    File.unlink 'spec/fixtures/workspace/Gemfile.lock'
-  end
 
   it 'returns gemsets for directories with bundles' do
     gemset = Solargraph::Documentor.specs_from_bundle('spec/fixtures/workspace')

--- a/spec/fixtures/workspace/Gemfile.lock
+++ b/spec/fixtures/workspace/Gemfile.lock
@@ -1,0 +1,13 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    backport (1.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  backport
+
+BUNDLED WITH
+   2.1.4

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,4 +10,4 @@ require 'simplecov'
 SimpleCov.start
 require 'solargraph'
 # Suppress logger output in specs (if possible)
-Solargraph::Logging.logger.reopen(File::NULL) if Solargraph::Logging.logger.respond_to?(:reopen)
+Solargraph::Logging.logger


### PR DESCRIPTION
Travis runs `bundler install` itself, but in parallel.
`cache: bundler` should speed up future CI runs.

<img width="989" alt="Screenshot 2020-05-25 at 13 39 03" src="https://user-images.githubusercontent.com/1301152/82809759-1d74e980-9e8d-11ea-8ce3-28effa7e3c6d.png">
