### PR TITLE
Batch processing of changed files for improved performance

### DIFF
--- a/lib/solargraph/language_server/message/workspace/did_change_watched_files.rb
+++ b/lib/solargraph/language_server/message/workspace/did_change_watched_files.rb
@@ -10,22 +10,29 @@ module Solargraph::LanguageServer::Message::Workspace
 
     def process
       need_catalog = false
+      to_create = []
+      to_delete = []
+
       # @param change [Hash]
       params['changes'].each do |change|
         if change['type'] == CREATED
-          host.create change['uri']
+          to_create << change['uri']
           need_catalog = true
         elsif change['type'] == CHANGED
           next if host.open?(change['uri'])
-          host.create change['uri']
+          to_create << change['uri']
           need_catalog = true
         elsif change['type'] == DELETED
-          host.delete change['uri']
+          to_delete << change['uri']
           need_catalog = true
         else
           set_error Solargraph::LanguageServer::ErrorCodes::INVALID_PARAMS, "Unknown change type ##{change['type']} for #{uri_to_file(change['uri'])}"
         end
       end
+
+      host.create *to_create
+      host.delete *to_delete
+
       # Force host to catalog libraries after file changes (see castwide/solargraph#139)
       host.catalog if need_catalog
     end

--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -46,24 +46,21 @@ module Solargraph
     #
     # @param source [Solargraph::Source]
     # @return [Boolean] True if the source was added to the workspace
-    def merge source
-      unless directory == '*' || source_hash.key?(source.filename)
+    def merge *sources
+      unless directory == '*' || sources.all? { |source| source_hash.key?(source.filename) }
         # Reload the config to determine if a new source should be included
         @config = Solargraph::Workspace::Config.new(directory)
-        return false unless config.calculated.include?(source.filename)
       end
-      source_hash[source.filename] = source
-      true
-    end
 
-    # Determine whether a file would be merged into the workspace.
-    #
-    # @param filename [String]
-    # @return [Boolean]
-    def would_merge? filename
-      return true if directory == '*' || source_hash.include?(filename)
-      @config = Solargraph::Workspace::Config.new(directory)
-      config.calculated.include?(filename)
+      includes_any = false
+      sources.each do |source|
+        if directory == "*" || config.calculated.include?(source.filename)
+          source_hash[source.filename] = source
+          includes_any = true
+        end
+      end
+
+      includes_any
     end
 
     # Remove a source from the workspace. The source will not be removed if

--- a/spec/language_server/message/workspace/did_change_watched_files_spec.rb
+++ b/spec/language_server/message/workspace/did_change_watched_files_spec.rb
@@ -82,6 +82,8 @@ describe Solargraph::LanguageServer::Message::Workspace::DidChangeWatchedFiles d
 
   it 'sets errors for invalid change types' do
     host = double(Solargraph::LanguageServer::Host, catalog: nil)
+    allow(host).to receive(:create)
+    allow(host).to receive(:delete)
     changed = Solargraph::LanguageServer::Message::Workspace::DidChangeWatchedFiles.new(host, {
       'method' => 'workspace/didChangeWatchedFiles',
       'params' => {


### PR DESCRIPTION
When multiple files change on disk (eg after a git branch change),
solargraph does a re-index operation for each change, because the
changes are processed individually. Indexing is a slow operation that
can take 10s of seconds on a very large codebase. These codebases are
also likely to have 10s or even 100s of changed files when checking out
a different git branch. This led to solargraph being very slow.

We can instead process all of the changed files in one go, requiring
only a single re-index.

This change also removes the `would_merge?` method, which is
unnecessary and redundant with `merge`, which already checks if a source
should be included.
