### PR TITLE
Handle rest/kwrest modifiers on overload arguments

### DIFF
--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -124,13 +124,14 @@ module Solargraph
             closure: self,
             # args: tag.parameters.map(&:first),
             parameters: tag.parameters.map do |src|
+              name, decl = parse_overload_param(src.first)
               Pin::Parameter.new(
                 location: location,
                 closure: self,
                 comments: tag.docstring.all.to_s,
-                name: src.first,
+                name: name,
                 presence: location ? location.range : nil,
-                decl: :arg
+                decl: decl
               )
             end,
             comments: tag.docstring.all.to_s
@@ -240,6 +241,21 @@ module Solargraph
         return ComplexType::UNDEFINED if types.empty?
         ComplexType.try_parse(*types.map(&:tag).uniq)
       end
+
+      # When YARD parses an overload tag, it includes rest modifiers in the parameters names.
+      #
+      # @param arg [String]
+      # @return [Array(String, Symbol)]
+      def parse_overload_param(name)
+        if name.start_with?('**')
+          [name[2..], :kwrestarg]
+        elsif name.start_with?('*')
+          [name[1..], :restarg]
+        else
+          [name, :arg]
+        end
+      end
+
     end
   end
 end

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -177,6 +177,18 @@ describe Solargraph::Pin::Method do
     expect(overload.docstring.tag(:param).types).to eq(['Integer'])
   end
 
+  it 'processes overload tags with restargs' do
+    pin = Solargraph::Pin::Method.new(name: 'foo', comments: %<
+@overload foo(*bar)
+@overload foo(**bar)
+    >)
+    expect(pin.overloads.length).to eq(2)
+    restarg_overload = pin.overloads.first
+    kwrestarg_overload = pin.overloads.last
+    expect(restarg_overload.parameters.first.decl).to eq(:restarg)
+    expect(kwrestarg_overload.parameters.first.decl).to eq(:kwrestarg)
+  end
+
   it 'infers from nil return nodes' do
     source = Solargraph::Source.load_string(%(
       class Foo


### PR DESCRIPTION
I stumbled on this while working on solargraph-rails.

I am generating method pins with `@overload` annotations in their comments that look like this:

```rb
class Post::ActiveRecord_Relation
  # @overload where()
  #   @ return [ActiveRecord::QueryMethods::WhereChain<self>]
  # @overload where(sql, *args)
  #   @param sql [String]
  #   @param args
  #   @return [self]
  # @overload where(hash)
  #   @return [self]
  def where; end
end
```

However, the typecheck reporter was showing "too many arguments to #where" problems on method calls like `Post.all.where("foo > ?", 3)`.

It turns out the cause was the `Parameter` pin for args not having the correct `:decl` passed in here.
