### PR TITLE
Differentiate between missing yard docs and gem not being found

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -21,6 +21,9 @@ module Solargraph
     # @return [Array<String>]
     attr_reader :unresolved_requires
 
+    # @return [Array<String>]
+    attr_reader :missing_docs
+
     # @param pins [Array<Solargraph::Pin::Base>]
     def initialize pins: []
       @source_map_hash = {}
@@ -68,6 +71,7 @@ module Solargraph
       yard_map.change(external_requires, bench.workspace.directory, bench.workspace.source_gems)
       @store = Store.new(yard_map.pins + implicit.pins + pins)
       @unresolved_requires = yard_map.unresolved_requires
+      @missing_docs = yard_map.missing_docs
       @rebindable_method_names = nil
       store.block_pins.each { |blk| blk.rebind(self) }
       self

--- a/lib/solargraph/diagnostics/require_not_found.rb
+++ b/lib/solargraph/diagnostics/require_not_found.rb
@@ -12,6 +12,10 @@ module Solargraph
         refs = {}
         map = api_map.source_map(source.filename)
         map.requires.each { |ref| refs[ref.name] = ref }
+        api_map.missing_docs.each do |r|
+          next unless refs.key?(r)
+          result.push docs_error(r, refs[r].location)
+        end
         api_map.unresolved_requires.each do |r|
           next unless refs.key?(r)
           result.push require_error(r, refs[r].location)
@@ -20,6 +24,18 @@ module Solargraph
       end
 
       private
+
+      # @param path [String]
+      # @param location [Location]
+      # @return [Hash]
+      def docs_error path, location
+        {
+          range: location.range.to_hash,
+          severity: Diagnostics::Severities::WARNING,
+          source: 'RequireNotFound',
+          message: "Yard docs missing for #{path}"
+        }
+      end
 
       # @param path [String]
       # @param location [Location]

--- a/spec/yard_map_spec.rb
+++ b/spec/yard_map_spec.rb
@@ -43,6 +43,12 @@ describe Solargraph::YardMap do
     expect(yard_map.unresolved_requires).not_to include('set')
   end
 
+  it "tracks missing documentation" do
+    yard_map = Solargraph::YardMap.new(required: ['set', 'not_valid'])
+    expect(yard_map.requires_missing_documentation).to include('not_valid')
+    expect(yard_map.requires_missing_documentation).not_to include('set')
+  end
+
   it "ignores duplicate requires" do
     # Assuming the parser gem exists because it's a Solargraph dependency
     yard_map = Solargraph::YardMap.new(required: ['parser', 'parser'])


### PR DESCRIPTION
I was debugging an issue where I was getting a `Required path <gem> could not be resolved`. Turns out I was missing the yard documentation. I have seen similar issues and I imagine it's quite common to receive this error.

While both are errors, missing a gem or not having the documentation are two different issues. I think this would be helpful to narrow down the possible issues on why is a gem not being found.

I don't know the codebase, so I preferred to open this early rather than spending a lot of time with it. Let me know if this would be acceptable or possible things to watch out and I can implement it, add specs, add the message you prefer etc.

Here's how it looks like for me:

![Screenshot 2022-07-01 at 08 20 12](https://user-images.githubusercontent.com/3609616/176836133-86359564-59fa-4553-84ad-ee771c31fa06.png)


