### PR TITLE
Handle symbol tags in method tag values

### DIFF
--- a/lib/solargraph/source_map/mapper.rb
+++ b/lib/solargraph/source_map/mapper.rb
@@ -107,7 +107,8 @@ module Solargraph
           begin
             src = Solargraph::Source.load_string("def #{directive.tag.name};end", @source.filename)
             region = Parser::Region.new(source: src, closure: namespace)
-            gen_pin = Parser.process_node(src.node, region).first.last
+            method_gen_pins = Parser.process_node(src.node, region).first.select { |pin| pin.is_a?(Pin::Method) }
+            gen_pin = method_gen_pins.last
             return if gen_pin.nil?
             # Move the location to the end of the line so it gets recognized
             # as originating from a comment

--- a/spec/source_map/mapper_spec.rb
+++ b/spec/source_map/mapper_spec.rb
@@ -106,11 +106,23 @@ describe Solargraph::SourceMap::Mapper do
       class Foo
         # @!method bar(baz)
         #   @return [String]
+        # @!method bing(bazzle = 'anchor')
+        #   @return [String]
+        # @!method bravo(charlie = :delta)
+        #   @return [String]
         make_bar_attr
+        make_bing_attr
+        make_bravo_attr
       end
     ))
     pin = map.first_pin('Foo#bar')
     expect(pin.parameter_names).to eq(['baz'])
+    expect(pin.return_type.tag).to eq('String')
+    pin = map.first_pin('Foo#bing')
+    expect(pin.parameter_names).to eq(['bazzle'])
+    expect(pin.return_type.tag).to eq('String')
+    pin = map.first_pin('Foo#bravo')
+    expect(pin.parameter_names).to eq(['charlie'])
     expect(pin.return_type.tag).to eq('String')
   end
 


### PR DESCRIPTION
Ensure that symbol-typed default values for method arguments in @!method tags don't have their method pin get disregarded because of the extra symbol pin created.