### PR TITLE
performance: handle request on a specific thread, and cancel completion when there has newer completion request

### DIFF
--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -522,6 +522,11 @@ module Solargraph
         library.completions_at uri_to_file(uri), line, column
       end
 
+      # @return [Bool] if has pending completion request
+      def has_pending_completions?
+        message_worker.messages.reverse_each.any? { |req| req['method'] == 'textDocument/completion' }
+      end
+
       # @param uri [String]
       # @param line [Integer]
       # @param column [Integer]

--- a/lib/solargraph/language_server/host/message_worker.rb
+++ b/lib/solargraph/language_server/host/message_worker.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+module Solargraph
+  module LanguageServer
+    class Host
+      # A serial worker Thread to handle message.
+      #
+      # this make check pending message possible, and maybe cancelled to speedup process
+      class MessageWorker
+        # @param host [Host]
+        def initialize(host)
+          @host = host
+          @mutex = Mutex.new
+          @resource = ConditionVariable.new
+          @stopped = true
+        end
+
+        # pending handle messages
+        def messages
+          @messages ||= []
+        end
+
+        def stopped?
+          @stopped
+        end
+        def stop
+          @stopped = true
+        end
+
+        # @param message the message should be handle. will pass back to Host#receive
+        def queue(message)
+          @mutex.synchronize {
+            messages.push(message)
+            @resource.signal
+          }
+        end
+
+        def start
+          return unless @stopped
+          @stopped = false
+          Thread.new do
+            tick until stopped?
+          end
+        end
+        def tick
+          message = @mutex.synchronize {
+            @resource.wait(@mutex) if messages.empty?
+            messages.shift
+          }
+          message = @host.receive(message)
+          message && message.send_response
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/language_server/message/text_document/completion.rb
+++ b/lib/solargraph/language_server/message/text_document/completion.rb
@@ -6,6 +6,8 @@ module Solargraph
       module TextDocument
         class Completion < Base
           def process
+            return set_error(ErrorCodes::REQUEST_CANCELLED, "cancelled by so many request") if host.has_pending_completions?
+
             line = params['position']['line']
             col = params['position']['character']
             begin

--- a/lib/solargraph/language_server/transport/adapter.rb
+++ b/lib/solargraph/language_server/transport/adapter.rb
@@ -41,8 +41,7 @@ module Solargraph
         # @param request [String]
         # @return [void]
         def process request
-          message = @host.receive(request)
-          message && message.send_response
+          @host.process(request)
         end
 
         def shutdown

--- a/spec/language_server/host/message_worker_spec.rb
+++ b/spec/language_server/host/message_worker_spec.rb
@@ -1,0 +1,12 @@
+describe Solargraph::LanguageServer::Host::MessageWorker do
+  it "handle requests on queue" do
+    host = double(Solargraph::LanguageServer::Host)
+    message = double()
+    expect(host).to receive(:receive).with(message).and_return(nil)
+
+    worker = Solargraph::LanguageServer::Host::MessageWorker.new(host)
+    worker.queue(message)
+    expect(worker.messages).to eq [message]
+    worker.tick
+  end
+end


### PR DESCRIPTION
The PR first commit processes the message on a dedicated thread and releases the input thread. So it can check how many requests are piled up and cancel unnecessary requests.

and second commit cancels completions when there have newer completion request. to avoid unnecessary catalog.

this will make server's more responsive and have better expreience 