### PR TITLE
Allow configuring the version of rubocop to require

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,21 @@ Run `bundle install` and use `bundle exec yard gems` to generate the documentati
 
 In order to make sure you're using the correct dependencies, you can start the language server with Bundler. In VS Code, there's a `solargraph.useBundler` option. Other clients will vary, but the command you probably want to run is `bundle exec solargraph socket` or `bundle exec solargraph stdio`.
 
+### Rubocop Version
+
+If you have multiple versions of [`rubocop`](https://rubygems.org/gems/rubocop) installed and you would like to choose a version other than the latest to use, this specific version can be configured.
+
+In `.solargraph.yml`:
+
+```yaml
+---
+reporters:
+- rubocop:version=0.61.0  # diagnostics
+formatter:
+  rubocop:
+    version: 0.61.0       # formatting
+```
+
 ### Integrating Other Editors
 
 The [language server protocol](https://microsoft.github.io/language-server-protocol/specification) is the recommended way for integrating Solargraph into editors and IDEs. Clients can connect using either stdio or TCP. Language client developers should refer to [https://solargraph.org/guides/language-server](https://solargraph.org/guides/language-server).

--- a/lib/solargraph.rb
+++ b/lib/solargraph.rb
@@ -9,13 +9,14 @@ require 'solargraph/version'
 # static analysis, and language server libraries.
 #
 module Solargraph
-  class InvalidOffsetError <      RangeError;    end
-  class DiagnosticsError <        RuntimeError;  end
-  class FileNotFoundError <       RuntimeError;  end
-  class SourceNotAvailableError < StandardError; end
-  class ComplexTypeError        < StandardError; end
-  class WorkspaceTooLargeError <  RuntimeError;  end
-  class BundleNotFoundError <     StandardError; end
+  class InvalidOffsetError         < RangeError;    end
+  class DiagnosticsError           < RuntimeError;  end
+  class FileNotFoundError          < RuntimeError;  end
+  class SourceNotAvailableError    < StandardError; end
+  class ComplexTypeError           < StandardError; end
+  class WorkspaceTooLargeError     < RuntimeError;  end
+  class BundleNotFoundError        < StandardError; end
+  class InvalidRubocopVersionError < RuntimeError;  end
 
   autoload :Position,         'solargraph/position'
   autoload :Range,            'solargraph/range'

--- a/lib/solargraph/diagnostics/rubocop.rb
+++ b/lib/solargraph/diagnostics/rubocop.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-require 'rubocop'
 require 'stringio'
 
 module Solargraph
@@ -23,6 +22,7 @@ module Solargraph
       # @param _api_map [Solargraph::ApiMap]
       # @return [Array<Hash>]
       def diagnose source, _api_map
+        require_rubocop(rubocop_version)
         options, paths = generate_options(source.filename, source.code)
         store = RuboCop::ConfigStore.new
         runner = RuboCop::Runner.new(options, store)
@@ -35,6 +35,13 @@ module Solargraph
       end
 
       private
+
+      # Extracts the rubocop version from _args_
+      #
+      # @return [String]
+      def rubocop_version
+        args.find { |a| a =~ /version=/ }.to_s.split('=').last
+      end
 
       # @param resp [Hash]
       # @return [Array<Hash>]

--- a/lib/solargraph/diagnostics/rubocop_helpers.rb
+++ b/lib/solargraph/diagnostics/rubocop_helpers.rb
@@ -7,6 +7,24 @@ module Solargraph
     module RubocopHelpers
       module_function
 
+      # Requires a specific version of rubocop, or the latest installed version
+      # if _version_ is `nil`.
+      #
+      # @param version [String]
+      # @raise [InvalidRubocopVersionError] if _version_ is not installed
+      def require_rubocop(version = nil)
+        begin
+          gem_path = Gem::Specification.find_by_name('rubocop', version).full_gem_path
+          gem_lib_path = File.join(gem_path, 'lib')
+          $LOAD_PATH.unshift(gem_lib_path) unless $LOAD_PATH.include?(gem_lib_path)
+        rescue Gem::MissingSpecVersionError => e
+          raise InvalidRubocopVersionError,
+                "could not find '#{e.name}' (#{e.requirement}) - "\
+                "did find: [#{e.specs.map { |s| s.version.version }.join(', ')}]"
+        end
+        require 'rubocop'
+      end
+
       # Generate command-line options for the specified filename and code.
       #
       # @param filename [String]

--- a/lib/solargraph/language_server/message/extended/environment.rb
+++ b/lib/solargraph/language_server/message/extended/environment.rb
@@ -1,8 +1,5 @@
 # frozen_string_literal: true
 
-# Make sure the environment page can report RuboCop's version
-require 'rubocop'
-
 module Solargraph
   module LanguageServer
     module Message
@@ -12,6 +9,9 @@ module Solargraph
         #
         class Environment < Base
           def process
+            # Make sure the environment page can report RuboCop's version
+            require 'rubocop'
+
             page = Solargraph::Page.new(host.options['viewsPath'])
             content = page.render('environment', layout: true, locals: { config: host.options, folders: host.folders })
             set_result(

--- a/spec/diagnostics/rubocop_helpers_spec.rb
+++ b/spec/diagnostics/rubocop_helpers_spec.rb
@@ -1,4 +1,42 @@
 describe Solargraph::Diagnostics::RubocopHelpers do
+  context do
+    around do |example|
+      old_gem_path = Gem.paths.path
+      custom_gem_path = File.absolute_path('spec/fixtures/rubocop-custom-version').gsub(/\\/, '/')
+      # Remove a post_reset hook set by bundler to restore cached specs
+      # Source: https://github.com/ruby/ruby/blob/master/lib/bundler/rubygems_integration.rb#L487-L489
+      old_post_reset_hooks = Gem.post_reset_hooks.dup
+      Gem.post_reset_hooks.clear
+      Gem.paths = { 'GEM_PATH' => [custom_gem_path, *old_gem_path].join(Gem.path_separator) }
+      example.run
+      old_post_reset_hooks.each(&Gem.post_reset_hooks.method(:<<))
+      Gem.paths = { 'GEM_PATH' => old_gem_path.join(Gem.path_separator) }
+      # Cleanup loaded classes from custom gem path
+      $LOAD_PATH.delete_if { |path| path[custom_gem_path] }
+      Object.send(:remove_const, 'RuboCop')
+    end
+
+    let(:custom_version) { '0.0.0' }
+
+    it "requires the specified version of rubocop" do
+      input = custom_version
+      Solargraph::Diagnostics::RubocopHelpers.require_rubocop(input)
+      output = RuboCop::Version::STRING
+      expect(output).to eq(custom_version)
+    end
+  end
+
+  context do
+    let(:default_version) { Gem::Specification.find_by_name('rubocop').full_gem_path[/[^-]+$/] }
+
+    it "requires the default version of rubocop" do
+      input = nil
+      Solargraph::Diagnostics::RubocopHelpers.require_rubocop(input)
+      output = RuboCop::Version::STRING
+      expect(output).to eq(default_version)
+    end
+  end
+
   it "converts lower-case drive letters to upper-case" do
     input = 'c:/one/two'
     output = Solargraph::Diagnostics::RubocopHelpers.fix_drive_letter(input)

--- a/spec/fixtures/rubocop-custom-version/gems/rubocop-0.0.0/lib/rubocop.rb
+++ b/spec/fixtures/rubocop-custom-version/gems/rubocop-0.0.0/lib/rubocop.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module RuboCop
+  class Version
+    STRING = '0.0.0'
+  end
+end

--- a/spec/fixtures/rubocop-custom-version/specifications/rubocop-0.0.0.gemspec
+++ b/spec/fixtures/rubocop-custom-version/specifications/rubocop-0.0.0.gemspec
@@ -1,0 +1,5 @@
+Gem::Specification.new do |s|
+  s.name = 'rubocop'
+  s.version = '0.0.0'
+  s.require_paths = %w[lib]
+end


### PR DESCRIPTION
Add the ability to specify a `rubocop` version when invoking [diagnostics](https://github.com/castwide/solargraph/blob/18854d7577737cf9929063d96dd99b3d0a77f703/lib/solargraph/diagnostics/rubocop.rb#L3) and [formatting](https://github.com/castwide/solargraph/blob/18854d7577737cf9929063d96dd99b3d0a77f703/lib/solargraph/language_server/message/text_document/formatting.rb#L3). This resolves the issue in case, for example, two versions of `rubocop` are installed and the active project requires the older version to be used.