### PR TITLE
fix: yard stdout may break language client

### DIFF
--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -437,5 +437,3 @@ module Solargraph
 end
 
 Solargraph::YardMap::CoreDocs.require_minimum
-# Change YARD log IO to avoid sending unexpected messages to STDOUT
-YARD::Logger.instance.io = File.new(File::NULL, 'w')

--- a/lib/yard-solargraph.rb
+++ b/lib/yard-solargraph.rb
@@ -2,6 +2,9 @@
 
 require 'yard'
 
+# Change YARD log IO to avoid sending unexpected messages to STDOUT
+YARD::Logger.instance.io = File.new(File::NULL, 'w')
+
 module Solargraph
   # A placeholder for the @!domain directive. It doesn't need to do anything
   # for yardocs. It's only used for Solargraph API maps.


### PR DESCRIPTION
I found recent version server broken some times, and find the unexpected stdio yard out.
seems original position not require early enough. 

![图片](https://user-images.githubusercontent.com/3897953/124753916-26732e00-df5c-11eb-9616-c4f4ee9ad0db.png)
