### PR TITLE
Use `ensure` block for File.unlink tempfile

### DIFF
--- a/lib/solargraph/language_server/message/text_document/formatting.rb
+++ b/lib/solargraph/language_server/message/text_document/formatting.rb
@@ -26,10 +26,10 @@ module Solargraph
               store = RuboCop::ConfigStore.new
               redirect_stdout { RuboCop::Runner.new(options, store).run(paths) }
               result = File.read(tempfile)
-              File.unlink tempfile
               format original, result
             rescue RuboCop::ValidationError, RuboCop::ConfigNotFoundError => e
               set_error(Solargraph::LanguageServer::ErrorCodes::INTERNAL_ERROR, "[#{e.class}] #{e.message}")
+            ensure
               File.unlink tempfile
             end
           end


### PR DESCRIPTION
This ensures that temporary files are removed even if the begin block
fails. This has been happening on some dev machines.

https://www.reddit.com/r/neovim/comments/gmq965/vim_creating_tmp_files/