### PR TITLE
Fix empty string case when processing requires

### DIFF
--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -220,7 +220,7 @@ module Solargraph
       result = []
       begin
         name = r.split('/').first
-        return [] if @source_gems.include?(name) || @gem_paths.key?(name)
+        return [] if name.empty? || @source_gems.include?(name) || @gem_paths.key?(name)
         spec = spec_for_require(name)
         @gem_paths[name] = spec.full_gem_path
 


### PR DESCRIPTION
My codebase has a require to an absolute path (`/opt/to/something/unusual`). Finding spec for it uses a nil value (spliting empty string returns emtpy array) that breaks `Gem::Specification.find_by_name`, therefore, scans fail.