### PR TITLE
Avoid discarding 'rooted?' information in Pin::Method#return_type

### DIFF
--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -10,9 +10,9 @@ module Solargraph
     autoload :TypeMethods, 'solargraph/complex_type/type_methods'
     autoload :UniqueType,  'solargraph/complex_type/unique_type'
 
-    # @param types [Array<UniqueType>]
+    # @param types [Array<[UniqueType, ComplexType]>]
     def initialize types = [UniqueType::UNDEFINED]
-      @items = types.uniq(&:to_s)
+      @items = types.flat_map(&:items).uniq(&:to_s)
     end
 
     # @param api_map [ApiMap]
@@ -132,9 +132,9 @@ module Solargraph
       @items.first.all_params || []
     end
 
-    protected
-
     attr_reader :items
+
+    protected
 
     def reduce_object
       return self if name != 'Object' || subtypes.empty?

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -51,10 +51,14 @@ module Solargraph
         tag
       end
 
+      def items
+        [self]
+      end
+
       def to_rbs
         "#{namespace}#{parameters? ? "[#{subtypes.map { |s| s.to_rbs }.join(', ')}]" : ''}"
       end
-  
+
       def parameterized?
         name == 'param' || all_params.any?(&:parameterized?)
       end
@@ -124,7 +128,7 @@ module Solargraph
       def selfy?
         @name == 'self' || @key_types.any?(&:selfy?) || @subtypes.any?(&:selfy?)
       end
-  
+
       UNDEFINED = UniqueType.new('undefined')
       BOOLEAN = UniqueType.new('Boolean')
     end

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -46,7 +46,7 @@ module Solargraph
       end
 
       def return_type
-        @return_type ||= ComplexType.try_parse(*signatures.map(&:return_type).map(&:to_s))
+        @return_type ||= ComplexType.new(signatures.map(&:return_type).flat_map(&:items))
       end
 
       # @return [Array<Signature>]

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -47,6 +47,16 @@ describe Solargraph::ComplexType do
     expect(types.first.scope).to eq(:instance)
   end
 
+  it "identify rooted types" do
+    types = Solargraph::ComplexType.parse '::Array'
+    expect(types.map(&:rooted?)).to eq([true])
+  end
+
+  it "identify unrooted types" do
+    types = Solargraph::ComplexType.parse 'Array'
+    expect(types.map(&:rooted?)).to eq([false])
+  end
+
   it "detects namespace and scope for classes with subtypes" do
     types = Solargraph::ComplexType.parse 'Class<String>'
     expect(types.length).to eq(1)


### PR DESCRIPTION
Solargraph gets confused when a return type's name exists at multiple levels - e.g., "@return [::Array]" in a Pin class method is understood as Solargraph::Pin::Array instead of Ruby's provided Array class.

Avoid that issue by avoiding unnecessary round-trip serialization of UniqueType objects via #to_s, which is ambiguous as it doesn't include the '::' prefix.