### PR TITLE
YardMap#spec_for_require: Get gem with version from bundle

### DIFF
--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -343,7 +343,9 @@ module Solargraph
     # @param path [String]
     # @return [Gem::Specification]
     def spec_for_require path
-      spec = Gem::Specification.find_by_path(path) || Gem::Specification.find_by_name(path.split('/').first)
+      name = path.split('/').first
+      spec = Gem::Specification.find_by_name(name, @gemset[name])
+
       # Avoid loading the spec again if it's going to be skipped anyway
       return spec if @source_gems.include?(spec.name)
       # Avoid loading the spec again if it's already the correct version


### PR DESCRIPTION
This is another stab at problem described in https://github.com/castwide/solargraph/pull/508. Which basically makes solargraph work better when being run outside bundle (without `bundle exec`)

# Why run solargraph outside bundle anyway?

Legacy projects usually have gems with old gem dependencies. This means that we want to use the latest solargraph version, we can't, because one of its depedencies cannot be satisfied:

```bash
Bundler could not find compatible versions for gem "diff-lcs":
  In snapshot (Gemfile.lock):
    diff-lcs (= 1.3)

  In Gemfile:
    rspec-rails was resolved to 3.5.2, which depends on
      rspec-expectations (~> 3.5.0) was resolved to 3.5.0, which depends on
        diff-lcs (>= 1.2.0, < 2.0)

    solargraph (~> 0.44.2) was resolved to 0.44.2, which depends on
      diff-lcs (~> 1.4)

Running `bundle update` will rebuild your snapshot from scratch, using only
the gems in your Gemfile, which may resolve the conflict.
```

Usually upgrading deps in such projects is a huge undertaking, which often does not justify installing solargraph

# What this fix does?

We already know the version of each gem from the bundle from `YardMap#process_gemsets`. So instead of fetching gem specification using `Gem::Specification.find_by_name(name)` (which, while in bundler will resolve to the only and correct version of the gem), we can fetch it using `Gem::Specification.find_by_name(name, version)`, which resolve to correct gem version even when solargraph runs outside bundle

# Impact

Before fix in a sample project with Rails [annotations](https://gist.github.com/castwide/28b349566a223dfb439a337aea29713e):

```
[10] pry(#<Repl>)> yard_map.yardocs.size
=> 39
[11] pry(#<Repl>)> api_map.pins.select {|p| p.path && p.path.include?("ActionController") }.map(&:path)
=> 6
```

After fix in a sample project

```
[3] pry(#<Repl>)> yard_map.yardocs.size
=> 42
[4] pry(#<Repl>)> api_map.pins.select {|p| p.path && p.path.include?("ActionController") }.map(&:path).size
=> 565
```