### PR TITLE
Fix query_symbols changed to exact match

### DIFF
--- a/lib/solargraph/source_map.rb
+++ b/lib/solargraph/source_map.rb
@@ -77,7 +77,8 @@ module Solargraph
     # @return [Array<Pin::Base>]
     def query_symbols query
       return document_symbols if query && query.empty?
-      document_symbols.select{ |pin| fuzzy_string_match(pin.path, query) || fuzzy_string_match(pin.name, query) }
+      document_symbols.select{ |pin| pin.name == query }
+      #document_symbols.select{ |pin| fuzzy_string_match(pin.path, query) || fuzzy_string_match(pin.name, query) }
     end
 
     # @param position [Position]


### PR DESCRIPTION
I could not find anything about the lsp spec suggesting to use fuzzy matching for this function. Opening this PR to discuss original intent.

Currently it breaks jumping to function in vim with `:tag` which is mapped to `workspace/symbol` in solargraph-lsp since all substring matches are also considered before the exact match. This is how it works in `gopls` as well.

Original issue: #44 