### PR TITLE
Better support for generics via Class @param tags

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -199,6 +199,13 @@ module Solargraph
       result
     end
 
+    # @param namespace [String]
+    # @param context [String]
+    # @return [Array<Pin::Namespace>]
+    def get_namespace_pins namespace, context
+      store.fqns_pins(qualify(namespace, context))
+    end
+
     # Get a fully qualified namespace name. This method will start the search
     # in the specified context until it finds a match for the name.
     #

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -147,8 +147,6 @@ module Solargraph
         @pin_select_cache[klass] ||= @pin_class_hash.each_with_object(Set.new) { |(key, o), n| n.merge(o) if key <= klass }
       end
 
-      private
-
       # @param fqns [String]
       # @return [Array<Solargraph::Pin::Namespace>]
       def fqns_pins fqns
@@ -163,6 +161,8 @@ module Solargraph
         end
         fqns_pins_map[[base, name]]
       end
+
+      private
 
       def fqns_pins_map
         @fqns_pins_map ||= Hash.new do |h, (base, name)|

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -110,6 +110,9 @@ module Solargraph
       any?(&:parameterized?)
     end
 
+    # @param definitions [Pin::Namespace]
+    # @param context [Pin::Base]
+    # @return [ComplexType]
     def resolve_parameters definitions, context
       result = @items.map { |i| i.resolve_parameters(definitions, context) }
       ComplexType.parse(*result.map(&:tag))

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -111,10 +111,10 @@ module Solargraph
     end
 
     # @param definitions [Pin::Namespace]
-    # @param context [Pin::Base]
+    # @param context_type [ComplexType]
     # @return [ComplexType]
-    def resolve_parameters definitions, context
-      result = @items.map { |i| i.resolve_parameters(definitions, context) }
+    def resolve_parameters definitions, context_type
+      result = @items.map { |i| i.resolve_parameters(definitions, context_type) }
       ComplexType.parse(*result.map(&:tag))
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -107,8 +107,8 @@ module Solargraph
       @items.any?(&:selfy?)
     end
 
-    def parameterized?
-      any?(&:parameterized?)
+    def generic?
+      any?(&:generic?)
     end
 
     # @param definitions [Pin::Namespace]

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -4,6 +4,7 @@ module Solargraph
   # A container for type data based on YARD type tags.
   #
   class ComplexType
+    GENERIC_TAG_NAME = 'generic'.freeze
     # @!parse
     #   include TypeMethods
 
@@ -113,8 +114,8 @@ module Solargraph
     # @param definitions [Pin::Namespace]
     # @param context_type [ComplexType]
     # @return [ComplexType]
-    def resolve_parameters definitions, context_type
-      result = @items.map { |i| i.resolve_parameters(definitions, context_type) }
+    def resolve_generics definitions, context_type
+      result = @items.map { |i| i.resolve_generics(definitions, context_type) }
       ComplexType.parse(*result.map(&:tag))
     end
 

--- a/lib/solargraph/complex_type/type_methods.rb
+++ b/lib/solargraph/complex_type/type_methods.rb
@@ -101,7 +101,7 @@ module Solargraph
       # @param context [String] The namespace from which to resolve names
       # @return [ComplexType] The generated ComplexType
       def qualify api_map, context = ''
-        return self if name == 'param'
+        return self if name == GENERIC_TAG_NAME
         return ComplexType.new([self]) if duck_type? || void? || undefined?
         recon = (rooted? ? '' : context)
         fqns = api_map.qualify(name, recon)

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -59,6 +59,9 @@ module Solargraph
         name == 'param' || all_params.any?(&:parameterized?)
       end
 
+      # @param definitions [Pin::Namespace]
+      # @param context [Pin::Base]
+      # @return [UniqueType]
       def resolve_parameters definitions, context
         new_name = if name == 'param'
           idx = definitions.parameters.index(subtypes.first.name)

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -60,25 +60,25 @@ module Solargraph
       end
 
       # @param definitions [Pin::Namespace]
-      # @param context [Pin::Base]
+      # @param context_type [ComplexType]
       # @return [UniqueType]
-      def resolve_parameters definitions, context
+      def resolve_parameters definitions, context_type
         new_name = if name == 'param'
           idx = definitions.parameters.index(subtypes.first.name)
           return ComplexType::UNDEFINED if idx.nil?
-          param_type = context.return_type.all_params[idx]
+          param_type = context_type.all_params[idx]
           return ComplexType::UNDEFINED unless param_type
           param_type.to_s
         else
           name
         end
         new_key_types = if name != 'param'
-          @key_types.map { |t| t.resolve_parameters(definitions, context) }.select(&:defined?)
+          @key_types.map { |t| t.resolve_parameters(definitions, context_type) }.select(&:defined?)
         else
           []
         end
         new_subtypes = if name != 'param'
-          @subtypes.map { |t| t.resolve_parameters(definitions, context) }.select(&:defined?)
+          @subtypes.map { |t| t.resolve_parameters(definitions, context_type) }.select(&:defined?)
         else
           []
         end

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -56,14 +56,14 @@ module Solargraph
       end
   
       def parameterized?
-        name == 'param' || all_params.any?(&:parameterized?)
+        name == GENERIC_TAG_NAME || all_params.any?(&:parameterized?)
       end
 
       # @param definitions [Pin::Namespace]
       # @param context_type [ComplexType]
       # @return [UniqueType]
-      def resolve_parameters definitions, context_type
-        new_name = if name == 'param'
+      def resolve_generics definitions, context_type
+        new_name = if name == GENERIC_TAG_NAME
           idx = definitions.generics.index(subtypes.first.name)
           return ComplexType::UNDEFINED if idx.nil?
           param_type = context_type.all_params[idx]
@@ -72,17 +72,17 @@ module Solargraph
         else
           name
         end
-        new_key_types = if name != 'param'
-          @key_types.map { |t| t.resolve_parameters(definitions, context_type) }.select(&:defined?)
+        new_key_types = if name != GENERIC_TAG_NAME
+          @key_types.map { |t| t.resolve_generics(definitions, context_type) }.select(&:defined?)
         else
           []
         end
-        new_subtypes = if name != 'param'
-          @subtypes.map { |t| t.resolve_parameters(definitions, context_type) }.select(&:defined?)
+        new_subtypes = if name != GENERIC_TAG_NAME
+          @subtypes.map { |t| t.resolve_generics(definitions, context_type) }.select(&:defined?)
         else
           []
         end
-        if name != 'param' && !(new_key_types.empty? && new_subtypes.empty?)
+        if name != GENERIC_TAG_NAME && !(new_key_types.empty? && new_subtypes.empty?)
           if hash_parameters?
             UniqueType.new(new_name, "{#{new_key_types.join(', ')} => #{new_subtypes.join(', ')}}")
           elsif parameters?

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -55,8 +55,8 @@ module Solargraph
         "#{namespace}#{parameters? ? "[#{subtypes.map { |s| s.to_rbs }.join(', ')}]" : ''}"
       end
   
-      def parameterized?
-        name == GENERIC_TAG_NAME || all_params.any?(&:parameterized?)
+      def generic?
+        name == GENERIC_TAG_NAME || all_params.any?(&:generic?)
       end
 
       # @param definitions [Pin::Namespace]

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -64,7 +64,7 @@ module Solargraph
       # @return [UniqueType]
       def resolve_parameters definitions, context_type
         new_name = if name == 'param'
-          idx = definitions.parameters.index(subtypes.first.name)
+          idx = definitions.generics.index(subtypes.first.name)
           return ComplexType::UNDEFINED if idx.nil?
           param_type = context_type.all_params[idx]
           return ComplexType::UNDEFINED unless param_type

--- a/lib/solargraph/parser.rb
+++ b/lib/solargraph/parser.rb
@@ -19,6 +19,8 @@ module Solargraph
 
     selected = rubyvm? ? Rubyvm : Legacy
     # include selected
+    # @!parse
+    #   extend Solargraph::Parser::Legacy::ClassMethods
     extend selected::ClassMethods
 
     NodeMethods = (rubyvm? ? Rubyvm::NodeMethods : Legacy::NodeMethods)

--- a/lib/solargraph/parser/node_methods.rb
+++ b/lib/solargraph/parser/node_methods.rb
@@ -27,6 +27,7 @@ module Solargraph
         raise NotImplementedError
       end
 
+      # @return [Source::Chain]
       def chain node, filename = nil, in_block = false
         raise NotImplementedError
       end

--- a/lib/solargraph/pin/namespace.rb
+++ b/lib/solargraph/pin/namespace.rb
@@ -14,7 +14,7 @@ module Solargraph
       # @param type [::Symbol] :class or :module
       # @param visibility [::Symbol] :public or :private
       # @param gates [Array<String>]
-      def initialize type: :class, visibility: :public, gates: [''], parameters: [], **splat
+      def initialize type: :class, visibility: :public, gates: [''], parameters: nil, **splat
         # super(location, namespace, name, comments)
         super(**splat)
         @type = type
@@ -88,6 +88,11 @@ module Solargraph
         else
           [path] + @open_gates
         end
+      end
+
+      # @return [Array<String>]
+      def parameters
+        @parameters ||= docstring.tags(:param).map(&:name)
       end
     end
   end

--- a/lib/solargraph/pin/namespace.rb
+++ b/lib/solargraph/pin/namespace.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'yard-solargraph'
+
 module Solargraph
   module Pin
     class Namespace < Closure
@@ -92,7 +94,7 @@ module Solargraph
 
       # @return [Array<String>]
       def parameters
-        @parameters ||= docstring.tags(:param).map(&:name)
+        @parameters ||= docstring.tags(:generic).map(&:name)
       end
     end
   end

--- a/lib/solargraph/pin/namespace.rb
+++ b/lib/solargraph/pin/namespace.rb
@@ -11,12 +11,12 @@ module Solargraph
       # @return [::Symbol] :class or :module
       attr_reader :type
 
-      attr_reader :parameters
+      attr_reader :generics
 
       # @param type [::Symbol] :class or :module
       # @param visibility [::Symbol] :public or :private
       # @param gates [Array<String>]
-      def initialize type: :class, visibility: :public, gates: [''], parameters: nil, **splat
+      def initialize type: :class, visibility: :public, gates: [''], generics: nil, **splat
         # super(location, namespace, name, comments)
         super(**splat)
         @type = type
@@ -40,7 +40,7 @@ module Solargraph
           @closure = Pin::Namespace.new(name: closure_name, gates: [parts.join('::')])
           @context = nil
         end
-        @parameters = parameters
+        @generics = generics
       end
 
       def namespace
@@ -93,8 +93,8 @@ module Solargraph
       end
 
       # @return [Array<String>]
-      def parameters
-        @parameters ||= docstring.tags(:generic).map(&:name)
+      def generics
+        @generics ||= docstring.tags(:generic).map(&:name)
       end
     end
   end

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -123,6 +123,7 @@ module Solargraph
           clip = api_map.clip_at(location.filename, location.range.start)
           locals = clip.locals - [self]
           meths = chain.define(api_map, closure, locals)
+          receiver_type = chain.base.infer(api_map, closure, locals)
           meths.each do |meth|
             if meth.docstring.has_tag?(:yieldparam_single_parameter)
               type = chain.base.infer(api_map, closure, locals)
@@ -133,7 +134,13 @@ module Solargraph
             else
               yps = meth.docstring.tags(:yieldparam)
               unless yps[index].nil? or yps[index].types.nil? or yps[index].types.empty?
-                return ComplexType.try_parse(yps[index].types.first).self_to(chain.base.infer(api_map, closure, locals).namespace).qualify(api_map, meth.context.namespace)
+                yield_type = ComplexType.try_parse(yps[index].types.first)
+                if yield_type.parameterized? && receiver_type.defined?
+                  namespace_pin = api_map.get_namespace_pins(meth.namespace, closure.namespace).first
+                  return yield_type.resolve_parameters(namespace_pin, receiver_type)
+                else
+                  return yield_type.self_to(chain.base.infer(api_map, closure, locals).namespace).qualify(api_map, meth.context.namespace)
+                end
               end
             end
           end

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -135,7 +135,7 @@ module Solargraph
               yps = meth.docstring.tags(:yieldparam)
               unless yps[index].nil? or yps[index].types.nil? or yps[index].types.empty?
                 yield_type = ComplexType.try_parse(yps[index].types.first)
-                if yield_type.parameterized? && receiver_type.defined?
+                if yield_type.generic? && receiver_type.defined?
                   namespace_pin = api_map.get_namespace_pins(meth.namespace, closure.namespace).first
                   return yield_type.resolve_generics(namespace_pin, receiver_type)
                 else

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -137,7 +137,7 @@ module Solargraph
                 yield_type = ComplexType.try_parse(yps[index].types.first)
                 if yield_type.parameterized? && receiver_type.defined?
                   namespace_pin = api_map.get_namespace_pins(meth.namespace, closure.namespace).first
-                  return yield_type.resolve_parameters(namespace_pin, receiver_type)
+                  return yield_type.resolve_generics(namespace_pin, receiver_type)
                 else
                   return yield_type.self_to(chain.base.infer(api_map, closure, locals).namespace).qualify(api_map, meth.context.namespace)
                 end

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -407,7 +407,7 @@ module Solargraph
         elsif type.is_a?(RBS::Types::Bases::Void)
           'void'
         elsif type.is_a?(RBS::Types::Variable)
-          "param<#{type.name}>"
+          "#{Solargraph::ComplexType::GENERIC_TAG_NAME}<#{type.name}>"
         elsif type.is_a?(RBS::Types::ClassInstance) #&& !type.args.empty?
           base = RBS_TO_YARD_TYPE[type.name.relative!.to_s] || type.name.relative!.to_s
           params = type.args.map { |a| other_type_to_tag(a) }.reject { |t| t == 'undefined' }

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -113,7 +113,7 @@ module Solargraph
           name: decl.name.relative!.to_s,
           closure: Solargraph::Pin::ROOT_PIN,
           comments: decl.comment&.string,
-          parameters: decl.type_params.map(&:name).map(&:to_s)
+          generics: decl.type_params.map(&:name).map(&:to_s)
         )
         pins.push class_pin
         if decl.super_class

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -129,7 +129,7 @@ module Solargraph
           @@inference_stack.pop
           if type.defined?
             if type.parameterized?
-              type = type.resolve_parameters(pin.closure, context)
+              type = type.resolve_parameters(pin.closure, context.return_type)
               # idx = pin.closure.parameters.index(type.subtypes.first.name)
               # next if idx.nil?
               # param_type = context.return_type.all_params[idx]

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -128,7 +128,7 @@ module Solargraph
           type = pin.typify(api_map)
           @@inference_stack.pop
           if type.defined?
-            if type.parameterized?
+            if type.generic?
               type = type.resolve_generics(pin.closure, context.return_type)
               # idx = pin.closure.parameters.index(type.subtypes.first.name)
               # next if idx.nil?

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -129,7 +129,7 @@ module Solargraph
           @@inference_stack.pop
           if type.defined?
             if type.parameterized?
-              type = type.resolve_parameters(pin.closure, context.return_type)
+              type = type.resolve_generics(pin.closure, context.return_type)
               # idx = pin.closure.parameters.index(type.subtypes.first.name)
               # next if idx.nil?
               # param_type = context.return_type.all_params[idx]

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -255,7 +255,7 @@ module Solargraph
           end
           closest = found.typify(api_map) if found
           if !found || found.is_a?(Pin::BaseVariable) || (closest.defined? && internal_or_core?(found))
-            unless closest.parameterized? || ignored_pins.include?(found)
+            unless closest.generic? || ignored_pins.include?(found)
               result.push Problem.new(location, "Unresolved call to #{missing.links.last.word}")
               @marked_ranges.push rng
             end

--- a/lib/yard-solargraph.rb
+++ b/lib/yard-solargraph.rb
@@ -25,6 +25,8 @@ YARD::Tags::Library.define_tag('ReturnSingleParameter', :return_single_parameter
 YARD::Tags::Library.define_tag('YieldparamSingleParameter', :yieldparam_single_parameter)
 # Define a @return_value_parameter tag for returning e.g. Hash values
 YARD::Tags::Library.define_tag('ReturnValueParameter', :return_value_parameter)
+# Define a @generic tag for documenting generic classes
+YARD::Tags::Library.define_tag('Generic', :generic, :with_title_and_text)
 # Define a @param_tuple tag for e.g. Hash#[]= parameters
 YARD::Tags::Library.define_tag('ParamTuple', :param_tuple)
 # Define a @!domain directive for documenting DSLs

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -297,7 +297,7 @@ describe Solargraph::ComplexType do
       name: 'bar',
       comments: '@return [Foo<String>]'
     )
-    type = return_type.resolve_parameters(generic_class, called_method)
+    type = return_type.resolve_parameters(generic_class, called_method.return_type)
     expect(type.tag).to eq('Array<String>')
   end
 end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -290,7 +290,7 @@ describe Solargraph::ComplexType do
   it 'resolves generic parameters' do
     api_map = Solargraph::ApiMap.new
     return_type = Solargraph::ComplexType.parse('Array<param<GenericTypeParam>>')
-    generic_class = Solargraph::Pin::Namespace.new(name: 'Foo', comments: '@param GenericTypeParam')
+    generic_class = Solargraph::Pin::Namespace.new(name: 'Foo', comments: '@generic GenericTypeParam')
     called_method = Solargraph::Pin::Method.new(
       location: Solargraph::Location.new('file:///foo.rb', Solargraph::Range.from_to(0, 0, 0, 0)),
       closure: generic_class,

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -286,4 +286,18 @@ describe Solargraph::ComplexType do
     result = type.qualify(api_map)
     expect(result.tag).to eq('String')
   end
+
+  it 'resolves generic parameters' do
+    api_map = Solargraph::ApiMap.new
+    return_type = Solargraph::ComplexType.parse('Array<param<GenericTypeParam>>')
+    generic_class = Solargraph::Pin::Namespace.new(name: 'Foo', comments: '@param GenericTypeParam')
+    called_method = Solargraph::Pin::Method.new(
+      location: Solargraph::Location.new('file:///foo.rb', Solargraph::Range.from_to(0, 0, 0, 0)),
+      closure: generic_class,
+      name: 'bar',
+      comments: '@return [Foo<String>]'
+    )
+    type = return_type.resolve_parameters(generic_class, called_method)
+    expect(type.tag).to eq('Array<String>')
+  end
 end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -270,12 +270,12 @@ describe Solargraph::ComplexType do
 
   it 'recognizes param types' do
     type = Solargraph::ComplexType.parse('generic<Variable>')
-    expect(type).to be_parameterized
+    expect(type).to be_generic
   end
 
   it 'recognizes parameterized parameters' do
     type = Solargraph::ComplexType.parse('Object<generic<Variable>>')
-    expect(type).to be_parameterized
+    expect(type).to be_generic
   end
 
   it 'reduces objects' do

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -269,12 +269,12 @@ describe Solargraph::ComplexType do
   end
 
   it 'recognizes param types' do
-    type = Solargraph::ComplexType.parse('param<Variable>')
+    type = Solargraph::ComplexType.parse('generic<Variable>')
     expect(type).to be_parameterized
   end
 
   it 'recognizes parameterized parameters' do
-    type = Solargraph::ComplexType.parse('Object<param<Variable>>')
+    type = Solargraph::ComplexType.parse('Object<generic<Variable>>')
     expect(type).to be_parameterized
   end
 
@@ -289,7 +289,7 @@ describe Solargraph::ComplexType do
 
   it 'resolves generic parameters' do
     api_map = Solargraph::ApiMap.new
-    return_type = Solargraph::ComplexType.parse('Array<param<GenericTypeParam>>')
+    return_type = Solargraph::ComplexType.parse('Array<generic<GenericTypeParam>>')
     generic_class = Solargraph::Pin::Namespace.new(name: 'Foo', comments: '@generic GenericTypeParam')
     called_method = Solargraph::Pin::Method.new(
       location: Solargraph::Location.new('file:///foo.rb', Solargraph::Range.from_to(0, 0, 0, 0)),
@@ -297,7 +297,7 @@ describe Solargraph::ComplexType do
       name: 'bar',
       comments: '@return [Foo<String>]'
     )
-    type = return_type.resolve_parameters(generic_class, called_method.return_type)
+    type = return_type.resolve_generics(generic_class, called_method.return_type)
     expect(type.tag).to eq('Array<String>')
   end
 end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -273,7 +273,7 @@ describe Solargraph::ComplexType do
     expect(type).to be_generic
   end
 
-  it 'recognizes parameterized parameters' do
+  it 'recognizes generic parameters' do
     type = Solargraph::ComplexType.parse('Object<generic<Variable>>')
     expect(type).to be_generic
   end

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -371,7 +371,7 @@ describe Solargraph::Library do
     expect(pins.map(&:path)).to include('Tagged::Example')
   end
 
-  it 'defines parameterized YARD tags' do
+  it 'defines generic YARD tags' do
     library = Solargraph::Library.new
     source = Solargraph::Source.load_string(%(
       class TaggedExample; end

--- a/spec/pin/namespace_spec.rb
+++ b/spec/pin/namespace_spec.rb
@@ -26,4 +26,9 @@ describe Solargraph::Pin::Namespace do
     expect(pin.name).to eq('Baz')
     expect(pin.path).to eq('Foo::Bar::Baz')
   end
+
+  it 'uses @param tags as generic type parameters' do
+    pin = Solargraph::Pin::Namespace.new(name: 'Foo', comments: '@param GenericType')
+    expect(pin.parameters).to eq(['GenericType'])
+  end
 end

--- a/spec/pin/namespace_spec.rb
+++ b/spec/pin/namespace_spec.rb
@@ -28,7 +28,7 @@ describe Solargraph::Pin::Namespace do
   end
 
   it 'uses @param tags as generic type parameters' do
-    pin = Solargraph::Pin::Namespace.new(name: 'Foo', comments: '@param GenericType')
+    pin = Solargraph::Pin::Namespace.new(name: 'Foo', comments: '@generic GenericType')
     expect(pin.parameters).to eq(['GenericType'])
   end
 end

--- a/spec/pin/namespace_spec.rb
+++ b/spec/pin/namespace_spec.rb
@@ -29,6 +29,6 @@ describe Solargraph::Pin::Namespace do
 
   it 'uses @param tags as generic type parameters' do
     pin = Solargraph::Pin::Namespace.new(name: 'Foo', comments: '@generic GenericType')
-    expect(pin.parameters).to eq(['GenericType'])
+    expect(pin.generics).to eq(['GenericType'])
   end
 end

--- a/spec/pin/parameter_spec.rb
+++ b/spec/pin/parameter_spec.rb
@@ -15,7 +15,7 @@ describe Solargraph::Pin::Parameter do
 
   it 'infers generic parameterized types' do
     source = Solargraph::Source.load_string(%(
-      # @param GenericTypeParam
+      # @generic GenericTypeParam
       class Foo
         # @return [Foo<String>]
         def self.bar

--- a/spec/pin/parameter_spec.rb
+++ b/spec/pin/parameter_spec.rb
@@ -21,7 +21,7 @@ describe Solargraph::Pin::Parameter do
         def self.bar
         end
 
-        # @yieldparam [param<GenericTypeParam>]
+        # @yieldparam [generic<GenericTypeParam>]
         def baz
         end
       end

--- a/spec/pin/parameter_spec.rb
+++ b/spec/pin/parameter_spec.rb
@@ -13,7 +13,7 @@ describe Solargraph::Pin::Parameter do
     expect(clip.infer.tag).to eq('Array')
   end
 
-  it 'infers generic parameterized types' do
+  it 'infers generic types' do
     source = Solargraph::Source.load_string(%(
       # @generic GenericTypeParam
       class Foo

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -180,7 +180,7 @@ describe Solargraph::Source::Chain::Call do
 
   it 'infers generic parameterized types' do
     source = Solargraph::Source.load_string(%(
-      # @param GenericTypeParam
+      # @generic GenericTypeParam
       class Foo
         # @return [Foo<String>]
         def self.bar

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -110,7 +110,7 @@ describe Solargraph::Source::Chain::Call do
     expect(type.tag).to eq('String')
   end
 
-  it 'infers parameterized types' do
+  it 'infers generic types' do
     source = Solargraph::Source.load_string(%(
       # @type [Array<String>]
       list = array_of_strings
@@ -178,7 +178,7 @@ describe Solargraph::Source::Chain::Call do
     expect(type.tag).to eq('Integer')
   end
 
-  it 'infers generic parameterized types' do
+  it 'infers generic types' do
     source = Solargraph::Source.load_string(%(
       # @generic GenericTypeParam
       class Foo
@@ -223,7 +223,7 @@ describe Solargraph::Source::Chain::Call do
     expect(type.tag).to eq('Integer')
   end
 
-  it 'infers parameterized types from union type' do
+  it 'infers generic types from union type' do
     source = Solargraph::Source.load_string(%(
       # @type [String, Array<Integer>]
       list = string_or_integer

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -178,6 +178,32 @@ describe Solargraph::Source::Chain::Call do
     expect(type.tag).to eq('Integer')
   end
 
+  it 'infers generic parameterized types' do
+    source = Solargraph::Source.load_string(%(
+      # @param GenericTypeParam
+      class Foo
+        # @return [Foo<String>]
+        def self.bar
+        end
+
+        # @return [Array<param<GenericTypeParam>>]
+        def baz
+        end
+      end
+
+      Foo.bar.baz
+      Foo.bar.baz.first
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(12, 15))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    expect(type.tag).to eq('Array<String>')
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(13, 20))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    expect(type.tag).to eq('String')
+  end
+
   it 'infers types from union type' do
     source = Solargraph::Source.load_string(%(
       # @type [String, Float]

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -186,7 +186,7 @@ describe Solargraph::Source::Chain::Call do
         def self.bar
         end
 
-        # @return [Array<param<GenericTypeParam>>]
+        # @return [Array<generic<GenericTypeParam>>]
         def baz
         end
       end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1452,7 +1452,7 @@ describe Solargraph::SourceMap::Clip do
     expect(clip.complete.pins.map(&:path)).to include('TaggedExample')
   end
 
-  it 'completes parameterized YARD tags' do
+  it 'completes generic YARD tags' do
     source = Solargraph::Source.load_string(%(
       class TaggedExample
       end

--- a/spec/type_checker/checks_spec.rb
+++ b/spec/type_checker/checks_spec.rb
@@ -111,7 +111,7 @@ describe Solargraph::TypeChecker::Checks do
     expect(match).to be(true)
   end
 
-  it 'validates parameterized classes with expected Class' do
+  it 'validates generic classes with expected Class' do
     api_map = Solargraph::ApiMap.new
     exp = Solargraph::ComplexType.parse('Class<String>')
     inf = Solargraph::ComplexType.parse('Class')

--- a/spec/type_checker/levels/normal_spec.rb
+++ b/spec/type_checker/levels/normal_spec.rb
@@ -414,7 +414,7 @@ describe Solargraph::TypeChecker do
       expect(checker.problems).to be_empty
     end
 
-    it 'ignores parameterized blocks' do
+    it 'ignores blocks with parameters' do
       checker = type_checker(%(
         class Foo
           def bar &block
@@ -871,7 +871,7 @@ describe Solargraph::TypeChecker do
       expect(checker.problems).to be_empty
     end
 
-    it 'accepts Hash#[] calls for parameterized Hash types' do
+    it 'accepts Hash#[] calls for generic Hash types' do
       checker = type_checker(%(
         # @type [Hash{String => String}]
         x = {}

--- a/spec/type_checker/levels/typed_spec.rb
+++ b/spec/type_checker/levels/typed_spec.rb
@@ -122,7 +122,7 @@ describe Solargraph::TypeChecker do
       expect(checker.problems).to be_empty
     end
 
-    it 'validates parameterized return types with unparameterized arrays' do
+    it 'validates generic return types with non-generic arrays' do
       checker = type_checker(%(
         class Foo
           # @return [Array<String>]
@@ -134,7 +134,7 @@ describe Solargraph::TypeChecker do
       expect(checker.problems).to be_empty
     end
 
-    it 'validates parameterized return types with unparameterized hashes' do
+    it 'validates generic return types with non-generic hashes' do
       checker = type_checker(%(
         class Foo
           # @return [Hash{String => Integer}]
@@ -176,7 +176,7 @@ describe Solargraph::TypeChecker do
       # expect(checker.problems.first.message).to include('does not match inferred type')
     end
 
-    it 'validates parameterized subclasses of return types' do
+    it 'validates generic subclasses of return types' do
       checker = type_checker(%(
         class Sup; end
         class Sub < Sup


### PR DESCRIPTION
Closes: https://github.com/castwide/solargraph/issues/681

This PR adds type inference for generics/parameterized params for `@return` and `@yieldparam` tags.

I went with `@param` instead of adding a custom tag for simplicity reasons. The tag is already parsed by YARDoc. Also, I think it's better to have fewer tags for developers to memorize. 

Does it make sense to you? Let me know if you have another opinion here.
 
<details><summary>Screenshots</summary>
<p>
	<img width="787" alt="Screenshot 2025-02-13 at 21 07 36" src="https://github.com/user-attachments/assets/6c2d3da3-0678-4982-ba30-06db27cd014a" />
	<img width="890" alt="Screenshot 2025-02-13 at 22 40 58" src="https://github.com/user-attachments/assets/d5b50b5f-7531-4f0d-97db-f5f39ebb340f" />
	<img width="673" alt="Screenshot 2025-02-13 at 22 43 22" src="https://github.com/user-attachments/assets/36c8166b-9bba-4779-974f-d823170d760e" />
</p>
</details> 

### Next steps

- [ ] Adjust documentation accordingly based on inferred types - right now raw yardoc `[param<...>]` is returned. 		<details><summary>Example</summary>
		<img width="624" alt="Screenshot 2025-02-13 at 22 52 22" src="https://github.com/user-attachments/assets/5eba41b1-9a3d-4958-ad62-9706c6bb710c" />
		</details> 

- [ ] Deprecate `@return_single_parameter` and `@yieldparam_single_parameter`(?)
