### PR TITLE
Update LICENSE file date to be 2023

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2017-2019 by Fred Snyder for Castwide Technologies
+Copyright (c) 2017-2023 by Fred Snyder for Castwide Technologies
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
This is in a similar vein to https://github.com/castwide/solargraph/pull/154, in that we are just updating the LICENSE file date. This just updates it to be 2023 since it was last updated in 2019, and I imagine we would want to update it to this year's date.

Happy to adjust if there are any concerns r.e this.