### PR TITLE
Improve the performance of catalog by 4 times 

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -138,7 +138,7 @@ module Solargraph
 
     # An array of pins based on Ruby keywords (`if`, `end`, etc.).
     #
-    # @return [Array<Solargraph::Pin::Keyword>]
+    # @return [Enumerable<Solargraph::Pin::Keyword>]
     def keyword_pins
       store.pins_by_class(Pin::Keyword)
     end

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -51,6 +51,10 @@ module Solargraph
     def select &block
       @items.select &block
     end
+    def namespace
+      # cache this attr for high frequency call
+      @namespace ||= method_missing(:namespace).to_s
+    end
 
     def method_missing name, *args, &block
       return if @items.first.nil?

--- a/lib/solargraph/complex_type/type_methods.rb
+++ b/lib/solargraph/complex_type/type_methods.rb
@@ -72,9 +72,12 @@ module Solargraph
 
       # @return [String]
       def namespace
-        @namespace ||= 'Object' if duck_type?
-        @namespace ||= 'NilClass' if nil_type?
-        @namespace ||= (name == 'Class' || name == 'Module') && !subtypes.empty? ? subtypes.first.name : name
+        # if priority higher than ||=, old implements cause unnecessary check
+        @namespace ||= lambda do
+          return 'Object' if duck_type?
+          return 'NilClass' if nil_type?
+          return (name == 'Class' || name == 'Module') && !subtypes.empty? ? subtypes.first.name : name
+        end.call
       end
 
       # @return [Symbol] :class or :instance

--- a/lib/solargraph/language_server/host/dispatch.rb
+++ b/lib/solargraph/language_server/host/dispatch.rb
@@ -41,7 +41,8 @@ module Solargraph
           result = explicit_library_for(uri) ||
             implicit_library_for(uri) ||
             generic_library_for(uri)
-          result.attach sources.find(uri) if sources.include?(uri)
+          # previous library for already call attach. avoid call twice
+          # result.attach sources.find(uri) if sources.include?(uri)
           result
         end
 
@@ -82,7 +83,6 @@ module Solargraph
           libraries.each do |lib|
             if filename.start_with?(lib.workspace.directory)
               lib.attach sources.find(uri)
-              lib.catalog
               return lib
             end
           end
@@ -98,7 +98,6 @@ module Solargraph
         # @return [Library]
         def generic_library_for uri
           generic_library.attach sources.find(uri)
-          generic_library.catalog
           generic_library
         end
 

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -56,7 +56,7 @@ module Solargraph
         end
         @current = source
         maybe_map @current
-        api_map.catalog bench unless synchronized?
+        catalog_inlock
       end
     end
 
@@ -368,12 +368,16 @@ module Solargraph
     # @return [void]
     def catalog
       mutex.synchronize do
-        break if synchronized?
+        catalog_inlock
+      end
+    end
+
+    private def catalog_inlock
+        return if synchronized?
         logger.info "Cataloging #{workspace.directory.empty? ? 'generic workspace' : workspace.directory}"
         api_map.catalog bench
         @synchronized = true
         logger.info "Catalog complete (#{api_map.source_maps.length} files, #{api_map.pins.length} pins)" if logger.info?
-      end
     end
 
     def bench

--- a/lib/solargraph/source_map/clip.rb
+++ b/lib/solargraph/source_map/clip.rb
@@ -213,7 +213,7 @@ module Solargraph
             result.concat api_map.get_methods(block.binder.namespace, scope: block.binder.scope, visibility: [:public, :private, :protected])
             result.concat api_map.get_methods('Kernel')
             # result.concat ApiMap.keywords
-            result.concat api_map.keyword_pins
+            result.concat api_map.keyword_pins.to_a
             result.concat yielded_self_pins
           end
         end


### PR DESCRIPTION
In My workspace, I have ~100,000 pins, and I often wait for a long time without semantic completion。

this PR optimize this problem by:

1. cache pin.namespace, catalog will call it many times. this boost store index performance to **almost twice**.
2. change store return type from Array to set, to avoid unnecessary array conversion. this gain a little performance.
3. remove duplicate attach call in method library_for. since specific library for already call attach. 
4. sink catalog_inlock, ensure attach also call it and mark @synchronized = true, to avoid unnecssary catalog

In All this actions, In My workspace, I reduce single store.index from `1~1.2s` to `0.5~0.7s`, and catalog call's from 16 to 6(Same as textChanged event count). In total boost 4 tims performance.