### PR TITLE
Fix namespace links generated by views/_method.erb

### DIFF
--- a/lib/solargraph/views/_method.erb
+++ b/lib/solargraph/views/_method.erb
@@ -2,7 +2,7 @@
     Namespace:
 </h2>
 <p>
-    <a href="command:solargraph._openDocument?<%= CGI.escape "\"solargraph:/document?query=#{object.namespace}\"" %>"><%= object.namespace %></a>
+    <a href="solargraph:/document?query=<%= CGI.escape object.namespace.path %>"><%= object.namespace %></a>
 </p>
 <h2>
     Overview:


### PR DESCRIPTION
As it stands, namespace links in method definitions generated by the `views/_method.erb` template are broken due to a misplaced `CGI.escape`. This pull request updates it to use the same format used for links in the other templates, such that rather than receiving results like this

```rb
[1] pry(main)> require 'solargraph'
=> true
[2] pry(main)> api_map = Solargraph::ApiMap.new
=> #<Solargraph::ApiMap:0x000055eeb73bf0a0...
[3] pry(main)> object = api_map.document('String#slice').first
=> #<yardoc method String#slice>
[4] pry(main)> <<-END
[4] pry(main)* <a href="command:solargraph._openDocument?#{CGI.escape "\"solargraph:/document?query=#{object.namespace}\""}">#{object.namespace}</a>
[4] pry(main)* END.strip
=> "<a href=\"command:solargraph._openDocument?%22solargraph%3A%2Fdocument%3Fquery%3DString%22\">String</a>"
```

where we have accidentally escaped the important parts of our link like forward slashes and equals signs, we have results like this

```rb
[5] pry(main)> <<-END.strip
[5] pry(main)* <a href="solargraph:/document?query=#{CGI.escape object.namespace.path}">#{object.namespace}</a>
[5] pry(main)* END
=> "<a href=\"solargraph:/document?query=String\">String</a>"

```

which serve as valid documentation links.