### PR TITLE
Fix file argument in rubocop

### DIFF
--- a/lib/solargraph/language_server/message/text_document/formatting.rb
+++ b/lib/solargraph/language_server/message/text_document/formatting.rb
@@ -40,7 +40,8 @@ module Solargraph
             conf['rubocop'] || {}
           end
 
-          def cli_args file, config
+          def cli_args file_uri, config
+            file = UriHelpers.uri_to_file(file_uri)
             args = [
               config['cops'] == 'all' ? '--auto-correct-all' : '--auto-correct',
               '--cache', 'false',


### PR DESCRIPTION
`RuboCop::Runner` file arguments with the `file://` prefix will not always match `Include` and `Exclude` settings.

If you run the following two commands on the Exclude configured file, you will see that the first one does not work as expected.

```
cat FILE_PATH | bundle exec rubocop -auto-correct --force-exclusion --stdin file:///FILE_PATH
```

```
cat FILE_PATH | bundle exec rubocop -auto-correct --force-exclusion --stdin /FILE_PATH
```

https://docs.rubocop.org/rubocop/configuration.html#includingexcluding-files