### PR TITLE
Fix for when rubocop diagnostics returns empty string

### DIFF
--- a/lib/solargraph/diagnostics/rubocop.rb
+++ b/lib/solargraph/diagnostics/rubocop.rb
@@ -29,6 +29,9 @@ module Solargraph
         store = RuboCop::ConfigStore.new
         runner = RuboCop::Runner.new(options, store)
         result = redirect_stdout{ runner.run(paths) }
+        
+        return [] if result.empty?
+        
         make_array JSON.parse(result)
       rescue RuboCop::ValidationError, RuboCop::ConfigNotFoundError => e
         raise DiagnosticsError, "Error in RuboCop configuration: #{e.message}"


### PR DESCRIPTION
I have been getting the following issue with rubocop diagnostics, the result of which is that diagnostics stop updating in my editor. Here are the logs.

Running via neovim in ruby 3.1.3

```
[ERROR][2023-02-16 10:46:38] .../vim/lsp/rpc.lua:734	"rpc"	"bin/bundle"	"stderr"
#<Thread:0x000000010a49f420 solargraph-0.48.0/lib/solargraph/language_server/host/diagnoser.rb:45 run> terminated with exception (report_on_exception is true):\n"
```

```
[ERROR][2023-02-16 10:46:38] .../vim/lsp/rpc.lua:734	"rpc"	"bin/bundle"	"stderr"
"solargraph-0.48.0/lib/solargraph/diagnostics/rubocop.rb:35:in `rescue in diagnose': undefined method `message' for nil:NilClass (NoMethodError)
raise DiagnosticsError, \"RuboCop returned invalid data: #{e.message}\"
                                                           ^^^^^^^^

from solargraph-0.48.0/lib/solargraph/diagnostics/rubocop.rb:25:in `diagnose'
from solargraph-0.48.0/lib/solargraph/library.rb:363:in `block in diagnose'
from solargraph-0.48.0/lib/solargraph/library.rb:362:in `each_pair'
from solargraph-0.48.0/lib/solargraph/library.rb:362:in `diagnose'
from solargraph-0.48.0/lib/solargraph/language_server/host.rb:211:in `diagnose'\n"
```

```
[ERROR][2023-02-16 10:46:38] .../vim/lsp/rpc.lua:734	"rpc"	"bin/bundle"	"stderr"
from solargraph-0.48.0/lib/solargraph/language_server/host/diagnoser.rb:66:in `tick'
from solargraph-0.48.0/lib/solargraph/language_server/host/diagnoser.rb:47:in `block in start'
>>>> json-2.6.3/lib/json/common.rb:216:in `parse': unexpected token at '' (JSON::ParserError)
from json-2.6.3/lib/json/common.rb:216:in `parse'
from solargraph-0.48.0/lib/solargraph/diagnostics/rubocop.rb:31:in `diagnose'
from solargraph-0.48.0/lib/solargraph/library.rb:363:in `block in diagnose'
from solargraph-0.48.0/lib/solargraph/library.rb:362:in `each_pair'
from solargraph-0.48.0/lib/solargraph/library.rb:362:in `diagnose'
from solargraph-0.48.0/lib/solargraph/language_server/host.rb:211:in `diagnose'
from solargraph-0.48.0/lib/solargraph/language_server/host/diagnoser.rb:66:in `tick'
from solargraph-0.48.0/lib/solargraph/language_server/host/diagnoser.rb:47:in `block in start'
```

