### PR TITLE
Don't require redundant attribute @return and @param tags

### DIFF
--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -26,6 +26,61 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.first.message).to include('Missing @param tag')
     end
 
+    it 'reports missing param and return tags on writers when instance variable type not defined' do
+      checker = type_checker(%(
+        class Foo
+          attr_writer :bar
+        end
+      ))
+      expect(checker.problems.map(&:message)).to include('Missing @param tag for value on Foo#bar=')
+      expect(checker.problems.map(&:message)).to include('Missing @return tag for Foo#bar=')
+    end
+
+    it 'reports missing return tags on readers when instance variable type not defined' do
+      checker = type_checker(%(
+        class Foo
+          attr_reader :bar
+        end
+      ))
+      expect(checker.problems).to be_one
+      expect(checker.problems.first.message).to include('Missing @return tag')
+    end
+
+    it 'ignores missing return tags on readers when instance variable type not defined' do
+      checker = type_checker(%(
+        class Foo
+          # @param bar [String]
+          def initialize(bar)
+            @bar = bar
+          end
+
+          attr_reader :bar
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
+    it 'ignores missing param and return tags on writers when instance variable type defined' do
+      checker = type_checker(%(
+
+        class Foo
+          # @param bar [String]
+          def initialize(bar)
+            @bar = bar
+          end
+
+          attr_writer :bar
+        end
+        class Bar
+          # @param baz [String]
+          def initialize(baz)
+            @baz = baz
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     it 'reports missing kwoptarg param tags' do
       checker = type_checker(%(
         class Foo


### PR DESCRIPTION
If the underlying instance variable is already typed (either via @type or via creation from a typed initializer param), don't require attributes (e.g., attr_accessor, attr_reader, etc.) to have redundant @return and @param tags, even under strong typechecking.