### PR TITLE
TypeChecker allow Hash as argument

### DIFF
--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -418,6 +418,7 @@ module Solargraph
         # Functions tagged param_tuple accepts two arguments (e.g., Hash#[]=)
         return [] if pin.docstring.tag(:param_tuple) && arguments.length == 2
         return [] if arguments.length == 1 && arguments.last.links.last.is_a?(Source::Chain::BlockVariable)
+        return [] if arguments.length == 2 && arguments.last.links.last.is_a?(Source::Chain::Hash)
         return [Problem.new(location, "Too many arguments to #{pin.path}")]
       end
       unchecked = arguments.clone


### PR DESCRIPTION
Typechecker complains if second argument is a Hash.
```rb
# Too many arguments to Hash#store
{}.store("key", {foo: "bar"})
```

Not sure if this is correct in context, but I hope it highlights the issue.