### PR TITLE
Fix idle cpu usage

### DIFF
--- a/lib/solargraph/language_server/host/cataloger.rb
+++ b/lib/solargraph/language_server/host/cataloger.rb
@@ -34,7 +34,7 @@ module Solargraph
           Thread.new do
             until stopped?
               tick
-              sleep 0.01
+              sleep 0.1
             end
           end
         end


### PR DESCRIPTION
I've noticed the cpu usage has been pretty high, around 10% when idling.

I believe this issue may have originated from the change in this [commit](https://github.com/castwide/solargraph/pull/136/commits/ac3f0628dcd67d80c7f4dc693fb6e5b1bc8be27b#), which altered the sleep duration from 0.1 to 0.01 seconds.

Changing it back to 0.1 seconds has returned the cpu usage to 1-2%.