### PR TITLE
Fix type annotations identified at 'typed' level

### DIFF
--- a/lib/solargraph.rb
+++ b/lib/solargraph.rb
@@ -56,8 +56,6 @@ module Solargraph
 
   # A helper method that runs Bundler.with_unbundled_env or falls back to
   # Bundler.with_clean_env for earlier versions of Bundler.
-  #
-  # @return [void]
   def self.with_clean_env &block
     meth = if Bundler.respond_to?(:with_original_env)
       :with_original_env

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -137,7 +137,7 @@ module Solargraph
       api_map
     end
 
-    # @return [Array<Solargraph::Pin::Base>]
+    # @return [Enumerable<Solargraph::Pin::Base>]
     def pins
       store.pins
     end
@@ -245,12 +245,12 @@ module Solargraph
       prefer_non_nil_variables(store.get_class_variables(namespace))
     end
 
-    # @return [Array<Solargraph::Pin::Base>]
+    # @return [Enumerable<Solargraph::Pin::Base>]
     def get_symbols
       store.get_symbols
     end
 
-    # @return [Array<Solargraph::Pin::GlobalVariable>]
+    # @return [Enumerable<Solargraph::Pin::GlobalVariable>]
     def get_global_variable_pins
       store.pins_by_class(Pin::GlobalVariable)
     end

--- a/lib/solargraph/api_map/cache.rb
+++ b/lib/solargraph/api_map/cache.rb
@@ -4,6 +4,7 @@ module Solargraph
   class ApiMap
     class Cache
       def initialize
+        # @type [Hash{Array => Array<Pin::Method>}]
         @methods = {}
         @constants = {}
         @qualified_namespaces = {}
@@ -15,6 +16,7 @@ module Solargraph
         @methods[[fqns, scope, visibility.sort, deep]]
       end
 
+      # @return [Array<Pin::Method>]
       def set_methods fqns, scope, visibility, deep, value
         @methods[[fqns, scope, visibility.sort, deep]] = value
       end

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -42,7 +42,7 @@ module Solargraph
     end
 
     # @yieldparam [UniqueType]
-    # @return [Array]
+    # @return [Enumerator<UniqueType>]
     def each &block
       @items.each &block
     end

--- a/lib/solargraph/documentor.rb
+++ b/lib/solargraph/documentor.rb
@@ -56,7 +56,7 @@ module Solargraph
     end
 
     # @param directory [String]
-    # @return [Hash]
+    # @return [Hash{String => BasicObject}]
     def self.specs_from_bundle directory
       Solargraph.with_clean_env do
         cmd = [

--- a/lib/solargraph/parser/comment_ripper.rb
+++ b/lib/solargraph/parser/comment_ripper.rb
@@ -42,6 +42,7 @@ module Solargraph
         result
       end
 
+      # @return [Hash{Integer => String}]
       def parse
         @comments = {}
         super

--- a/lib/solargraph/parser/legacy/class_methods.rb
+++ b/lib/solargraph/parser/legacy/class_methods.rb
@@ -5,7 +5,7 @@ module Solargraph
     module Legacy
       module ClassMethods
         # @param code [String]
-        # @param filename [String]
+        # @param filename [String, nil]
         # @return [Array(Parser::AST::Node, Array<Parser::Source::Comment>)]
         def parse_with_comments code, filename = nil
           buffer = ::Parser::Source::Buffer.new(filename, 0)
@@ -128,7 +128,7 @@ module Solargraph
             end
           end
           result
-        end  
+        end
       end
     end
   end

--- a/lib/solargraph/parser/legacy/node_chainer.rb
+++ b/lib/solargraph/parser/legacy/node_chainer.rb
@@ -10,7 +10,7 @@ module Solargraph
         Chain = Source::Chain
 
         # @param node [Parser::AST::Node]
-        # @param filename [String]
+        # @param filename [String, nil]
         def initialize node, filename = nil, in_block = false
           @node = node
           @filename = filename
@@ -25,7 +25,7 @@ module Solargraph
 
         class << self
           # @param node [Parser::AST::Node]
-          # @param filename [String]
+          # @param filename [String, nil]
           # @return [Source::Chain]
           def chain node, filename = nil, in_block = false
             NodeChainer.new(node, filename, in_block).chain

--- a/lib/solargraph/parser/region.rb
+++ b/lib/solargraph/parser/region.rb
@@ -23,7 +23,7 @@ module Solargraph
 
       # @param source [Source]
       # @param namespace [String]
-      # @param scope [Symbol]
+      # @param scope [Symbol, nil]
       # @param visibility [Symbol]
       def initialize source: Solargraph::Source.load_string(''), closure: nil,
                      scope: nil, visibility: :public, lvars: []

--- a/lib/solargraph/parser/rubyvm/node_chainer.rb
+++ b/lib/solargraph/parser/rubyvm/node_chainer.rb
@@ -11,7 +11,7 @@ module Solargraph
         Chain = Source::Chain
 
         # @param node [Parser::AST::Node]
-        # @param filename [String]
+        # @param filename [String, nil]
         def initialize node, filename = nil, in_block = false
           @node = node
           @filename = filename
@@ -26,7 +26,7 @@ module Solargraph
 
         class << self
           # @param node [Parser::AST::Node]
-          # @param filename [String]
+          # @param filename [String, nil]
           # @return [Source::Chain]
           def chain node, filename = nil, in_block = false
             NodeChainer.new(node, filename, in_block).chain

--- a/lib/solargraph/pin/delegated_method.rb
+++ b/lib/solargraph/pin/delegated_method.rb
@@ -12,7 +12,7 @@ module Solargraph
       # to a method pin on that type.
       #
       # @param resolved_method [Method] an already resolved method pin.
-      # @param receiver [Source::Chain] the source code used to resolve the receiver for this delegated method.
+      # @param receiver [Source::Chain, nil] the source code used to resolve the receiver for this delegated method.
       # @param receiver_method_name [String] the method name that will be called on the receiver (defaults to :name).
       def initialize(method: nil, receiver: nil, name: method&.name, receiver_method_name: name, **splat)
         raise ArgumentError, 'either :method or :receiver is required' if (method && receiver) || (!method && !receiver)

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -19,7 +19,7 @@ module Solargraph
       # @param visibility [::Symbol] :public, :protected, or :private
       # @param explicit [Boolean]
       # @param parameters [Array<Pin::Parameter>]
-      # @param node [Parser::AST::Node, RubyVM::AbstractSyntaxTree::Node]
+      # @param node [Parser::AST::Node, RubyVM::AbstractSyntaxTree::Node, nil]
       # @param attribute [Boolean]
       def initialize visibility: :public, explicit: true, parameters: [], node: nil, attribute: false, signatures: nil, anon_splat: false, **splat
         super(**splat)

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -25,6 +25,7 @@ module Solargraph
 
       private
 
+      # @return Hash{String => RBS::AST::Declarations::TypeAlias}
       def type_aliases
         @type_aliases ||= {}
       end
@@ -329,6 +330,7 @@ module Solargraph
         )
       end
 
+      # @param decl [RBS::AST::Members::Alias]
       def alias_to_pin decl, closure
         pins.push Solargraph::Pin::MethodAlias.new(
           name: decl.new_name.to_s,
@@ -345,6 +347,8 @@ module Solargraph
         'NilClass' => 'nil'
       }
 
+      # @param type [RBS::AST::Members::MethodDefinition::Overload]
+      # @return [String]
       def method_type_to_tag type
         if type_aliases.key?(type.type.return_type.to_s)
           other_type_to_tag(type_aliases[type.type.return_type.to_s].type)

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -33,7 +33,7 @@ module Solargraph
     attr_reader :version
 
     # @param code [String]
-    # @param filename [String]
+    # @param filename [String, nil]
     # @param version [Integer]
     def initialize code, filename = nil, version = 0
       @code = normalize(code)
@@ -332,7 +332,7 @@ module Solargraph
 
     # @param top [Parser::AST::Node]
     # @param result [Array<Range>]
-    # @param parent [Symbol]
+    # @param parent [Symbol, nil]
     # @return [void]
     def inner_folding_ranges top, result = [], parent = nil
       return unless Parser.is_ast_node?(top)
@@ -503,7 +503,7 @@ module Solargraph
       end
 
       # @param code [String]
-      # @param filename [String]
+      # @param filename [String, nil]
       # @param version [Integer]
       # @return [Solargraph::Source]
       def load_string code, filename = nil, version = 0

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -31,12 +31,12 @@ module Solargraph
       UNDEFINED_CALL = Chain::Call.new('<undefined>')
       UNDEFINED_CONSTANT = Chain::Constant.new('<undefined>')
 
-      # @return [Array<Source::Chain::Link>]
+      # @return [::Array<Source::Chain::Link>]
       attr_reader :links
 
       attr_reader :node
 
-      # @param links [Array<Chain::Link>]
+      # @param links [::Array<Chain::Link>]
       def initialize links, node = nil, splat = false
         @links = links.clone
         @links.push UNDEFINED_CALL if @links.empty?
@@ -58,7 +58,7 @@ module Solargraph
       # @param api_map [ApiMap]
       # @param name_pin [Pin::Base]
       # @param locals [Array<Pin::Base>]
-      # @return [Array<Pin::Base>]
+      # @return [::Array<Pin::Base>]
       def define api_map, name_pin, locals
         return [] if undefined?
         working_pin = name_pin

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -11,7 +11,7 @@ module Solargraph
         attr_reader :arguments
 
         # @param word [String]
-        # @param arguments [Array<Chain>]
+        # @param arguments [::Array<Chain>]
         # @param with_block [Boolean] True if the chain is inside a block
         # @param head [Boolean] True if the call is the start of its chain
         def initialize word, arguments = [], with_block = false
@@ -197,7 +197,7 @@ module Solargraph
 
         # @param api_map [ApiMap]
         # @param name_pin [Pin::Base]
-        # @return [Array<Pin::Base>]
+        # @return [::Array<Pin::Base>]
         def super_pins api_map, name_pin
           pins = api_map.get_method_stack(name_pin.namespace, name_pin.name, scope: name_pin.context.scope)
           pins.reject{|p| p.path == name_pin.path}

--- a/lib/solargraph/source/chain/link.rb
+++ b/lib/solargraph/source/chain/link.rb
@@ -24,7 +24,7 @@ module Solargraph
         # @param api_map [ApiMap]
         # @param name_pin [Pin::Base]
         # @param locals [Array<Pin::Base>]
-        # @return [Array<Pin::Base>]
+        # @return [::Array<Pin::Base>]
         def resolve api_map, name_pin, locals
           []
         end

--- a/lib/solargraph/source/chain/z_super.rb
+++ b/lib/solargraph/source/chain/z_super.rb
@@ -20,7 +20,7 @@ module Solargraph
 
         # @param api_map [ApiMap]
         # @param name_pin [Pin::Base]
-        # @param locals [Array<Pin::Base>]
+        # @param locals [::Array<Pin::Base>]
         def resolve api_map, name_pin, locals
           return super_pins(api_map, name_pin)
         end

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -22,7 +22,7 @@ module Solargraph
     attr_reader :api_map
 
     # @param filename [String]
-    # @param api_map [ApiMap]
+    # @param api_map [ApiMap, nil]
     # @param level [Symbol]
     def initialize filename, api_map: nil, level: :normal
       @filename = filename

--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -145,7 +145,7 @@ module Solargraph
       @cache ||= YardMap::Cache.new
     end
 
-    # @return [Hash]
+    # @return [Hash{Class => Set<Pin::Base>}]
     def pin_class_hash
       @pin_class_hash ||= pins.to_set.classify(&:class).transform_values(&:to_a)
     end

--- a/lib/solargraph/yard_map/mapper.rb
+++ b/lib/solargraph/yard_map/mapper.rb
@@ -8,7 +8,7 @@ module Solargraph
       autoload :ToConstant, 'solargraph/yard_map/mapper/to_constant'
 
       # @param code_objects [Array<YARD::CodeObjects::Base>]
-      # @param spec [Gem::Specification]
+      # @param spec [Gem::Specification, nil]
       def initialize code_objects, spec = nil
         @code_objects = code_objects
         @spec = spec


### PR DESCRIPTION
This doesn't get the codebase to be --level=typed clean yet, but does get rid of the easy things.