### PR TITLE
Remove condition for skipping gems

### DIFF
--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -214,7 +214,6 @@ module Solargraph
           if @source_gems.include?(spec.name)
             next
           end
-          next if @gem_paths.key?(spec.name)
           yd = yardoc_file_for_spec(spec)
           # YARD detects gems for certain libraries that do not have a yardoc
           # but exist in the stdlib. `fileutils` is an example. Treat those


### PR DESCRIPTION
@gem_paths is updated below, so this condition may skip gems that are actually searchable.

Currently, solargraph does not include `actionpack` gem yardocs in my test projects because of this condition. Here is the impact of the change in one of my projects:

```bash
# before this change
[3] pry(#<Repl>)> api_map.yard_map.yardocs.size
=> 114

# after this change
[3] pry(#<Repl>)> api_map.yard_map.yardocs.size
=> 126
```