### PR TITLE
Complete global methods from a file inside modules/classes

### DIFF
--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1478,4 +1478,22 @@ describe Solargraph::SourceMap::Clip do
     string_names = api_map.clip_at('test.rb', [6, 22]).complete.pins.map(&:name)
     expect(string_names).to eq(["upcase", "upcase!", "upto"])
   end
+
+  it 'completes global methods defined in top level scope inside class when referenced inside a namespace' do
+    source = Solargraph::Source.load_string(%(
+      def some_method;end
+
+      class Thing
+        def foo
+          some_
+        end
+      end
+      some_
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    pin_names = api_map.clip_at('test.rb', [5, 15]).complete.pins.map(&:name)
+    expect(pin_names).to eq(["some_method"])
+    pin_names = api_map.clip_at('test.rb', [8, 5]).complete.pins.map(&:name)
+    expect(pin_names).to include("some_method")
+  end
 end


### PR DESCRIPTION
Hi, 

I noticed this issue while trying to make the "normal ruby" method completion work for RSpec `context` blocks initially in https://github.com/lekemula/solargraph-rspec. Even though I ultimately ended up with a different solution, I thought to still port this change as it's still a valid ruby code, albeit a rare case in real life (?).

```ruby
# thing.rb
def some_method;end

class Thing
  def foo
    some_
    #   ^ this does not work
  end
end
```