### PR TITLE
DeepInference: Fix some bugs, add docs, refactor

### DIFF
--- a/lib/solargraph/cache.rb
+++ b/lib/solargraph/cache.rb
@@ -23,6 +23,7 @@ module Solargraph
         File.join(base_dir, "ruby-#{RUBY_VERSION}", "rbs-#{RBS::VERSION}", "solargraph-#{Solargraph::VERSION}")
       end
 
+      # @param path [Array<String>]
       # @return [Array<Solargraph::Pin::Base>, nil]
       def load *path
         file = File.join(work_dir, *path)
@@ -45,6 +46,7 @@ module Solargraph
         true
       end
 
+      # @return [void]
       def clear
         FileUtils.rm_rf base_dir, secure: true
       end

--- a/lib/solargraph/parser/legacy/class_methods.rb
+++ b/lib/solargraph/parser/legacy/class_methods.rb
@@ -100,6 +100,8 @@ module Solargraph
           parser.version
         end
 
+        # @param node [BasicObject]
+        # @return [Boolean]
         def is_ast_node? node
           node.is_a?(::Parser::AST::Node)
         end

--- a/lib/solargraph/parser/legacy/node_methods.rb
+++ b/lib/solargraph/parser/legacy/node_methods.rb
@@ -1,7 +1,23 @@
 # frozen_string_literal: true
 
 require 'parser'
+require 'ast'
 
+# Teach AST::Node#children about its generic type
+#
+# @todo contribute back to https://github.com/ruby/gem_rbs_collection/blob/main/gems/ast/2.4/ast.rbs
+#
+# @!parse
+#   module ::AST
+#     class Node
+#       # New children
+#
+#       # @return [Array<AST::Node>]
+#       attr_reader :children
+#     end
+#   end
+
+# https://github.com/whitequark/parser
 module Solargraph
   module Parser
     module Legacy
@@ -17,6 +33,7 @@ module Solargraph
         # @param node [Parser::AST::Node]
         # @return [Array<String>]
         def pack_name(node)
+          # @type [Array<String>]
           parts = []
           if node.is_a?(AST::Node)
             node.children.each { |n|
@@ -75,6 +92,10 @@ module Solargraph
           Position.new(node.loc.last_line, node.loc.last_column)
         end
 
+        # @param node [Parser::AST::Node]
+        # @param signature [String]
+        #
+        # @return [String]
         def drill_signature node, signature
           return signature unless node.is_a?(AST::Node)
           if node.type == :const or node.type == :cbase
@@ -96,6 +117,8 @@ module Solargraph
           signature
         end
 
+        # @param node [Parser::AST::Node]
+        # @return [Hash{Parser::AST::Node => Chain}]
         def convert_hash node
           return {} unless Parser.is_ast_node?(node)
           return convert_hash(node.children[0]) if node.type == :kwsplat
@@ -110,6 +133,9 @@ module Solargraph
 
         NIL_NODE = ::Parser::AST::Node.new(:nil)
 
+        # @param node [Parser::AST::Node]
+        #
+        # @return [Array<Parser::AST::Node>]
         def const_nodes_from node
           return [] unless Parser.is_ast_node?(node)
           result = []
@@ -121,20 +147,25 @@ module Solargraph
           result
         end
 
+        # @param node [Parser::AST::Node]
         def splatted_hash? node
           Parser.is_ast_node?(node.children[0]) && node.children[0].type == :kwsplat
         end
 
+        # @param node [Parser::AST::Node]
         def splatted_call? node
           return false unless Parser.is_ast_node?(node)
           Parser.is_ast_node?(node.children[0]) && node.children[0].type == :kwsplat && node.children[0].children[0].type != :hash
         end
 
+        # @param nodes [Enumerable<Parser::AST::Node>]
         def any_splatted_call?(nodes)
           nodes.any? { |n| splatted_call?(n) }
         end
 
         # @todo Temporarily here for testing. Move to Solargraph::Parser.
+        # @param node [Parser::AST::Node]
+        # @return [Array<Parser::AST::Node>]
         def call_nodes_from node
           return [] unless node.is_a?(::Parser::AST::Node)
           result = []
@@ -172,11 +203,22 @@ module Solargraph
         #
         # @param node [Parser::AST::Node]
         # @return [Array<Parser::AST::Node>]
-        def returns_from node
-          DeepInference.get_return_nodes(node).map { |n| n || NIL_NODE }
+        def returns_from_method_body node
+          # @todo is the || NIL_NODE necessary?
+          # STDERR.puts("Evaluating expression: #{node.inspect}")
+          DeepInference.from_method_body(node).map { |n| n || NIL_NODE }
+        end
+
+        # @param node [Parser::AST::Node]
+        # @return [Array<AST::Node>] low-level value nodes in
+        #   value position.  Does not include explicit return
+        #   statements
+        def value_position_nodes_only(node)
+          DeepInference.value_position_nodes_only(node).map { |n| n || NIL_NODE }
         end
 
         # @param cursor [Solargraph::Source::Cursor]
+        # @return [Parser::AST::Node, nil]
         def find_recipient_node cursor
           return repaired_find_recipient_node(cursor) if cursor.source.repaired? && cursor.source.code[cursor.offset - 1] == '('
           source = cursor.source
@@ -211,36 +253,127 @@ module Solargraph
           nil
         end
 
+        # @param cursor [Solargraph::Source::Cursor]
+        # @return [Parser::AST::Node, nil]
         def repaired_find_recipient_node cursor
           cursor = cursor.source.cursor_at([cursor.position.line, cursor.position.column - 1])
           node = cursor.source.tree_at(cursor.position.line, cursor.position.column).first
           return node if node && node.type == :send
         end
 
+        #
+        # Concepts:
+        #
+        #  - statement - one single node in the AST.  Generally used
+        #    synonymously with how the Parser gem uses the term
+        #    'expression'.  This may have side effects (e.g.,
+        #    registering a method in the namespace, modifying
+        #    variables or doing I/O).  It may encapsulate multiple
+        #    other statements (see compound statement).
+        #
+        #  - value - something that can be assigned to a variable by
+        #    evaluating a statement
+        #
+        #  - value node - the 'lowest level' AST node whose return
+        #    type is a subset of the value type of the overall
+        #    statement.  Might be a literal, a method call, etc - the
+        #    goal is to find the lowest level node, which we can use
+        #    Chains and Pins later on to determine the type of.
+        #
+        #    e.g., if the node 'b ? 123 : 456' were a return value, we
+        #    know the actual return values possible are 123 and 456,
+        #    and can disregard the rest.
+        #
+        #  - value type - the type representing the multiple possible
+        #    values that can result from evaluation of the statement.
+        #
+        #  - return type - the type describing the values a statement
+        #    might evaluate to.  When used with a method, the term
+        #    describes the values that may result from the method
+        #    being called, and includes explicit return statements
+        #    within the method body's closure.
+        #
+        #  - method body - a compound statement with parameters whose
+        #    return value type must account both for the explicit
+        #    'return' statemnts as well as the final statements
+        #    executed in any given control flow through the method.
+        #
+        #  - explicit return statement - a statement which, when part of a
+        #     method body, is a possible value of a call to that method -
+        #     e.g., "return 123"
+        #
+        #  - compound statement - a statement which can be expanded to
+        #     be multiple statements in a row, executed in the context
+        #     of a method which can be explicitly returned from.
+        #
+        #  - value position - the positions in the AST where the
+        #    return type of the statement would be one of the return
+        #    types of any compound statements it is a part of.  For a
+        #    compound statement, the last of the child statements
+        #    would be in return position.  This concept can be applied
+        #    recursively through e.g. conditionals to find a list of
+        #    statements in value positions.
         module DeepInference
           class << self
-            CONDITIONAL = [:if, :unless]
-            REDUCEABLE = [:begin, :kwbegin]
+            CONDITIONAL_ALL_BUT_FIRST = [:if, :unless]
+            CONDITIONAL_ALL = [:or]
+            ONLY_ONE_CHILD = [:return]
+            COMPOUND_STATEMENTS = [:begin, :kwbegin, :resbody]
             SKIPPABLE = [:def, :defs, :class, :sclass, :module]
+            FUNCTION_VALUE = [:block]
+            CASE_STATEMENT = [:case]
 
-            # @param node [Parser::AST::Node]
+            # @param node [AST::Node] a method body compound statement
+            # @param include_explicit_returns [Boolean] If true,
+            #    include the value nodes of the parameter of the
+            #    'return' statements in the type returned.
+            # @return [Array<AST::Node>] low-level value nodes from
+            #   both nodes in value position as well as explicit
+            #   return statements in the method's closure.
+            def from_method_body node
+              from_value_position_statement(node, include_explicit_returns: true)
+            end
+
+            # @param node [AST::Node] an individual statement, to be
+            #   evaluated outside the context of a containing method
+            # @return [Array<AST::Node>] low-level value nodes in
+            #   value position.  Does not include explicit return
+            #   statements
+            def value_position_nodes_only(node)
+              from_value_position_statement(node, include_explicit_returns: false)
+            end
+
+            # Look at known control statements and use them to find
+            # more specific return nodes.
+            #
+            # @param node [Parser::AST::Node] Statement which is in
+            #    value position for a method body
+            # @param include_explicit_returns [Boolean] If true,
+            #    include the value nodes of the parameter of the
+            #    'return' statements in the type returned.
             # @return [Array<Parser::AST::Node>]
-            def get_return_nodes node
+            def from_value_position_statement node, include_explicit_returns: true
+              # STDERR.puts("from_expression called on #{node.inspect}")
               return [] unless node.is_a?(::Parser::AST::Node)
+              # @type [Array<Parser::AST::Node>]
               result = []
-              if REDUCEABLE.include?(node.type)
-                result.concat get_return_nodes_from_children(node)
-              elsif CONDITIONAL.include?(node.type)
+              if COMPOUND_STATEMENTS.include?(node.type)
+                result.concat from_value_position_compound_statement node
+              elsif CONDITIONAL_ALL_BUT_FIRST.include?(node.type)
                 result.concat reduce_to_value_nodes(node.children[1..-1])
                 # result.push NIL_NODE unless node.children[2]
-              elsif node.type == :or
+              elsif CONDITIONAL_ALL.include?(node.type)
                 result.concat reduce_to_value_nodes(node.children)
-              elsif node.type == :return
+              elsif ONLY_ONE_CHILD.include?(node.type)
                 result.concat reduce_to_value_nodes([node.children[0]])
-              elsif node.type == :block
+              elsif FUNCTION_VALUE.include?(node.type)
+                # the block itself is a first class value that could be returned
                 result.push node
-                result.concat get_return_nodes_only(node.children[2])
-              elsif node.type == :case
+                # @todo any explicit returns actually return from
+                #   scope in which the proc is run.  This asssumes
+                #   that the function is executed here.
+                result.concat explicit_return_values_from_compound_statement(node.children[2]) if include_explicit_returns
+              elsif CASE_STATEMENT.include?(node.type)
                 node.children[1..-1].each do |cc|
                   if cc.nil?
                     result.push NIL_NODE
@@ -257,30 +390,60 @@ module Solargraph
               result
             end
 
-            private
-
-            def get_return_nodes_from_children parent
+            # Treat parent as as a begin block and use the last node's
+            # return node plus any explicit return nodes' return nodes.  e.g.,
+            #
+            #    123
+            #    456
+            #    return 'a' if foo == bar
+            #    789
+            #
+            #  would return 'a' and 789.
+            #
+            # @param parent [Parser::AST::Node]
+            #
+            # @return [Array<Parser::AST::Node>]
+            def from_value_position_compound_statement parent
               result = []
               nodes = parent.children.select{|n| n.is_a?(AST::Node)}
               nodes.each_with_index do |node, idx|
                 if node.type == :block
-                  result.concat get_return_nodes_only(node.children[2])
+                  result.concat explicit_return_values_from_compound_statement(node.children[2])
+                elsif node.type == :rescue
+                  # body statements
+                  result.concat from_value_position_statement(node.children[0])
+                  # rescue statements
+                  result.concat from_value_position_statement(node.children[1])
+                elsif node.type == :resbody
+                  result.concat from_value_position_statement(node.children[2])
                 elsif SKIPPABLE.include?(node.type)
                   next
                 elsif node.type == :return
                   result.concat reduce_to_value_nodes([node.children[0]])
-                  # Return the result here because the rest of the code is
-                  # unreachable
+                  # Return here because the rest of the code is
+                  # unreachable and shouldn't be looked at
                   return result
                 else
-                  result.concat get_return_nodes_only(node)
+                  result.concat explicit_return_values_from_compound_statement(node)
                 end
-                result.concat reduce_to_value_nodes([nodes.last]) if idx == nodes.length - 1
+                # handle last line of compound statements, which is in
+                # value position.  we already have the explicit values
+                # from above; now we need to also gather the value
+                # position nodes
+                result.concat from_value_position_statement(nodes.last, include_explicit_returns: false) if idx == nodes.length - 1
               end
               result
             end
 
-            def get_return_nodes_only parent
+            private
+
+            # Useful when this statement isn't in value position, but
+            # we care explicit return statements nonetheless.
+            #
+            # @param parent [Parser::AST::Node]
+            #
+            # @return [Array<Parser::AST::Node>]
+            def explicit_return_values_from_compound_statement parent
               return [] unless parent.is_a?(::Parser::AST::Node)
               result = []
               nodes = parent.children.select{|n| n.is_a?(::Parser::AST::Node)}
@@ -292,29 +455,29 @@ module Solargraph
                   # unreachable
                   return result
                 else
-                  result.concat get_return_nodes_only(node)
+                  result.concat explicit_return_values_from_compound_statement(node)
                 end
               end
               result
             end
 
             # @param nodes [Enumerable<Parser::AST::Node, BaseObject>]
-            # @return [Array<Parser::AST::Node>]
+            # @return [Array<Parser::AST::Node, nil>]
             def reduce_to_value_nodes nodes
               result = []
               nodes.each do |node|
                 if !node.is_a?(::Parser::AST::Node)
                   result.push nil
-                elsif REDUCEABLE.include?(node.type)
-                  result.concat get_return_nodes_from_children(node)
-                elsif CONDITIONAL.include?(node.type)
+                elsif COMPOUND_STATEMENTS.include?(node.type)
+                  result.concat from_value_position_compound_statement(node)
+                elsif CONDITIONAL_ALL_BUT_FIRST.include?(node.type)
                   result.concat reduce_to_value_nodes(node.children[1..-1])
                 elsif node.type == :return
                   result.concat reduce_to_value_nodes([node.children[0]])
                 elsif node.type == :or
                   result.concat reduce_to_value_nodes(node.children)
                 elsif node.type == :block
-                  result.concat get_return_nodes_only(node.children[2])
+                  result.concat explicit_return_values_from_compound_statement(node.children[2])
                 else
                   result.push node
                 end

--- a/lib/solargraph/parser/legacy/node_methods.rb
+++ b/lib/solargraph/parser/legacy/node_methods.rb
@@ -315,7 +315,7 @@ module Solargraph
         #    statements in value positions.
         module DeepInference
           class << self
-            CONDITIONAL_ALL_BUT_FIRST = [:if, :unless]
+            CONDITIONAL_ALL_BUT_FIRST = [:if, :unless, :or_asgn]
             CONDITIONAL_ALL = [:or]
             ONLY_ONE_CHILD = [:return]
             FIRST_TWO_CHILDREN = [:rescue]

--- a/lib/solargraph/parser/legacy/node_processors/resbody_node.rb
+++ b/lib/solargraph/parser/legacy/node_processors/resbody_node.rb
@@ -8,7 +8,7 @@ module Solargraph
           include Legacy::NodeMethods
 
           def process
-            if node.children[1]
+            if node.children[1] # Exception local variable name
               here = get_node_start_position(node.children[1])
               presence = Range.new(here, region.closure.location.range.ending)
               loc = get_node_location(node.children[1])

--- a/lib/solargraph/parser/rubyvm/class_methods.rb
+++ b/lib/solargraph/parser/rubyvm/class_methods.rb
@@ -20,7 +20,7 @@ module Solargraph
         # @param code [String]
         # @param filename [String, nil]
         # @param line [Integer]
-        # @return [Parser::AST::Node]
+        # @return [RubyVM::AbstractSyntaxTree::NodeWrapper, nil]
         def parse code, filename = nil, line = 0
           node = RubyVM::AbstractSyntaxTree.parse(code).children[2]
           node and RubyVM::AbstractSyntaxTree::NodeWrapper.from(node, code.lines)

--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -39,7 +39,7 @@ module Solargraph
       def probe api_map
         return ComplexType::UNDEFINED if @assignment.nil?
         types = []
-        returns_from(@assignment).each do |node|
+        value_position_nodes_only(@assignment).each do |node|
           # Nil nodes may not have a location
           if node.nil? || node.type == :NIL || node.type == :nil
             types.push ComplexType::NIL

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -349,7 +349,7 @@ module Solargraph
         result = []
         has_nil = false
         return ComplexType::NIL if method_body_node.nil?
-        returns_from(method_body_node).each do |n|
+        returns_from_method_body(method_body_node).each do |n|
           if n.nil? || [:NIL, :nil].include?(n.type)
             has_nil = true
             next

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -117,7 +117,7 @@ module Solargraph
 
       private
 
-      # @param pins [::Array<Pin::ProxyType>] Potential types returned by define()
+      # @param pins [::Array<Pin::Base>]
       # @param context [Pin::Base]
       # @param api_map [ApiMap]
       # @param locals [::Array<Pin::Base>]

--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -152,6 +152,7 @@ module Solargraph
       @pin_class_hash ||= pins.to_set.classify(&:class).transform_values(&:to_a)
     end
 
+    # @param klass [Class<Pin::Base>]
     # @return [Array<Pin::Base>]
     def pins_by_class klass
       @pin_select_cache[klass] ||= pin_class_hash.select { |key, _| key <= klass }.values.flatten

--- a/spec/parser/node_methods_spec.rb
+++ b/spec/parser/node_methods_spec.rb
@@ -62,8 +62,9 @@ describe Solargraph::Parser::NodeMethods do
     node = Solargraph::Parser.parse(%(
       return if true
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     # @todo Should there be two returns, the second being nil?
+    expect(rets.map(&:to_s)).to eq(['(nil)', '(nil)'])
     expect(rets.length).to eq(2)
   end
 
@@ -71,7 +72,7 @@ describe Solargraph::Parser::NodeMethods do
     node = Solargraph::Parser.parse(%(
       return bla if true
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     # Two returns, the second being implicit nil
     expect(rets.length).to eq(2)
   end
@@ -83,7 +84,7 @@ describe Solargraph::Parser::NodeMethods do
         true
       end
     ))
-    returns = Solargraph::Parser::NodeMethods.returns_from(node)
+    returns = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     # Include an implicit `nil` for missing else
     expect(returns.length).to eq(2)
   end
@@ -107,7 +108,7 @@ describe Solargraph::Parser::NodeMethods do
         end
       end
     ))
-    returns = Solargraph::Parser::NodeMethods.returns_from(node)
+    returns = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(returns.length).to eq(6)
     expect(returns.map(&:to_s)).to eq(['(true)', '(int 73)', '(false)', '(nil)', '(false)', '(true)'])
   end
@@ -121,7 +122,7 @@ describe Solargraph::Parser::NodeMethods do
         false
       end
     ))
-    returns = Solargraph::Parser::NodeMethods.returns_from(node)
+    returns = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(returns.length).to eq(2)
   end
 
@@ -141,7 +142,7 @@ describe Solargraph::Parser::NodeMethods do
       x = 1
       return x
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(1)
   end
 
@@ -151,7 +152,7 @@ describe Solargraph::Parser::NodeMethods do
       return x
       y
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(1)
   end
 
@@ -161,7 +162,7 @@ describe Solargraph::Parser::NodeMethods do
       return x if foo
       y
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
   end
 
@@ -172,20 +173,20 @@ describe Solargraph::Parser::NodeMethods do
         y
       end
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(1)
   end
 
   it "handles top 'and' nodes" do
     node = Solargraph::Parser.parse('1 && "2"')
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(1)
     expect(rets[0].type.to_s.downcase).to eq('and')
   end
 
   it "handles top 'or' nodes" do
     node = Solargraph::Parser.parse('1 || "2"')
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
     expect(Solargraph::Parser::NodeMethods.infer_literal_node_type(rets[0])).to eq('::Integer')
     expect(Solargraph::Parser::NodeMethods.infer_literal_node_type(rets[1])).to eq('::String')
@@ -193,14 +194,14 @@ describe Solargraph::Parser::NodeMethods do
 
   it "handles nested 'and' nodes" do
     node = Solargraph::Parser.parse('return 1 && "2"')
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(1)
     expect(rets[0].type.to_s.downcase).to eq('and')
   end
 
   it "handles nested 'or' nodes" do
     node = Solargraph::Parser.parse('return 1 || "2"')
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
     expect(Solargraph::Parser::NodeMethods.infer_literal_node_type(rets[0])).to eq('::Integer')
     expect(Solargraph::Parser::NodeMethods.infer_literal_node_type(rets[1])).to eq('::String')
@@ -212,7 +213,7 @@ describe Solargraph::Parser::NodeMethods do
         return item if foo
       end
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
     expect([:lvar, :DVAR]).to include(rets[1].type)
   end
@@ -226,7 +227,7 @@ describe Solargraph::Parser::NodeMethods do
       end
       nil
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
     expect([:lvar, :DVAR]).to include(rets[0].type)
   end
@@ -235,7 +236,7 @@ describe Solargraph::Parser::NodeMethods do
     node = Solargraph::Parser.parse(%(
       return if true
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     # The expectation is changing from previous versions. If conditions
     # have an implicit else branch, so this node should return [nil, nil].
     expect(rets.length).to eq(2)
@@ -245,7 +246,7 @@ describe Solargraph::Parser::NodeMethods do
     node = Solargraph::Parser.parse(%(
       return bla if true
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
   end
 
@@ -256,7 +257,7 @@ describe Solargraph::Parser::NodeMethods do
     #     return if true
     #   end
     # ))
-    # rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    # rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     # expect(rets.length).to eq(2)
   end
 
@@ -265,7 +266,7 @@ describe Solargraph::Parser::NodeMethods do
       x = 1
       return x
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(1)
   end
 
@@ -275,7 +276,7 @@ describe Solargraph::Parser::NodeMethods do
       return x
       y
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(1)
   end
 
@@ -285,7 +286,7 @@ describe Solargraph::Parser::NodeMethods do
       return x if foo
       y
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     # Another implicit else branch. This should have 3 return nodes.
     expect(rets.length).to eq(2)
   end
@@ -297,19 +298,19 @@ describe Solargraph::Parser::NodeMethods do
         y
       end
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(1)
   end
 
   it "handles top 'and' nodes" do
     node = Solargraph::Parser.parse('1 && "2"')
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(1)
   end
 
   it "handles top 'or' nodes" do
     node = Solargraph::Parser.parse('1 || "2"')
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
     # expect(rets[0].type).to eq(:LIT)
     # expect(rets[1].type).to eq(:STR)
@@ -317,13 +318,13 @@ describe Solargraph::Parser::NodeMethods do
 
   it "handles nested 'and' nodes" do
     node = Solargraph::Parser.parse('return 1 && "2"')
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(1)
   end
 
   it "handles nested 'or' nodes" do
     node = Solargraph::Parser.parse('return 1 || "2"')
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
     # expect(rets[0].type).to eq(:LIT)
     # expect(rets[1].type).to eq(:STR)
@@ -335,7 +336,7 @@ describe Solargraph::Parser::NodeMethods do
         return item if foo
       end
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
     # expect(rets[1].type).to eq(:DVAR)
   end
@@ -349,7 +350,7 @@ describe Solargraph::Parser::NodeMethods do
       end
       nil
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
     # expect(rets[0].type).to eq(:DVAR)
   end
@@ -362,7 +363,7 @@ describe Solargraph::Parser::NodeMethods do
         ""
       end
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
   end
 
@@ -373,7 +374,7 @@ describe Solargraph::Parser::NodeMethods do
         ""
       end
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
   end
 
@@ -386,7 +387,7 @@ describe Solargraph::Parser::NodeMethods do
         super
       end
     ))
-    rets = Solargraph::Parser::NodeMethods.returns_from(node)
+    rets = Solargraph::Parser::NodeMethods.returns_from_method_body(node)
     expect(rets.length).to eq(2)
   end
 

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -401,6 +401,23 @@ describe Solargraph::Pin::Method do
       expect(pin.probe(api_map).tag).to eq('String')
     end
 
+    it 'infers return types from method rescue block' do
+      source = Solargraph::Source.load_string(%(
+        class Foo
+          def bar
+            'abc'
+          rescue
+            1
+          end
+        end
+      ))
+      api_map = Solargraph::ApiMap.new
+      api_map.map source
+      pin = api_map.get_path_pins('Foo#bar').first
+      expect(pin.typify(api_map)).to be_undefined
+      expect(pin.probe(api_map).items.map(&:tag)).to eq(['String', 'Integer'])
+    end
+
     it 'infers return types from begin rescue block' do
       source = Solargraph::Source.load_string(%(
         class Foo

--- a/spec/type_checker/levels/strict_spec.rb
+++ b/spec/type_checker/levels/strict_spec.rb
@@ -461,6 +461,15 @@ describe Solargraph::TypeChecker do
       expect(checker.problems).to be_empty
     end
 
+    it 'Can infer through ||= with a begin+end' do
+      checker = type_checker(%(
+        def recipient
+          @recipient ||= true ? "foo" : "bar"
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     it 'validates kwoptargs without arguments' do
       checker = type_checker(%(
         class Foo


### PR DESCRIPTION
Address some unhandled cases around rescue blocks after documenting and refactoring DeepInference based on my best understanding of it.

This fixes some false positives given by Solargraph while typechecking its own codebase at level 'strict'.