### PR TITLE
Generic module support through RBS

### DIFF
--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -149,7 +149,8 @@ module Solargraph
           type: :module,
           name: decl.name.relative!.to_s,
           closure: Solargraph::Pin::ROOT_PIN,
-          comments: decl.comment&.string
+          comments: decl.comment&.string,
+          parameters: decl.type_params.map(&:name).map(&:to_s),
         )
         pins.push module_pin
         convert_members_to_pin decl, module_pin

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -150,7 +150,7 @@ module Solargraph
           name: decl.name.relative!.to_s,
           closure: Solargraph::Pin::ROOT_PIN,
           comments: decl.comment&.string,
-          parameters: decl.type_params.map(&:name).map(&:to_s),
+          generics: decl.type_params.map(&:name).map(&:to_s),
         )
         pins.push module_pin
         convert_members_to_pin decl, module_pin

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -144,7 +144,7 @@ describe Solargraph::Source::Chain::Call do
     source = Solargraph::Source.load_string(%(
       # @generic GenericTypeParam
       module Foo
-        # @return [Array<param<GenericTypeParam>>]
+        # @return [Array<generic<GenericTypeParam>>]
         def baz
         end
       end

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -140,6 +140,45 @@ describe Solargraph::Source::Chain::Call do
     expect(type.tag).to eq('String')
   end
 
+  it 'infers generic parameterized types through module inclusion' do
+    source = Solargraph::Source.load_string(%(
+      # @generic GenericTypeParam
+      module Foo
+        # @return [Array<param<GenericTypeParam>>]
+        def baz
+        end
+      end
+
+      class Baz
+        # @return [Baz<String>]
+        def self.bar
+        end
+
+        include Foo
+      end
+
+      Baz.bar.baz
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(16, 15))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    expect(type.tag).to eq('Array<String>')
+  end
+
+  it 'infers generic parameterized types through module inclusion via RBS definition of module' do
+    source = Solargraph::Source.load_string(%(
+      foo = ['bar'].to_set
+
+      foo
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(3, 9))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    expect(type.tag).to eq('Set<String>')
+  end
+
   it 'infers method return types' do
     source = Solargraph::Source.load_string(%(
       def bar


### PR DESCRIPTION
Allow support for generic modules like 'Enumerable<String>' to provide methods to Array<String> by reading module typeparams from RBS just like we read class typeparams today.