### PR TITLE
Completion candidates for union types

### DIFF
--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1424,7 +1424,7 @@ describe Solargraph::SourceMap::Clip do
     expect(names).to eq(['Baz'])
   end
 
-  it 'complete all methods from union types' do
+  it 'completes all methods from union types' do
     source = Solargraph::Source.load_string(%(
       class Thing
         # @return [String, Array]
@@ -1435,10 +1435,10 @@ describe Solargraph::SourceMap::Clip do
     ), 'test.rb')
     api_map = Solargraph::ApiMap.new.map(source)
 
-    string_names = api_map.clip_at('test.rb', [6, 22]).complete.pins.map(&:name)
-    expect(string_names).to eq(["upcase", "upcase!", "upto"])
-
     array_names = api_map.clip_at('test.rb', [5, 22]).complete.pins.map(&:name)
     expect(array_names).to eq(["any?"])
+
+    string_names = api_map.clip_at('test.rb', [6, 22]).complete.pins.map(&:name)
+    expect(string_names).to eq(["upcase", "upcase!", "upto"])
   end
 end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1423,4 +1423,22 @@ describe Solargraph::SourceMap::Clip do
     names = api_map.clip_at('test.rb', [6, 17]).complete.pins.map(&:name)
     expect(names).to eq(['Baz'])
   end
+
+  it 'complete all methods from union types' do
+    source = Solargraph::Source.load_string(%(
+      class Thing
+        # @return [String, Array]
+        def foo; end
+      end
+      Thing.new.foo.an
+      Thing.new.foo.up
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+
+    string_names = api_map.clip_at('test.rb', [6, 22]).complete.pins.map(&:name)
+    expect(string_names).to eq(["upcase", "upcase!", "upto"])
+
+    array_names = api_map.clip_at('test.rb', [5, 22]).complete.pins.map(&:name)
+    expect(array_names).to eq(["any?"])
+  end
 end


### PR DESCRIPTION
Ref #507 

`ApiMap#get_complex_type_methods` collects a union of methods for complex types, e.g., `[String, Array]` returns both `String` and `Array` methods.