### PR TITLE
fix(formatter): strip file:// from file path given to RuboCop

### DIFF
--- a/lib/solargraph/language_server/message/text_document/formatting.rb
+++ b/lib/solargraph/language_server/message/text_document/formatting.rb
@@ -41,6 +41,8 @@ module Solargraph
           end
 
           def cli_args file, config
+            file = file.gsub(/^file:\/\//, '')
+
             args = [
               config['cops'] == 'all' ? '--auto-correct-all' : '--auto-correct',
               '--cache', 'false',


### PR DESCRIPTION
Passing in a file path to RuboCop which begins with `file://` seems to cause
strange behavior. Some parts of RuboCop seem to work correctly, while others
don't.

I have come across a couple of cases where formatting via Solargraph while it is
passing in `file:///path/to/file` causes some disabled cops corrections to run,
while other disabled cops do not run.

I have not narrowed it down to a exact list of cops, or affected versions of
Rubucop, but this change fixes all such instances I've run into.