### PR TITLE
Use @yieldreturn tags for type inference

### DIFF
--- a/lib/solargraph/parser/legacy/node_chainer.rb
+++ b/lib/solargraph/parser/legacy/node_chainer.rb
@@ -95,6 +95,9 @@ module Solargraph
           elsif n.type == :super
             args = n.children.map { |c| NodeChainer.chain(c) }
             result.push Chain::Call.new('super', args, @in_block > 0 || block_passed?(n))
+          elsif n.type == :yield
+            args = n.children.map { |c| NodeChainer.chain(c) }
+            result.push Chain::Call.new('yield', args, @in_block > 0 || block_passed?(n))
           elsif n.type == :const
             const = unpack_name(n)
             result.push Chain::Constant.new(const)

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -1,18 +1,26 @@
 module Solargraph
   module Pin
-    class Signature
+    class Signature < Base
       # @return [Array<Parameter>]
       attr_reader :parameters
 
       # @return [ComplexType]
       attr_reader :return_type
 
+      # @return [self]
       attr_reader :block
 
+      # @param parameters [Array<Parameter>]
+      # @param return_type [ComplexType]
+      # @param block [Signature]
       def initialize parameters, return_type, block = nil
         @parameters = parameters
         @return_type = return_type
         @block = block
+      end
+
+      def identity
+        @identity ||= "signature#{object_id}"
       end
 
       def block?

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -29,6 +29,7 @@ module Solargraph
         # @param locals [Array<Pin::Base>]
         def resolve api_map, name_pin, locals
           return super_pins(api_map, name_pin) if word == 'super'
+          return yield_pins(api_map, name_pin) if word == 'yield'
           found = if head?
             locals.select { |p| p.name == word }
           else
@@ -201,6 +202,16 @@ module Solargraph
         def super_pins api_map, name_pin
           pins = api_map.get_method_stack(name_pin.namespace, name_pin.name, scope: name_pin.context.scope)
           pins.reject{|p| p.path == name_pin.path}
+        end
+
+        # @param api_map [ApiMap]
+        # @param name_pin [Pin::Base]
+        # @return [Array<Pin::Base>]
+        def yield_pins api_map, name_pin
+          method_pin = api_map.get_method_stack(name_pin.namespace, name_pin.name, scope: name_pin.context.scope).first
+          return [] if method_pin.nil?
+
+          method_pin.signatures.map(&:block).compact
         end
 
         # @param type [ComplexType]

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -26,10 +26,12 @@ describe Solargraph::Pin::Method do
   end
 
   it "includes param tags in documentation" do
-    comments = %(
+    # Yard wants to be handed data without comment markers or leading
+    # whitespace, so we use <<~
+    comments = <<~COMMENTS
       @param one [First] description1
       @param two [Second] description2
-    )
+    COMMENTS
     # pin = source.pins.select{|pin| pin.path == 'Foo#bar'}.first
     pin = Solargraph::Pin::Method.new(comments: comments)
     expect(pin.documentation).to include('one')
@@ -38,6 +40,30 @@ describe Solargraph::Pin::Method do
     expect(pin.documentation).to include('two')
     expect(pin.documentation).to include('[Second]')
     expect(pin.documentation).to include('description2')
+  end
+
+  it "includes yieldparam tags in documentation" do
+    comments = <<~COMMENTS
+      @yieldparam one [First] description1
+      @yieldparam two [Second] description2
+    COMMENTS
+    # pin = source.pins.select{|pin| pin.path == 'Foo#bar'}.first
+    pin = Solargraph::Pin::Method.new(comments: comments)
+    expect(pin.documentation).to include('[First]')
+    expect(pin.documentation).to include('description1')
+    expect(pin.documentation).to include('two')
+    expect(pin.documentation).to include('[Second]')
+    expect(pin.documentation).to include('description2')
+  end
+
+  it "includes yieldreturn tag in documentation" do
+    comments = <<~COMMENTS
+      @yieldreturn [YRet] yretdescription
+      @return [String]
+    COMMENTS
+    pin = Solargraph::Pin::Method.new(comments: comments)
+    expect(pin.documentation).to include('YRet')
+    expect(pin.documentation).to include('yretdescription')
   end
 
   it "detects return types from tags" do


### PR DESCRIPTION
* Track yield calls similarly to super() calls in source chains
* Add a block's Signature pin in method Signature when block parameter declared or documented
* Include info from yieldparam/yieldreturn tags in that block Signature pin when they exist
* Teach Signature pin to be included in inference chains
* Fix a docstring-related test bug in method_spec.rb
* Include yieldparam/yieldreturn info in method documentation from LSP
* Add misc inference specs to lock down existing related behavior
* Add ability to method return types based on yield call's @yieldreturn