### PR TITLE
Add Pin::DelegatedMethod

### DIFF
--- a/lib/solargraph/pin.rb
+++ b/lib/solargraph/pin.rb
@@ -12,6 +12,7 @@ module Solargraph
     autoload :Method,           'solargraph/pin/method'
     autoload :Signature,        'solargraph/pin/signature'
     autoload :MethodAlias,      'solargraph/pin/method_alias'
+    autoload :DelegatedMethod,  'solargraph/pin/delegated_method'
     autoload :BaseVariable,     'solargraph/pin/base_variable'
     autoload :InstanceVariable, 'solargraph/pin/instance_variable'
     autoload :ClassVariable,    'solargraph/pin/class_variable'

--- a/lib/solargraph/pin/delegated_method.rb
+++ b/lib/solargraph/pin/delegated_method.rb
@@ -1,0 +1,92 @@
+# frozen_string_literal: true
+
+module Solargraph
+  module Pin
+    # A DelegatedMethod is a more complicated version of a MethodAlias that
+    # allows aliasing a method from a different closure (class/module etc).
+    class DelegatedMethod < Pin::Method
+      # A DelegatedMethod can be constructed with either a :resolved_method
+      # pin, or a :receiver_chain. When a :receiver_chain is supplied, it
+      # will be used to *dynamically* resolve a receiver type within the
+      # given closure/scope, and the delegated method will then be resolved
+      # to a method pin on that type.
+      #
+      # @param resolved_method [Method] an already resolved method pin.
+      # @param receiver [Source::Chain] the source code used to resolve the receiver for this delegated method.
+      # @param receiver_method_name [String] the method name that will be called on the receiver (defaults to :name).
+      def initialize(method: nil, receiver: nil, name: method&.name, receiver_method_name: name, **splat)
+        raise ArgumentError, 'either :method or :receiver is required' if (method && receiver) || (!method && !receiver)
+        super(name: name, **splat)
+
+        @receiver_chain = receiver
+        @resolved_method = method
+        @receiver_method_name = receiver_method_name
+      end
+
+      %i[comments parameters return_type location].each do |method|
+        define_method(method) do
+          @resolved_method ? @resolved_method.send(method) : super()
+        end
+      end
+
+      %i[typify realize infer probe].each do |method|
+        # @param api_map [ApiMap]
+        define_method(method) do |api_map|
+          resolve_method(api_map)
+          @resolved_method ? @resolved_method.send(method, api_map) : super(api_map)
+        end
+      end
+
+      private
+
+      # Resolves the receiver chain and method name to a method pin, resetting any previously resolution.
+      #
+      # @param api_map [ApiMap]
+      # @return [Pin::Method, nil]
+      def resolve_method api_map
+        return if @resolved_method
+
+        resolver = @receiver_chain.define(api_map, self, []).first
+
+        unless resolver
+          Solargraph.logger.warn \
+            "Delegated receiver for #{path} was resolved to nil from `#{print_chain(@receiver_chain)}'"
+          return
+        end
+
+        receiver_type = resolver.return_type
+
+        return if receiver_type.undefined?
+
+        receiver_path, method_scope =
+          if @receiver_chain.constant?
+            # HACK: the `return_type` of a constant is Class<Whatever>, but looking up a method expects
+            # the arguments `"Whatever"` and `scope: :class`.
+            [receiver_type.to_s.sub(/^Class<(.+)>$/, '\1'), :class]
+          else
+            [receiver_type.to_s, :instance]
+          end
+
+        method_stack = api_map.get_method_stack(receiver_path, @receiver_method_name, scope: method_scope)
+        @resolved_method = method_stack.first
+      end
+
+      # helper to print a source chain as code, probably not 100% correct.
+      #
+      # @param chain [Source::Chain]
+      def print_chain(chain)
+        out = +''
+        chain.links.each_with_index do |link, index|
+          if index > 0
+            if Source::Chain::Constant
+              out << '::' unless link.word.start_with?('::')
+            else
+              out << '.'
+            end
+          end
+          out << link.word
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/pin/delegated_method.rb
+++ b/lib/solargraph/pin/delegated_method.rb
@@ -37,6 +37,11 @@ module Solargraph
         end
       end
 
+      def resolvable?(api_map)
+        resolve_method(api_map)
+        !!@resolved_method
+      end
+
       private
 
       # Resolves the receiver chain and method name to a method pin, resetting any previously resolution.

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -259,7 +259,10 @@ module Solargraph
       base = chain
       until base.links.length == 1 && base.undefined?
         pins = base.define(api_map, block_pin, locals)
-        if pins.first.is_a?(Pin::Method)
+
+        if pins.first.is_a?(Pin::DelegatedMethod) && !pins.first.resolvable?(api_map)
+          # Do nothing, as we can't find the actual method implementation
+        elsif pins.first.is_a?(Pin::Method)
           # @type [Pin::Method]
           pin = pins.first
           ap = if base.links.last.is_a?(Solargraph::Source::Chain::ZSuper)

--- a/spec/pin/delegated_method_spec.rb
+++ b/spec/pin/delegated_method_spec.rb
@@ -1,0 +1,40 @@
+require 'pry'
+
+describe Solargraph::Pin::DelegatedMethod do
+  it 'can be constructed from a Method pin' do
+    method_pin = Solargraph::Pin::Method.new(comments: '@return [Hash<String, String>]')
+
+    delegation_pin = Solargraph::Pin::DelegatedMethod.new(method: method_pin, scope: :instance)
+    expect(delegation_pin.return_type.to_s).to eq('Hash<String, String>')
+  end
+
+  it 'can be constructed from a receiver source and method name' do
+    api_map = Solargraph::ApiMap.new
+    source = Solargraph::Source.load_string(%(
+      class Class1
+        # @return [String]
+        def name; end
+      end
+
+      class Class2
+        # @return [Class1]
+        def collaborator; end
+      end
+    ))
+    api_map.map source
+
+    class2 = api_map.get_path_pins('Class2').first
+
+    chain = Solargraph::Source::Chain.new([Solargraph::Source::Chain::Call.new('collaborator')])
+    pin = Solargraph::Pin::DelegatedMethod.new(
+      closure: class2,
+      scope: :instance,
+      name: 'name',
+      receiver: chain
+    )
+
+    pin.probe(api_map)
+
+    expect(pin.return_type.to_s).to eq('String')
+  end
+end


### PR DESCRIPTION
This is a more complicated version of a method alias, where the type of the method receiver can be resolved dynamically using a Source::Chain.

The idea didn't get much of a response in #591, but I really wanted to implement proper support for the `Module.delegate` method from ActiveSupport. You can see how it's used in my solargraph-rails work [here](https://github.com/grncdr/solargraph-rails/commit/f53fe4889fb50fb7da4be6811b6a73e021a8ad23).

I'd really like to get this merged, and I'm happy to add specs for it, but I want to get feedback on the implementation, as it's a pretty "unusual" pin type.