### PR TITLE
fix: support find require xxx.rb in local workspace.

### DIFF
--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -104,7 +104,8 @@ module Solargraph
     # @return [Boolean]
     def would_require? path
       require_paths.each do |rp|
-        return true if File.exist?(File.join(rp, "#{path}.rb"))
+        full = File.join rp, path
+        return true if File.exist?(full) or File.exist?(full << ".rb")
       end
       false
     end

--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -120,8 +120,9 @@ module Solargraph
       # @type [Gem::Specification]
       spec = spec_for_require(path)
       spec.full_require_paths.each do |rp|
-        file = File.join(rp, "#{path}.rb")
-        next unless File.file?(file)
+        file = File.join(rp, path)
+        file = [file, file + ".rb"].find { |file| File.file?(file) }
+        next unless file
         return Solargraph::Location.new(file, Solargraph::Range.from_to(0, 0, 0, 0))
       end
       nil


### PR DESCRIPTION
before this patch:
```
require "path" # ok
require "path.rb" # can't found required file
```

this pr fix it to allow a full name match.