### PR TITLE
Fixed Solargraph::Cache.base_dir

### DIFF
--- a/lib/solargraph/cache.rb
+++ b/lib/solargraph/cache.rb
@@ -9,7 +9,7 @@ module Solargraph
       def base_dir
         # The directory is not stored in a variable so it can be overridden
         # in specs.
-        ENV['SOLARGRAPH_CACHE'] ||
+        ENV['SOLARGRAPH_CACHE'] or
           ENV['XDG_CACHE_HOME'] ? File.join(ENV['XDG_CACHE_HOME'], 'solargraph') :
           File.join(Dir.home, '.cache', 'solargraph')
       end


### PR DESCRIPTION
Switched Ruby's || operator to 'or' to account for precedence.

When the environment variable SOLARGRAPH_CACHE is defined, the cache is always configured to use XDG_CACHE_HOME. When XDG_CACHE_HOME is defined, it silently replaces SOLARGRAPH_CACHE. When it is undefined, it leads to a TypeError.