### PR TITLE
Fix exception from parser when anonymous block forwarding is used

### DIFF
--- a/lib/solargraph/parser/legacy/node_chainer.rb
+++ b/lib/solargraph/parser/legacy/node_chainer.rb
@@ -118,7 +118,15 @@ module Solargraph
           elsif [:begin, :kwbegin].include?(n.type)
             result.concat generate_links(n.children[0])
           elsif n.type == :block_pass
-            result.push Chain::BlockVariable.new("&#{n.children[0].children[0].to_s}")
+            block_variable_name_node = n.children[0]
+            if block_variable_name_node.nil?
+              # anonymous block forwarding (e.g., "&")
+              # added in Ruby 3.1 - https://bugs.ruby-lang.org/issues/11256
+              result.push Chain::BlockVariable.new(nil)
+            else
+              result.push Chain::BlockVariable.new("&#{block_variable_name_node.children[0].to_s}")
+            end
+
           elsif n.type == :hash
             result.push Chain::Hash.new('::Hash', hash_is_splatted?(n))
           else

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -47,4 +47,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'rspec', '~> 3.5'
   s.add_development_dependency 'simplecov', '~> 0.14'
   s.add_development_dependency 'webmock', '~> 3.6'
+  # work around missing yard dependency needed as of Ruby 3.5
+  s.add_development_dependency 'irb'
 end

--- a/spec/parser/node_chainer_spec.rb
+++ b/spec/parser/node_chainer_spec.rb
@@ -112,15 +112,18 @@ describe 'NodeChainer' do
     expect(chain.links.first.arguments.length).to eq(2)
   end
 
-  it 'tracks anonymous block forwarding' do
-    source = Solargraph::Source.load_string(%(
+  # feature added in Ruby 3.1
+  if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1')
+    it 'tracks anonymous block forwarding' do
+      source = Solargraph::Source.load_string(%(
       def foo(&)
         bar(&)
       end
     ))
-    anonymous_block_pass = source.node.children[2].children[2]
-    chain = Solargraph::Parser.chain(anonymous_block_pass)
-    block_variable_node = chain.links.first
-    expect(block_variable_node.word).to be_nil
+      anonymous_block_pass = source.node.children[2].children[2]
+      chain = Solargraph::Parser.chain(anonymous_block_pass)
+      block_variable_node = chain.links.first
+      expect(block_variable_node.word).to be_nil
+    end
   end
 end

--- a/spec/parser/node_chainer_spec.rb
+++ b/spec/parser/node_chainer_spec.rb
@@ -111,4 +111,16 @@ describe 'NodeChainer' do
     chain = Solargraph::Parser.chain(source.node)
     expect(chain.links.first.arguments.length).to eq(2)
   end
+
+  it 'tracks anonymous block forwarding' do
+    source = Solargraph::Source.load_string(%(
+      def foo(&)
+        bar(&)
+      end
+    ))
+    anonymous_block_pass = source.node.children[2].children[2]
+    chain = Solargraph::Parser.chain(anonymous_block_pass)
+    block_variable_node = chain.links.first
+    expect(block_variable_node.word).to be_nil
+  end
 end


### PR DESCRIPTION
This code is valid as of Ruby 3.1, but solargraph raises an exception when parsing it:

```ruby
      def foo(&)
        bar(&)
      end
```