### PR TITLE
Define `e` in `JSON::ParserError` rescue block

### DIFF
--- a/lib/solargraph/diagnostics/rubocop.rb
+++ b/lib/solargraph/diagnostics/rubocop.rb
@@ -32,7 +32,7 @@ module Solargraph
         make_array JSON.parse(result)
       rescue RuboCop::ValidationError, RuboCop::ConfigNotFoundError => e
         raise DiagnosticsError, "Error in RuboCop configuration: #{e.message}"
-      rescue JSON::ParserError
+      rescue JSON::ParserError => e
         raise DiagnosticsError, "RuboCop returned invalid data: #{e.message}"
       end
 


### PR DESCRIPTION
The `JSON::ParserError` rescue statement in the Rubocop `diagnose` method does not pass the exception to the block, but the block calls `e.message` which causes the server to crash with an `rescue in 'diagnose': undefined method 'message' for nil:NilClass (NoMethodError)` error. This PR simply passes `e` to the block.