### PR TITLE
Simplify and allow to configure rubocop formatter

### DIFF
--- a/lib/solargraph/diagnostics/rubocop_helpers.rb
+++ b/lib/solargraph/diagnostics/rubocop_helpers.rb
@@ -13,30 +13,11 @@ module Solargraph
       # @param code [String]
       # @return [Array(Array<String>, Array<String>)]
       def generate_options filename, code
-        args = ['-f', 'j']
-        rubocop_file = find_rubocop_file(filename)
-        args.push('-c', fix_drive_letter(rubocop_file)) unless rubocop_file.nil?
-        args.push filename
+        args = ['-f', 'j', filename]
         base_options = RuboCop::Options.new
         options, paths = base_options.parse(args)
         options[:stdin] = code
         [options, paths]
-      end
-
-      # Find a RuboCop configuration file in a file's directory tree.
-      #
-      # @param filename [String]
-      # @return [String, nil]
-      def find_rubocop_file filename
-        return nil unless File.exist?(filename)
-        filename = File.realpath(filename)
-        dir = File.dirname(filename)
-        until File.dirname(dir) == dir
-          here = File.join(dir, '.rubocop.yml')
-          return here if File.exist?(here)
-          dir = File.dirname(dir)
-        end
-        nil
       end
 
       # RuboCop internally uses capitalized drive letters for Windows paths,

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -494,6 +494,11 @@ module Solargraph
         library.read_text(filename)
       end
 
+      def formatter_config uri
+        library = library_for(uri)
+        library.workspace.config.formatter
+      end
+
       # @param uri [String]
       # @param line [Integer]
       # @param column [Integer]

--- a/lib/solargraph/language_server/message/text_document/formatting.rb
+++ b/lib/solargraph/language_server/message/text_document/formatting.rb
@@ -14,8 +14,10 @@ module Solargraph
           class BlankRubocopFormatter < ::RuboCop::Formatter::BaseFormatter; end
 
           def process
-            original = host.read_text(params['textDocument']['uri'])
-            args = cli_args(params['textDocument']['uri'])
+            file_uri = params['textDocument']['uri']
+            config = host.formatter_config(file_uri)
+            original = host.read_text(file_uri)
+            args = cli_args(file_uri, config)
 
             options, paths = RuboCop::Options.new.parse(args)
             options[:stdin] = original
@@ -31,14 +33,15 @@ module Solargraph
 
           private
 
-          def cli_args file
+          def cli_args file, config
             [
-              '--auto-correct',
+              config['cops'] == 'all' ? '--auto-correct-all' : '--auto-correct',
               '--cache', 'false',
               '--format', 'Solargraph::LanguageServer::Message::' \
                           'TextDocument::Formatting::BlankRubocopFormatter',
+              config['extra_args'],
               file
-            ]
+            ].flatten
           end
 
           # @param original [String]

--- a/lib/solargraph/language_server/message/text_document/formatting.rb
+++ b/lib/solargraph/language_server/message/text_document/formatting.rb
@@ -41,14 +41,26 @@ module Solargraph
           end
 
           def cli_args file, config
-            [
+            args = [
               config['cops'] == 'all' ? '--auto-correct-all' : '--auto-correct',
               '--cache', 'false',
               '--format', 'Solargraph::LanguageServer::Message::' \
                           'TextDocument::Formatting::BlankRubocopFormatter',
-              config['extra_args'],
-              file
-            ].flatten
+            ]
+
+            ['except', 'only'].each do |arg|
+              cops = cop_list(config[arg])
+              args += ["--#{arg}", cops] if cops
+            end
+
+            args += config['extra_args'] if config['extra_args']
+            args + [file]
+          end
+
+          def cop_list(value)
+            value = value.join(',') if value.respond_to?(:join)
+            return nil if value == '' || !value.is_a?(String)
+            value
           end
 
           # @param original [String]

--- a/lib/solargraph/language_server/message/text_document/formatting.rb
+++ b/lib/solargraph/language_server/message/text_document/formatting.rb
@@ -15,7 +15,7 @@ module Solargraph
 
           def process
             file_uri = params['textDocument']['uri']
-            config = host.formatter_config(file_uri)
+            config = config_for(file_uri)
             original = host.read_text(file_uri)
             args = cli_args(file_uri, config)
 
@@ -32,6 +32,13 @@ module Solargraph
           end
 
           private
+
+          def config_for(file_uri)
+            conf = host.formatter_config(file_uri)
+            return {} unless conf.is_a?(Hash)
+
+            conf['rubocop'] || {}
+          end
 
           def cli_args file, config
             [

--- a/lib/solargraph/workspace/config.rb
+++ b/lib/solargraph/workspace/config.rb
@@ -85,6 +85,13 @@ module Solargraph
         raw_data['reporters']
       end
 
+      # A hash of options supported by the formatter
+      #
+      # @return [Hash]
+      def formatter
+        raw_data['formatter']
+      end
+
       # An array of plugins to require.
       #
       # @return [Array<String>]
@@ -144,6 +151,10 @@ module Solargraph
           'require' => [],
           'domains' => [],
           'reporters' => %w[rubocop require_not_found],
+          'formatter' => {
+            'cops' => 'safe',
+            'extra_args' => []
+          },
           'require_paths' => [],
           'plugins' => [],
           'max_files' => MAX_FILES

--- a/lib/solargraph/workspace/config.rb
+++ b/lib/solargraph/workspace/config.rb
@@ -152,8 +152,10 @@ module Solargraph
           'domains' => [],
           'reporters' => %w[rubocop require_not_found],
           'formatter' => {
-            'cops' => 'safe',
-            'extra_args' => []
+            'rubocop' => {
+              'cops' => 'safe',
+              'extra_args' =>[]
+            }
           },
           'require_paths' => [],
           'plugins' => [],

--- a/lib/solargraph/workspace/config.rb
+++ b/lib/solargraph/workspace/config.rb
@@ -154,6 +154,8 @@ module Solargraph
           'formatter' => {
             'rubocop' => {
               'cops' => 'safe',
+              'except' => [],
+              'only' => [],
               'extra_args' =>[]
             }
           },

--- a/spec/diagnostics/rubocop_helpers_spec.rb
+++ b/spec/diagnostics/rubocop_helpers_spec.rb
@@ -1,11 +1,4 @@
 describe Solargraph::Diagnostics::RubocopHelpers do
-  it "finds a .rubocop.yml file in a parent directory" do
-    file = File.realpath(File.join 'spec', 'fixtures', 'rubocop-subfolder-configuration', 'folder1', 'folder2', 'test.rb')
-    conf = File.realpath(File.join 'spec', 'fixtures', 'rubocop-subfolder-configuration', '.rubocop.yml')
-    found = Solargraph::Diagnostics::RubocopHelpers.find_rubocop_file(file)
-    expect(found).to eq(conf)
-  end
-
   it "converts lower-case drive letters to upper-case" do
     input = 'c:/one/two'
     output = Solargraph::Diagnostics::RubocopHelpers.fix_drive_letter(input)

--- a/spec/language_server/message/text_document/formatting_spec.rb
+++ b/spec/language_server/message/text_document/formatting_spec.rb
@@ -1,6 +1,6 @@
 describe Solargraph::LanguageServer::Message::TextDocument::Formatting do
   it 'gracefully handles empty files' do
-    host = double(:Host, read_text: '')
+    host = double(:Host, read_text: '', formatter_config: {})
     request = {
       'params' => {
           'textDocument' => {


### PR DESCRIPTION
This effectively simplifies and enhances how Solargraph interacts with RuboCop in three specific ways. Below is a summary, more details about each change is in the commit messages.

- Removes the need of creating/reading/writing any temporary files on disk when formatting code, by passing it in to rubocop in-memory via its STDIN options.
- The STDIN method means that the real original filepath on disk can be provided to rubocop, allowing it to correctly find any relevant `.rubocop.yml` config files itself, negating the need for Solargraph to have it's own implementation of rubocop config file finding. So no `-c` option is needed within the formatter, nor was it needed within the diagnostics implementation as that already used the STDIN method.
- A new `formatter` option is available within Solargraph's own configuration file, which allows some basic customization of rubocop. This is useful if you want to disable certain cops when formatting from within your editor, but you otherwise want the cops enabled when manually running rubocop.

**Update:** I'm not sure why it's not displayed here in the PR, but the Travis-CI build has passed: https://travis-ci.org/github/castwide/solargraph/builds/753192754

---

I believe this PR will fix #401, as no temp directory/file is used anymore, and rubocop's config is correctly picked up by rubocop itself without any intervention by Solargraph.