### PR TITLE
Setup LOAD_PATH from require_paths

### DIFF
--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -32,6 +32,7 @@ module Solargraph
       load_sources
       @gemnames = []
       @require_paths = generate_require_paths
+      setup_load_paths
       require_plugins
     end
 
@@ -207,6 +208,11 @@ module Solargraph
           Solargraph.logger.warn "Failed to load plugin '#{plugin}'"
         end
       end
+    end
+
+    def setup_load_paths
+      # Make files available to require calls in for example rubocop
+      $LOAD_PATH.unshift *@require_paths
     end
   end
 end


### PR DESCRIPTION
Hey everyone, thanks for this nice gem, I am trying to incorporate it into more parts of my ruby development.

Sometimes I am using a setup where I do not want to add solargraph to the Gemfile, so I can not start it via bundle exec. However I still want a diagnoser like rubocop to be able to require files of local gems, for example custom cops provided by a local gem (with a path pointer in the local Gemfile).

Currently rubocop will just crash because it can not load those files for custom cop definitions, but with some simple change we can expose the configuration of require_files to rubocop by updating `LOAD_PATH`. In many cases require_files already has a working default and there is no additional configuration required.

WDYT?