### PR TITLE
Process non-self singleton classes

### DIFF
--- a/lib/solargraph/parser/rubyvm/node_processors/sclass_node.rb
+++ b/lib/solargraph/parser/rubyvm/node_processors/sclass_node.rb
@@ -6,11 +6,22 @@ module Solargraph
       module NodeProcessors
         class SclassNode < Parser::NodeProcessor::Base
           def process
-            # @todo Temporarily skipping remote metaclasses
-            return unless node.children[0].is_a?(RubyVM::AbstractSyntaxTree::Node) && node.children[0].type == :SELF
+            sclass = node.children[0]
+            if sclass.is_a?(RubyVM::AbstractSyntaxTree::Node) && sclass.type == :SELF
+              closure = region.closure
+            elsif sclass.is_a?(RubyVM::AbstractSyntaxTree::Node) && %i[CDECL CONST].include?(sclass.type)
+              names = [region.closure.namespace, region.closure.name]
+              if names.last != sclass.children[0].to_s
+                names << sclass.children[0].to_s
+              end
+              name = names.reject(&:empty?).join('::')
+              closure = Solargraph::Pin::Namespace.new(name: name, location: region.closure.location)
+            else
+              return
+            end
             pins.push Solargraph::Pin::Singleton.new(
               location: get_node_location(node),
-              closure: region.closure
+              closure: closure
             )
             process_children region.update(visibility: :public, scope: :class, closure: pins.last)
           end

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -658,6 +658,44 @@ describe Solargraph::ApiMap do
     expect(pins.map(&:name)).to include('foo')
   end
 
+  it 'finds class methods in class << Example' do
+    source = Solargraph::Source.load_string(%(
+      class << Example = Class.new
+        def foo; end
+      end
+      class Example
+        class << Example
+          def bar; end
+        end
+      end
+    ))
+    @api_map.map source
+    pins = @api_map.get_methods('Example', scope: :class).select do |pin|
+      pin.namespace == 'Example'
+    end
+    expect(pins.map(&:name).sort).to eq(['bar', 'foo'])
+  end
+
+  it 'finds class methods in nested class << Example' do
+    source = Solargraph::Source.load_string(%(
+      module Container
+        class << Example = Class.new
+          def foo; end
+        end
+        class Example
+          class << Example
+            def bar; end
+          end
+        end
+      end
+    ))
+    @api_map.map source
+    pins = @api_map.get_methods('Container::Example', scope: :class).select do |pin|
+      pin.namespace == 'Container::Example'
+    end
+    expect(pins.map(&:name).sort).to eq(['bar', 'foo'])
+  end
+
   it 'resolves aliases for YARD methods' do
     dir = File.absolute_path(File.join('spec', 'fixtures', 'yard_map'))
     yard_pins = Dir.chdir dir do


### PR DESCRIPTION
To avoid deep indentation while still using `private` and skipping `def self.`, I sometimes declare a class and define singleton methods on it with `class << Example = Class.new`. I'd like Solargraph to process its children.

```rb
class << Example = Class.new
  def foo
    bar
  end

  private

  def bar
    "example"
  end
end
```

The current `SclassNodes` [supports only `class << self`](https://github.com/castwide/solargraph/commit/b0852417a1d9f8d44e4ad8db05b0465325b5b66c), so I extended it to handle the above `CDECL` case as well as `CONST` case, .e.g. `class << Example`.