### PR TITLE
Fix source of diagnostic

### DIFF
--- a/lib/solargraph/diagnostics/rubocop.rb
+++ b/lib/solargraph/diagnostics/rubocop.rb
@@ -57,7 +57,8 @@ module Solargraph
           range: offense_range(off).to_hash,
           # 1 = Error, 2 = Warning, 3 = Information, 4 = Hint
           severity: SEVERITIES[off['severity']],
-          source: off['cop_name'],
+          source: 'rubocop',
+          code: off['cop_name'],
           message: off['message'].gsub(/^#{off['cop_name']}\:/, '')
         }
       end


### PR DESCRIPTION
The diagnostic source is easy to understand if it is a linter name.

![Image from Gyazo](https://i.gyazo.com/6a1fa3fb4636effb730ab9b16b30639c.png)

https://microsoft.github.io/language-server-protocol/specifications/specification-current/#diagnostic

https://github.com/microsoft/vscode-eslint/blob/3e2b4a8a72487da052c46dcf4e145767bb81d110/server/src/eslintServer.ts#L424-L444