### PR TITLE
Update YARD tags on Pin::Block methods

### DIFF
--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -8,6 +8,7 @@ module Solargraph
       # @return [Parser::AST::Node]
       attr_reader :receiver
 
+      # @param args [Array<Parameter>]
       def initialize receiver: nil, args: [], context: nil, **splat
         super(**splat)
         @receiver = receiver
@@ -25,7 +26,7 @@ module Solargraph
         @binder || closure.binder
       end
 
-      # @return [Array<String>]
+      # @return [Array<Parameter>]
       def parameters
         @parameters ||= []
       end


### PR DESCRIPTION
I was debugging and noticed that these tags are inaccurate. The `@parameters` array in a `Pin::Block` contains `Pin::Parameter` instances.