### PR TITLE
Add argument to satisfy typechecker on which signature to use

### DIFF
--- a/lib/solargraph/rbs_map.rb
+++ b/lib/solargraph/rbs_map.rb
@@ -57,7 +57,7 @@ module Solargraph
     # @return [Boolean] true if adding the library succeeded
     def add_library loader, library
       @resolved = if loader.has_library?(library: library, version: nil)
-        loader.add library: library
+        loader.add library: library, version: nil
         Solargraph.logger.info "#{short_name} successfully loaded library #{library}"
         true
       else


### PR DESCRIPTION
This gets rid of a typecheck error on the solargraph codebase--the RBS for the method called has two signatures, and without the additional argument in the call neither signature is satisified.

It works in practice because the single implementation already defaults this 'version' argument to nil.