### PR TITLE
Add ruby 3.2 to CI

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1']
+        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -25,12 +25,9 @@ jobs:
         ruby-version: ['2.6', '2.7', '3.0', '3.1']
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Set up Ruby
-    # To automatically get bug fixes and new Ruby versions for ruby/setup-ruby,
-    # change this to (see https://github.com/ruby/setup-ruby#versioning):
-    # uses: ruby/setup-ruby@v1
-      uses: ruby/setup-ruby@2b019609e2b0f1ea1a2bc8ca11cb82ab46ada124
+      uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: false


### PR DESCRIPTION
Bumps the github actions, and especially setup-ruby since it didn't know about ruby 3.2 beforehand.

Uses a tag for setup-ruby, for convenience. It will not need to be updated for ruby 3.3 again, and will pick up the latest patch version available at runtime.