### PR TITLE
make rubocop info severity Severity::HINT

### DIFF
--- a/lib/solargraph/diagnostics/rubocop.rb
+++ b/lib/solargraph/diagnostics/rubocop.rb
@@ -11,6 +11,7 @@ module Solargraph
 
       # Conversion of RuboCop severity names to LSP constants
       SEVERITIES = {
+        'info' => Severities::HINT,
         'refactor' => Severities::HINT,
         'convention' => Severities::INFORMATION,
         'warning' => Severities::WARNING,


### PR DESCRIPTION
At the moment, solargraph doesn't handle rubocop's "info" severity level. As a result, if you specify that a rubocop rule has the "info" severity level, it will default to the highest severity level. In a code editor like vscode, you'll get a red underline.

For example, in my project, I changed rubocop's line length rule to have the "info" severity level. Long lines then get a red underline:

<img width="690" alt="Screen Shot 2022-08-09 at 9 24 12 PM" src="https://user-images.githubusercontent.com/2966419/183815458-33419148-88d0-4222-a143-1250ff20184c.png">

