### PR TITLE
Remove dependency on e2mmap

### DIFF
--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -27,7 +27,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'benchmark'
   s.add_runtime_dependency 'bundler', '~> 2.0'
   s.add_runtime_dependency 'diff-lcs', '~> 1.4'
-  s.add_runtime_dependency 'e2mmap'
   s.add_runtime_dependency 'jaro_winkler', '~> 1.5'
   s.add_runtime_dependency 'kramdown', '~> 2.3'
   s.add_runtime_dependency 'kramdown-parser-gfm', '~> 1.1'


### PR DESCRIPTION
Added in #253 for early ruby 2.7 compatibility.

The gem is not used directly here but was a workaround for it being removed as a default bundled gem.
Yard used this but internal usage was removed in https://github.com/lsegal/yard/pull/1297 so this is not needed anymore.

The yard version constraint is already high enough that removing this will not cause any problems. The fix was shipped with 0.9.21 while the gemspec requires 0.9.24 or higher.