### PR TITLE
Implement Go To Type Definition

### DIFF
--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -67,9 +67,16 @@ module Solargraph
     def select &block
       @items.select &block
     end
+
+    # @return [String]
     def namespace
       # cache this attr for high frequency call
       @namespace ||= method_missing(:namespace).to_s
+    end
+
+    # @return [Array<String>]
+    def namespaces
+      @items.map(&:namespace)
     end
 
     def method_missing name, *args, &block

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -537,6 +537,15 @@ module Solargraph
       # @param line [Integer]
       # @param column [Integer]
       # @return [Array<Solargraph::Pin::Base>]
+      def type_definitions_at uri, line, column
+        library = library_for(uri)
+        library.type_definitions_at(uri_to_file(uri), line, column)
+      end
+
+      # @param uri [String]
+      # @param line [Integer]
+      # @param column [Integer]
+      # @return [Array<Solargraph::Pin::Base>]
       def signatures_at uri, line, column
         library = library_for(uri)
         library.signatures_at(uri_to_file(uri), line, column)
@@ -630,6 +639,7 @@ module Solargraph
           'hover' => true,
           'symbols' => true,
           'definitions' => true,
+          'typeDefinitions' => true,
           'rename' => true,
           'references' => true,
           'autoformat' => false,

--- a/lib/solargraph/language_server/message.rb
+++ b/lib/solargraph/language_server/message.rb
@@ -66,6 +66,7 @@ module Solargraph
       register 'textDocument/didClose',               TextDocument::DidClose
       register 'textDocument/hover',                  TextDocument::Hover
       register 'textDocument/definition',             TextDocument::Definition
+      register 'textDocument/typeDefinition',         TextDocument::TypeDefinition
       register 'textDocument/formatting',             TextDocument::Formatting
       register 'textDocument/onTypeFormatting',       TextDocument::OnTypeFormatting
       register 'textDocument/documentSymbol',         TextDocument::DocumentSymbol

--- a/lib/solargraph/language_server/message/initialize.rb
+++ b/lib/solargraph/language_server/message/initialize.rb
@@ -34,6 +34,7 @@ module Solargraph
           result[:capabilities].merge! static_document_formatting unless dynamic_registration_for?('textDocument', 'formatting')
           result[:capabilities].merge! static_document_symbols unless dynamic_registration_for?('textDocument', 'documentSymbol')
           result[:capabilities].merge! static_definitions unless dynamic_registration_for?('textDocument', 'definition')
+          result[:capabilities].merge! static_type_definitions unless dynamic_registration_for?('textDocument', 'typeDefinition')
           result[:capabilities].merge! static_rename unless dynamic_registration_for?('textDocument', 'rename')
           result[:capabilities].merge! static_references unless dynamic_registration_for?('textDocument', 'references')
           result[:capabilities].merge! static_workspace_symbols unless dynamic_registration_for?('workspace', 'symbol')
@@ -116,6 +117,13 @@ module Solargraph
 
         def static_definitions
           return {} unless host.options['definitions']
+          {
+            definitionProvider: true
+          }
+        end
+
+        def static_type_definitions
+          return {} unless host.options['type_definitions']
           {
             definitionProvider: true
           }

--- a/lib/solargraph/language_server/message/initialized.rb
+++ b/lib/solargraph/language_server/message/initialized.rb
@@ -13,6 +13,7 @@ module Solargraph
             textDocument/formatting
             textDocument/documentSymbol
             textDocument/definition
+            textDocument/typeDefinition
             textDocument/references
             textDocument/rename
             textDocument/prepareRename

--- a/lib/solargraph/language_server/message/text_document.rb
+++ b/lib/solargraph/language_server/message/text_document.rb
@@ -15,6 +15,7 @@ module Solargraph
         autoload :DiagnosticsQueue,  'solargraph/language_server/message/text_document/diagnostics_queue'
         autoload :OnTypeFormatting,  'solargraph/language_server/message/text_document/on_type_formatting'
         autoload :Definition,        'solargraph/language_server/message/text_document/definition'
+        autoload :TypeDefinition,    'solargraph/language_server/message/text_document/type_definition'
         autoload :DocumentSymbol,    'solargraph/language_server/message/text_document/document_symbol'
         autoload :Formatting,        'solargraph/language_server/message/text_document/formatting'
         autoload :References,        'solargraph/language_server/message/text_document/references'

--- a/lib/solargraph/language_server/message/text_document/type_definition.rb
+++ b/lib/solargraph/language_server/message/text_document/type_definition.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+module Solargraph::LanguageServer::Message::TextDocument
+  class TypeDefinition < Base
+    def process
+      @line = params['position']['line']
+      @column = params['position']['character']
+      set_result(code_location || [])
+    end
+
+    private
+
+    def code_location
+      suggestions = host.type_definitions_at(params['textDocument']['uri'], @line, @column)
+      return nil if suggestions.empty?
+      suggestions.reject { |pin| pin.location.nil? || pin.location.filename.nil? }.map do |pin|
+        {
+          uri: file_to_uri(pin.location.filename),
+          range: pin.location.range.to_hash
+        }
+      end
+    end
+  end
+end

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -199,6 +199,22 @@ module Solargraph
       handle_file_not_found(filename, e)
     end
 
+    # Get type definition suggestions for the expression at the specified file and
+    # location.
+    #
+    # @param filename [String] The file to analyze
+    # @param line [Integer] The zero-based line number
+    # @param column [Integer] The zero-based column number
+    # @return [Array<Solargraph::Pin::Base>]
+    # @todo Take filename/position instead of filename/line/column
+    def type_definitions_at filename, line, column
+      position = Position.new(line, column)
+      cursor = Source::Cursor.new(read(filename), position)
+      api_map.clip(cursor).types
+    rescue FileNotFoundError => e
+      handle_file_not_found filename, e
+    end
+
     # Get signature suggestions for the method at the specified file and
     # location.
     #

--- a/lib/solargraph/source_map/clip.rb
+++ b/lib/solargraph/source_map/clip.rb
@@ -21,6 +21,11 @@ module Solargraph
         result
       end
 
+      # @return [Array<Pin::Base>]
+      def types
+        infer.namespaces.map { |namespace| api_map.get_path_pins(namespace) }.flatten
+      end
+
       # @return [Completion]
       def complete
         return package_completions([]) if !source_map.source.parsed? || cursor.string?

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -59,6 +59,9 @@ describe Solargraph::ComplexType do
     expect(types.length).to eq(1)
     expect(types.first.namespace).to eq('Foo')
     expect(types.first.scope).to eq(:class)
+    multiple_types = Solargraph::ComplexType.parse 'Module<Foo>, Class<Bar>, String, nil'
+    expect(multiple_types.length).to eq(4)
+    expect(multiple_types.namespaces).to eq(['Foo', 'Bar', 'String', 'NilClass'])
   end
 
   it "identifies duck types" do

--- a/spec/fixtures/workspace/lib/something.rb
+++ b/spec/fixtures/workspace/lib/something.rb
@@ -1,0 +1,2 @@
+class Something
+end

--- a/spec/fixtures/workspace/lib/thing.rb
+++ b/spec/fixtures/workspace/lib/thing.rb
@@ -1,4 +1,4 @@
 class Thing
-  def do_thing
-  end
+  # @return [Something]
+  def do_thing; end
 end

--- a/spec/language_server/message/text_document/type_definition_spec.rb
+++ b/spec/language_server/message/text_document/type_definition_spec.rb
@@ -1,0 +1,23 @@
+describe Solargraph::LanguageServer::Message::TextDocument::TypeDefinition do
+  it 'finds definitions of methods' do
+    host = Solargraph::LanguageServer::Host.new
+    host.prepare('spec/fixtures/workspace')
+    sleep 0.1 until host.libraries.all?(&:mapped?)
+    host.catalog
+    file_uri = Solargraph::LanguageServer::UriHelpers.file_to_uri(File.absolute_path('spec/fixtures/workspace/lib/other.rb'))
+    something_uri = Solargraph::LanguageServer::UriHelpers.file_to_uri(File.absolute_path('spec/fixtures/workspace/lib/something.rb'))
+    message = Solargraph::LanguageServer::Message::TextDocument::TypeDefinition.new(host, {
+      'params' => {
+        'textDocument' => {
+          'uri' => file_uri
+        },
+        'position' => {
+          'line' => 4,
+          'character' => 10
+        }
+      }
+    })
+    message.process
+    expect(message.result.first[:uri]).to eq(something_uri)
+  end
+end

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -39,6 +39,22 @@ describe Solargraph::Library do
     expect(paths).to include('Foo#bar')
   end
 
+  it "gets type definitions from a file" do
+    library = Solargraph::Library.new
+    src = Solargraph::Source.load_string %(
+      class Bar; end
+      class Foo
+        # @return [Bar]
+        def self.bar
+        end
+      end
+      Foo.bar
+    ), 'file.rb', 0
+    library.attach src
+    paths = library.type_definitions_at('file.rb', 7, 13).map(&:path)
+    expect(paths).to include('Bar')
+  end
+
   it "signifies method arguments" do
     library = Solargraph::Library.new
     src = Solargraph::Source.load_string %(


### PR DESCRIPTION
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_typeDefinition

Demo in VScode (since in VIM everything is too fast 🤪)
![solargraph_go_to_type_definition](https://github.com/castwide/solargraph/assets/9197495/dbc931cb-c2d7-4bb1-a497-7524da7154ba)

All the necessary pieces were in place, and nothing fancy changed, mostly just exposing the functionality for LanguageServer. Almost feels like an easter egg for a new contributor like me 😄.

The only "functionality" added is `ComplexType#namespaces` which also utilizes existing implementation.