### PR TITLE
Include "self type" methods like Enumerable#each from RBS files

### DIFF
--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -68,7 +68,7 @@ module Solargraph
           class_decl_to_pin decl
         when RBS::AST::Declarations::Interface
           # STDERR.puts "Skipping interface #{decl.name.relative!}"
-          interface_decl_to_pin decl
+          interface_decl_to_pin decl, closure
         when RBS::AST::Declarations::TypeAlias
           type_aliases[decl.name.to_s] = decl
         when RBS::AST::Declarations::Module
@@ -82,7 +82,28 @@ module Solargraph
         end
       end
 
-      def convert_members_to_pin decl, closure
+      # @param decl [RBS::AST::Declarations::Module]
+      # @param module_pin [Pin::Namespace]
+      # @return [void]
+      def convert_self_types_to_pins decl, module_pin
+        decl.self_types.each { |self_type| context = convert_self_type_to_pins(self_type, module_pin) }
+      end
+
+      # @param decl [RBS::AST::Declarations::Module::Self]
+      # @param closure [Pin::Namespace]
+      def convert_self_type_to_pins decl, closure
+        include_pin = Solargraph::Pin::Reference::Include.new(
+          name: decl.name.relative!.to_s,
+          location: rbs_location_to_location(decl.location),
+          closure: closure
+        )
+        pins.push include_pin
+      end
+
+      # @param decl [RBS::AST::Declarations::Module,RBS::AST::Declarations::Class,RBS::AST::Declarations::Interface]
+      # @param closure [Pin::Namespace]
+      # @return [void]
+      def convert_members_to_pins decl, closure
         context = Context.new
         decl.members.each { |m| context = convert_member_to_pin(m, closure, context) }
       end
@@ -136,12 +157,12 @@ module Solargraph
             name: decl.super_class.name.relative!.to_s
           )
         end
-        convert_members_to_pin decl, class_pin
+        convert_members_to_pins decl, class_pin
       end
 
       # @param decl [RBS::AST::Declarations::Interface]
       # @return [void]
-      def interface_decl_to_pin decl
+      def interface_decl_to_pin decl, closure
         class_pin = Solargraph::Pin::Namespace.new(
           type: :module,
           name: decl.name.relative!.to_s,
@@ -153,7 +174,7 @@ module Solargraph
         )
         class_pin.docstring.add_tag(YARD::Tags::Tag.new(:abstract, '(RBS interface)'))
         pins.push class_pin
-        convert_members_to_pin decl, class_pin
+        convert_members_to_pins decl, class_pin
       end
 
       # @param decl [RBS::AST::Declarations::Module]
@@ -167,7 +188,8 @@ module Solargraph
           generics: decl.type_params.map(&:name).map(&:to_s),
         )
         pins.push module_pin
-        convert_members_to_pin decl, module_pin
+        convert_self_types_to_pins decl, module_pin
+        convert_members_to_pins decl, module_pin
       end
 
       # @param name [String]
@@ -278,6 +300,17 @@ module Solargraph
           return_type = ComplexType.try_parse(method_type_to_tag(overload.method_type))
           Pin::Signature.new(parameters, return_type, block)
         end
+      end
+
+      # @param location [RBS::Location, nil]
+      # @return [Solargraph::Location, nil]
+      def rbs_location_to_location(location)
+        return nil if location&.name.nil?
+
+        start_pos = Position.new(location.start_line - 1, location.start_column)
+        end_pos = Position.new(location.end_line - 1, location.end_column)
+        range = Range.new(start_pos, end_pos)
+        Location.new(location.name, range)
       end
 
       def parts_of_function type, pin

--- a/spec/rbs_map/core_map_spec.rb
+++ b/spec/rbs_map/core_map_spec.rb
@@ -22,4 +22,18 @@ describe Solargraph::RbsMap::CoreMap do
     expect(mutex_pin).to be_a(Solargraph::Pin::Constant)
     expect(mutex_pin.return_type.to_s).to eq("Class<Thread::Mutex>")
   end
+
+  it 'understands implied Enumerator#each method' do
+    api_map = Solargraph::ApiMap.new
+    methods = api_map.get_methods('Enumerable')
+    each_pins = methods.select{|pin| pin.path.end_with?('#each')}
+    # expect this to come from the _Each implied interface ("self
+    # type") defined in the RBS
+    expect(each_pins.map(&:path)).to eq(["_Each#each"])
+    expect(each_pins.map(&:class)).to eq([Solargraph::Pin::Method])
+    each_pin = each_pins.first
+    expect(each_pin.signatures.length).to eq(1)
+    signature = each_pin.signatures.first
+    expect(signature.block.return_type.to_s).to eq('void')
+  end
 end

--- a/spec/type_checker/levels/strict_spec.rb
+++ b/spec/type_checker/levels/strict_spec.rb
@@ -4,6 +4,16 @@ describe Solargraph::TypeChecker do
       Solargraph::TypeChecker.load_string(code, 'test.rb', :strict)
     end
 
+    it 'handles compatible interfaces with self types on call' do
+      checker = type_checker(%(
+        # @param a [Enumerable<String>]
+        def bar(a); end
+
+        bar(['a'])
+      ))
+      expect(checker.problems).to be_empty
+    end
+
     it 'complains on @!parse blocks too' do
       checker = type_checker(%(
       # @!parse

--- a/spec/type_checker/levels/typed_spec.rb
+++ b/spec/type_checker/levels/typed_spec.rb
@@ -286,6 +286,14 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.first.message).to include('does not match inferred type')
     end
 
+    it 'handles mixin types with self types on init' do
+      checker = type_checker(%(
+        # @param a [Enumerable<String>]
+        def bar(a = ['a']); end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
     it 'reports undefined param tags' do
       checker = type_checker(%(
         # @param bar [UndefinedClass]


### PR DESCRIPTION
RBS has the concept of a 'self type', which is a way to refer to the requirements a class must implement in order to use a mix-in.  An example would be the 'each' method, which you must implement before you can import 'Enumerable'.

The implication of this is that is it reasonably safe to assume that anything that includes Enumerable will have this method, which allows 'Enumerable' to be treated as a de-facto superclass of concrete container classes like 'Hash', 'Set' and 'Array' and allow methods to depend on the Enumerable abstract interface and accept a variety of container types.

With this change, we assume that if we receive something with type X, it implements all of its self types.  As a result, we won't see typechecking errors when e.g. using #each on an Enumerable.

A future typechecking improvement would double check that the concrete class does implement the self type interface when the receiving type requires it.