### PR TITLE
Remove non-existent `Workspace#would_merge?` call

### DIFF
--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -97,7 +97,7 @@ module Solargraph
     def create filename, text
       result = false
       mutex.synchronize do
-        next unless contain?(filename) || open?(filename) || workspace.would_merge?(filename)
+        next unless contain?(filename) || open?(filename)
         @synchronized = false
         source = Solargraph::Source.load_string(text, filename)
         workspace.merge(source)


### PR DESCRIPTION
I somehow stumbled over this issue while working on https://github.com/lekemula/solargraph-rspec a while ago but I don't quite remember how. Anyhow after digging a bit, it turned out that:

`Workspace#would_merge?` was removed here:
https://github.com/castwide/solargraph/pull/638/commits/84b75324dddd176b765d3f1322ac0ad351d1b4a0