### PR TITLE
Include @example tags in Pin::Method documentation

### DIFF
--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -130,6 +130,11 @@ module Solargraph
           end
           @documentation += "\n\n" unless @documentation.empty?
           @documentation += "Visibility: #{visibility}"
+          example_tags = docstring.tags(:example)
+          unless example_tags.empty?
+            @documentation += "\n\nExamples:\n\n"
+            @documentation += example_tags.map(&:text).join("\n")
+          end
         end
         @documentation.to_s
       end

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -275,6 +275,17 @@ describe Solargraph::Pin::Method do
     expect(pin.documentation).to include('the foo text string')
   end
 
+  it 'includes @example text in documentation' do
+    pin = Solargraph::Pin::Method.new(
+      name: 'foo',
+      comments: %(
+@example
+  foo
+      )
+    )
+    expect(pin.documentation).to include('foo')
+  end
+
   context 'as attribute' do
     it "is a kind of attribute/property" do
       source = Solargraph::Source.load_string(%(


### PR DESCRIPTION
When trying to [add yardoc comments for some of RSpec DSL](https://github.com/lekemula/solargraph-rspec/commit/a08427ad6544b6e72abaab7e4d8081f2093293ec) I noticed that `@example` tags are not being included. And for RSpec DSL those seem to be the most useful part. I believe examples are quite helpful in general for devs to see how a particular method is used.

Before:

![image_1717952008834_0](https://github.com/castwide/solargraph/assets/9197495/fee6981f-0be1-4113-8cce-c8162461e881)

After:

![image_1717951339627_0](https://github.com/castwide/solargraph/assets/9197495/630bdafd-6651-4260-8b49-cca510998d87)
