### PR TITLE
Include convention (eg. solargraph-rspec) pins in document_symbols

### DIFF
--- a/lib/solargraph/language_server/message/text_document/document_symbol.rb
+++ b/lib/solargraph/language_server/message/text_document/document_symbol.rb
@@ -6,6 +6,8 @@ class Solargraph::LanguageServer::Message::TextDocument::DocumentSymbol < Solarg
   def process
     pins = host.document_symbols params['textDocument']['uri']
     info = pins.map do |pin|
+      next nil unless pin.location&.filename
+
       result = {
         name: pin.name,
         containerName: pin.namespace,
@@ -17,7 +19,8 @@ class Solargraph::LanguageServer::Message::TextDocument::DocumentSymbol < Solarg
         deprecated: pin.deprecated?
       }
       result
-    end
+    end.compact
+
     set_result info
   end
 end

--- a/lib/solargraph/source_map.rb
+++ b/lib/solargraph/source_map.rb
@@ -30,6 +30,7 @@ module Solargraph
       @pins = pins
       @locals = locals
       environ.merge Convention.for_local(self) unless filename.nil?
+      self.convention_pins = environ.pins
       @pin_class_hash = pins.to_set.classify(&:class).transform_values(&:to_a)
       @pin_select_cache = {}
     end
@@ -65,11 +66,12 @@ module Solargraph
       @environ ||= Environ.new
     end
 
+    # all pins except Solargraph::Pin::Reference::Reference
     # @return [Array<Pin::Base>]
     def document_symbols
-      @document_symbols ||= pins.select { |pin|
+      @document_symbols ||= (pins + convention_pins).select do |pin|
         pin.path && !pin.path.empty?
-      }
+      end
     end
 
     # @param query [String]
@@ -158,6 +160,17 @@ module Solargraph
     end
 
     private
+
+    # @return [Array<Pin::Base>]
+    def convention_pins
+      @convention_pins || []
+    end
+
+    def convention_pins=(pins)
+      # unmemoizing the document_symbols in case it was called from any of convnetions
+      @document_symbols = nil
+      @convention_pins = pins
+    end
 
     # @param line [Integer]
     # @param character [Integer]


### PR DESCRIPTION
Hi there,

It looks like currently the additional pins added from conventions are not included in [documentSymbol request](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentSymbol).

This PR adds them, thus enabling finding and easier navigation between `RSpec` `describe/context` blocks via [solargraph-rspec](https://github.com/lekemula/solargraph-rspec) plugin:

![solargraph_rspec_document_symbols_1](https://github.com/user-attachments/assets/ed6fd34e-137f-4472-ad7c-a2e25ec8eda6)

![solargraph_rspec_document_symbols_2](https://github.com/user-attachments/assets/1cb0191d-f448-4306-97ee-ff68773a88f2)


