### PR TITLE
Fix inference of begin expression types

### DIFF
--- a/lib/solargraph/parser/legacy/node_chainer.rb
+++ b/lib/solargraph/parser/legacy/node_chainer.rb
@@ -116,7 +116,7 @@ module Solargraph
           elsif n.type == :or
             result.push Chain::Or.new([NodeChainer.chain(n.children[0], @filename), NodeChainer.chain(n.children[1], @filename)])
           elsif [:begin, :kwbegin].include?(n.type)
-            result.concat generate_links(n.children[0])
+            result.concat generate_links(n.children.last)
           elsif n.type == :block_pass
             block_variable_name_node = n.children[0]
             if block_variable_name_node.nil?

--- a/spec/source/chain_spec.rb
+++ b/spec/source/chain_spec.rb
@@ -140,6 +140,32 @@ describe Solargraph::Source::Chain do
     }.not_to raise_error
   end
 
+  it "pulls types from multiple lines of code" do
+    source = Solargraph::Source.load_string(%(
+      123
+      'abc'
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(2, 11))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, [])
+    expect(type.to_s).to eq('String')
+  end
+
+  it "uses last line of a begin expression as return type" do
+    source = Solargraph::Source.load_string(%(
+      begin
+        123
+        'abc'
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(4, 9))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, [])
+    expect(type.to_s).to eq('String')
+  end
+
   it "matches constants on complete symbols" do
     source = Solargraph::Source.load_string(%(
       class Correct; end


### PR DESCRIPTION
Currently the first line of a begin...end expression is used as the type of the expression; instead, the last line should be used.