### PR TITLE
Honor Rubocop "Exclude" config for diagnostics

### DIFF
--- a/lib/solargraph/diagnostics/rubocop_helpers.rb
+++ b/lib/solargraph/diagnostics/rubocop_helpers.rb
@@ -31,7 +31,7 @@ module Solargraph
       # @param code [String]
       # @return [Array(Array<String>, Array<String>)]
       def generate_options filename, code
-        args = ['-f', 'j', filename]
+        args = ['-f', 'j', '--force-exclusion', filename]
         base_options = RuboCop::Options.new
         options, paths = base_options.parse(args)
         options[:stdin] = code


### PR DESCRIPTION
RuboCop can be configured to ignore certain files with Exclude directives in `.rubocop.yml`

However, passing filename on the command line (which is what Solargraph emulates) overrides this config. Adding the --force-exclusion option to the command tells RuboCop to apply the config anyways.