### PR TITLE
added failing (and passing?) tests

### DIFF
--- a/spec/language_server/message/text_document/rename_spec.rb
+++ b/spec/language_server/message/text_document/rename_spec.rb
@@ -24,4 +24,92 @@ describe Solargraph::LanguageServer::Message::TextDocument::Rename do
     rename.process
     expect(rename.result[:changes]['file:///file.rb'].length).to eq(2)
   end
+
+  it "renames an argument symbol from method signature" do
+    host = Solargraph::LanguageServer::Host.new
+    host.start
+    host.open('file:///file.rb', %(
+      class Example
+      def foo(bar)
+      bar += 1
+      return bar
+      end
+    	end
+    	), 1)
+    	rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
+      'id' => 1,
+      'method' => 'textDocument/rename',
+      'params' => {
+        'textDocument' => {
+          'uri' => 'file:///file.rb'
+        },
+        'position' => {
+          'line' => 2,
+          'character' => 14
+        },
+        'newName' => 'baz'
+      }
+    })
+    rename.process
+    expect(rename.result[:changes]['file:///file.rb'].length).to eq(3)
+  end
+
+  it "renames an argument symbol from method body" do
+    host = Solargraph::LanguageServer::Host.new
+    host.start
+    host.open('file:///file.rb', %(
+      class Example
+      def foo(bar)
+      bar += 1
+      return bar
+      end
+    	end
+    	), 1)
+    	rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
+      'id' => 1,
+      'method' => 'textDocument/rename',
+      'params' => {
+        'textDocument' => {
+          'uri' => 'file:///file.rb'
+        },
+        'position' => {
+          'line' => 3,
+          'character' => 6
+        },
+        'newName' => 'baz'
+      }
+    })
+    rename.process
+    expect(rename.result[:changes]['file:///file.rb'].length).to eq(3)
+  end
+
+  it "renames namespace symbol with proper range" do
+    host = Solargraph::LanguageServer::Host.new
+    host.start
+    host.open('file:///file.rb', %(
+      module Namespace; end
+      class Namespace::ExampleClass
+      end
+      obj = Namespace::ExampleClass.new
+    	), 1)
+    	rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
+      'id' => 1,
+      'method' => 'textDocument/rename',
+      'params' => {
+        'textDocument' => {
+          'uri' => 'file:///file.rb'
+        },
+        'position' => {
+          'line' => 2,
+          'character' => 12
+        },
+        'newName' => 'Nameplace'
+      }
+    })
+    rename.process
+    changes = rename.result[:changes]['file:///file.rb']
+    expect(changes.length).to eq(3)
+    expect(changes.first[:range][:start][:character]).to eq(13)
+    expect(changes.first[:range][:end][:character]).to eq(22)
+  end
 end


### PR DESCRIPTION
Hello, I've been following along with a couple old issues some have reported, and that I have personally experienced with renaming.

The respective issues I think are related are #135 and #107.

I am not familiar with language server protocol, but was able to add a few tests that correlate with the renaming bug that I and others have had in our respective editors. The first 2 tests are related to comments at the bottom of #135, and the extra element in `rename.result[:changes]['file:///file.rb']` I believe is the 'overlapping ranges error'. Both of those tests are currently failing.

The final test at the bottom is for #107, but seems to be passing, so it's just an added test at this point.

If time permits, I'll come back soon and figure out how to get these tests to pass, but wanted to post the PR in case it sparks an idea for anyone more familiar with LSP.