### PR TITLE
Exit with 1 if type check finds problems

### DIFF
--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -153,6 +153,7 @@ module Solargraph
         probcount += problems.length
       end
       puts "#{probcount} problem#{probcount != 1 ? 's' : ''} found#{files.length != 1 ? " in #{filecount} of #{files.length} files" : ''}."
+      exit 1 if probcount.positive?
     end
 
     desc 'scan', 'Test the workspace for problems'


### PR DESCRIPTION
I am looking to use Solargraph's type check in a CI environment, and I want to fail the build if there are errors. Currently the exit code is 0 whether errors are found or not.