### PR TITLE
fix: offset error for unicode

### DIFF
--- a/lib/solargraph/language_server/message/initialize.rb
+++ b/lib/solargraph/language_server/message/initialize.rb
@@ -25,6 +25,8 @@ module Solargraph
               }
             }
           }
+          # FIXME: lsp default is utf-16, may have different position
+          result[:capabilities][:positionEncoding] = "utf-32" if params.dig("capabilities", "general", "positionEncodings")&.include?("utf-32")
           result[:capabilities].merge! static_completion unless dynamic_registration_for?('textDocument', 'completion')
           result[:capabilities].merge! static_signature_help unless dynamic_registration_for?('textDocument', 'signatureHelp')
           # result[:capabilities].merge! static_on_type_formatting unless dynamic_registration_for?('textDocument', 'onTypeFormatting')

--- a/lib/solargraph/parser/rubyvm/class_methods.rb
+++ b/lib/solargraph/parser/rubyvm/class_methods.rb
@@ -1,4 +1,5 @@
 require 'solargraph/parser/rubyvm/node_processors'
+require 'solargraph/parser/rubyvm/node_wrapper'
 
 module Solargraph
   module Parser
@@ -7,8 +8,10 @@ module Solargraph
         # @param code [String]
         # @param filename [String]
         # @return [Array(Parser::AST::Node, Array<Parser::Source::Comment>)]
+        # @sg-ignore
         def parse_with_comments code, filename = nil
           node = RubyVM::AbstractSyntaxTree.parse(code).children[2]
+          node &&= RubyVM::AbstractSyntaxTree::NodeWrapper.from(node, code.lines)
           comments = CommentRipper.new(code).parse
           [node, comments]
         rescue ::SyntaxError => e
@@ -19,8 +22,10 @@ module Solargraph
         # @param filename [String, nil]
         # @param line [Integer]
         # @return [Parser::AST::Node]
+        # @sg-ignore
         def parse code, filename = nil, line = 0
-          RubyVM::AbstractSyntaxTree.parse(code).children[2]
+          node = RubyVM::AbstractSyntaxTree.parse(code).children[2]
+          node and RubyVM::AbstractSyntaxTree::NodeWrapper.from(node, code.lines)
         rescue ::SyntaxError => e
           raise Parser::SyntaxError, e.message
         end

--- a/lib/solargraph/parser/rubyvm/node_wrapper.rb
+++ b/lib/solargraph/parser/rubyvm/node_wrapper.rb
@@ -1,0 +1,47 @@
+require 'delegate'
+
+module RubyVM::AbstractSyntaxTree
+  # Wrapper for RubyVM::AbstractSyntaxTree::Node. for return character based column
+  class NodeWrapper < SimpleDelegator
+    attr_reader :code
+    # @param node [RubyVM::AbstractSyntaxTree::Node] wrapped node to return character based column
+    # @param code [Array<String>] source code lines for generated this node
+    def initialize(node, code)
+      @code = code
+      super(node)
+    end
+
+    def self.from(node, code)
+      return node unless node.is_a?(RubyVM::AbstractSyntaxTree::Node) and !node.kind_of?(SimpleDelegator)
+
+      new(node, code)
+    end
+
+    def is_a?(type)
+      __getobj__.is_a?(type) || super.is_a?(type)
+    end
+
+    def class
+      __getobj__.class
+    end
+
+
+    def first_column
+      @first_column ||= begin
+        line = @code[__getobj__.first_lineno - 1] || ""
+        line.byteslice(0, __getobj__.first_column).length
+      end
+    end
+
+    def last_column
+      @last_column ||= begin
+        line = @code[__getobj__.last_lineno - 1] || ""
+        line.byteslice(0, __getobj__.last_column).length
+      end
+    end
+
+    def children
+      @children ||= __getobj__.children.map do |node| NodeWrapper.from(node, @code) end
+    end
+  end
+end

--- a/spec/parser/rubyvm_spec.rb
+++ b/spec/parser/rubyvm_spec.rb
@@ -1,0 +1,8 @@
+if defined?(RubyVM::AbstractSyntaxTree)
+  describe RubyVM::AbstractSyntaxTree do
+    it "parses node by byteoffset" do
+      node = RubyVM::AbstractSyntaxTree.parse("𐐀 + 𐐀").children[2]
+      expect(node.last_column).to eq(11)
+    end
+  end
+end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -114,9 +114,9 @@ describe Solargraph::Source do
         def bar=
         end
       end
-      foo = Foo.new
-      foo.bar
-      foo.bar = 1
+      𐐀 = Foo.new # unicode name to test offset
+      𐐀.bar
+      𐐀.bar = 1
     ))
     foos = source.references('Foo')
     foobacks = foos.map{|f| source.at(f.range)}


### PR DESCRIPTION
Character have different length in different standards, and will affect how offset calculated

for example, for a string "𐐀":

`String#length` returns 1 (utf32 character length, no matter which encoding used) `RubyVM::AbstractSyntaxTree.parse("𐐀").children[2].last_column` return 4 (utf8 bytes size)
[LSP Spec](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments) default use utf16, which length is 2. ( 4 bytes size)

if the standard does not match, offset will be wrong and get wrong result.

Fortunately, most char utf16 and utf32 char lengths are the same, and rarely cause problems. but In the unicode environment, the byte length and character length are generally different, and will report error

Because Ruby String handle char instead of bytes. so the offset all should be char length based

Since AbstractSyntaxTree::Node is passed to many place and hard to control, the simplest repair is to wrap it when create and return a character based column

this should fixes #539 and maybe other unicode related offset errors

if LSP client support UTF32, notify it use utf-32 position [capabilities.positionEncoding](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#serverCapabilities), then all position should be same.
But same client may be only support default utf-16 position...