### PR TITLE
Fix required_paths when gemspec is used

### DIFF
--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -183,7 +183,7 @@ module Solargraph
           end
         end
       end
-      result.concat config.require_paths
+      result.concat config.require_paths.map{|p| File.join(directory, p)}
       result.push File.join(directory, 'lib') if result.empty?
       result
     end


### PR DESCRIPTION
In gemspec case they were not prepended `directory`