### PR TITLE
replace with_unbundled_env with with_original_env

### DIFF
--- a/lib/solargraph.rb
+++ b/lib/solargraph.rb
@@ -59,8 +59,8 @@ module Solargraph
   #
   # @return [void]
   def self.with_clean_env &block
-    meth = if Bundler.respond_to?(:with_unbundled_env)
-      :with_unbundled_env
+    meth = if Bundler.respond_to?(:with_original_env)
+      :with_original_env
     else
       :with_clean_env
     end


### PR DESCRIPTION
## Narrative 
I'm setting `BUNDLE_PATH` to use inside docker without rebuilding the docker image on each Gemfile change, then when I try to run bin/solargraph bundle inside the docker container it can't find the gems in the custom BUNDLE_PATH.

Similar issue with Spring:
https://github.com/rails/spring/pull/546