### PR TITLE
Configure FUNDING

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,1 @@
+patreon: castwide

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -16,6 +16,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://solargraph.org'
   s.license     = 'MIT'
   s.executables = ['solargraph']
+  s.metadata["funding_uri"] = "https://www.patreon.com/castwide"
 
   s.required_ruby_version = '>= 2.6'
 


### PR DESCRIPTION
GitHub and Bundler now support funding urls for open-source projects. The project patreon is listed on the website, but not configured for GitHub or Bundler. This PR adds the necessary configuration to display the correct funding messaging on both platforms.

Note: You will need to enable funding links under "Sponsorships" in the settings here. https://github.com/castwide/solargraph/settings