### PR TITLE
Process RBS globals, module aliases, class vars and class instance vars

### DIFF
--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -77,8 +77,12 @@ module Solargraph
           constant_decl_to_pin decl
         when RBS::AST::Declarations::ClassAlias
           class_alias_decl_to_pin decl
+        when RBS::AST::Declarations::ModuleAlias
+          module_alias_decl_to_pin decl
+        when RBS::AST::Declarations::Global
+          global_decl_to_pin decl
         else
-          Solargraph.logger.info "Skipping declaration #{decl.class}"
+          Solargraph.logger.warn "Skipping declaration #{decl.class}"
         end
       end
 
@@ -105,6 +109,10 @@ module Solargraph
           extend_to_pin(member, closure)
         when RBS::AST::Members::Alias
           alias_to_pin(member, closure)
+        when RBS::AST::Members::ClassInstanceVariable
+          civar_to_pin(member, closure)
+        when RBS::AST::Members::ClassVariable
+          cvar_to_pin(member, closure)
         when RBS::AST::Members::InstanceVariable
           ivar_to_pin(member, closure)
         when RBS::AST::Members::Public
@@ -140,6 +148,7 @@ module Solargraph
       end
 
       # @param decl [RBS::AST::Declarations::Interface]
+      # @param closure [Pin::Closure]
       # @return [void]
       def interface_decl_to_pin decl
         class_pin = Solargraph::Pin::Namespace.new(
@@ -173,9 +182,10 @@ module Solargraph
       # @param name [String]
       # @param tag [String]
       # @param comments [String]
+      # @param type [Symbol] :class or :module
       #
       # @return [Solargraph::Pin::Constant]
-      def create_constant(name, tag, comments)
+      def create_constant(name, tag, comments, type)
         parts = name.split('::')
         if parts.length > 1
           name = parts.last
@@ -189,8 +199,15 @@ module Solargraph
           closure: closure,
           comments: comments
         )
-        # @todo Class or Module?
-        constant_pin.docstring.add_tag(YARD::Tags::Tag.new(:return, '', "Class<#{tag}>"))
+        tag = if type == :class
+                "Class<#{tag}>"
+              elsif type == :module
+                "Module<#{tag}>"
+              else
+                Solargraph.logger.warn "Unrecognized constant type: #{type.inspect}"
+                "Class<#{tag}>"
+              end
+        constant_pin.docstring.add_tag(YARD::Tags::Tag.new(:return, '', tag))
         constant_pin
       end
 
@@ -201,14 +218,40 @@ module Solargraph
         new_name = decl.new_name.relative!.to_s
         old_name = decl.old_name.relative!.to_s
 
-        pins.push create_constant(new_name, old_name, decl.comment&.string)
+        pins.push create_constant(new_name, old_name, decl.comment&.string, :class)
+      end
+
+      # @param decl [RBS::AST::Declarations::ModuleAlias]
+      # @return [void]
+      def module_alias_decl_to_pin decl
+        # See https://www.rubydoc.info/gems/rbs/3.4.3/RBS/AST/Declarations/ModuleAlias
+        new_name = decl.new_name.relative!.to_s
+        old_name = decl.old_name.relative!.to_s
+
+        pins.push create_constant(new_name, old_name, decl.comment&.string, :module)
       end
 
       # @param decl [RBS::AST::Declarations::Constant]
       # @return [void]
       def constant_decl_to_pin decl
         tag = other_type_to_tag(decl.type)
-        pins.push create_constant(decl.name.relative!.to_s, tag, decl.comment&.string)
+        # @todo Class or Module?
+        pins.push create_constant(decl.name.relative!.to_s, tag, decl.comment&.string, :class)
+      end
+
+      # @param decl [RBS::AST::Declarations::Global]
+      # @return [void]
+      def global_decl_to_pin decl
+        closure = Solargraph::Pin::ROOT_PIN
+        name = decl.name.to_s
+        tag = other_type_to_tag(decl.type)
+        pin = Solargraph::Pin::GlobalVariable.new(
+          name: name,
+          closure: closure,
+          comments: decl.comment&.string,
+        )
+        pin.docstring.add_tag(YARD::Tags::Tag.new(:type, '', tag))
+        pins.push pin
       end
 
       # @param decl [RBS::AST::Members::MethodDefinition]
@@ -359,6 +402,37 @@ module Solargraph
         pins.push pin
       end
 
+      # @param decl [RBS::AST::Members::ClassVariable]
+      # @param closure [Pin::Namespace]
+      # @return [void]
+      def cvar_to_pin(decl, closure)
+        name = decl.name.to_s
+        pin = Solargraph::Pin::ClassVariable.new(
+          name: name,
+          closure: closure,
+          comments: decl.comment&.string
+        )
+        pin.docstring.add_tag(YARD::Tags::Tag.new(:type, '', other_type_to_tag(decl.type)))
+        pins.push pin
+      end
+
+      # @param decl [RBS::AST::Members::ClassInstanceVariable]
+      # @param closure [Pin::Namespace]
+      # @return [void]
+      def civar_to_pin(decl, closure)
+        name = decl.name.to_s
+        pin = Solargraph::Pin::InstanceVariable.new(
+          name: name,
+          closure: closure,
+          comments: decl.comment&.string
+        )
+        pin.docstring.add_tag(YARD::Tags::Tag.new(:type, '', other_type_to_tag(decl.type)))
+        pins.push pin
+      end
+
+      # @param decl [RBS::AST::Members::Include]
+      # @param closure [Pin::Namespace]
+      # @return [void]
       def include_to_pin decl, closure
         pins.push Solargraph::Pin::Reference::Include.new(
           name: decl.name.relative!.to_s,

--- a/lib/solargraph/rbs_map/stdlib_map.rb
+++ b/lib/solargraph/rbs_map/stdlib_map.rb
@@ -18,9 +18,6 @@ module Solargraph
           pins.replace cache
         else
           super
-          if library == 'yaml'
-            pins.push Solargraph::Pin::Constant.new(name: 'YAML', comments: '@return [Module<Psych>]', closure: Pin::ROOT_PIN)
-          end
           Cache.save('stdlib', "#{library}.ser", pins)
         end
       end

--- a/lib/solargraph/yard_map.rb
+++ b/lib/solargraph/yard_map.rb
@@ -51,8 +51,6 @@ module Solargraph
       @gem_paths = {}
       base_required.replace new_requires
       required.replace new_requires
-      # HACK: Hardcoded YAML handling
-      required.add 'psych' if new_requires.include?('yaml')
       @source_gems = new_source_gems
       @directory = new_directory
       process_requires
@@ -192,12 +190,6 @@ module Solargraph
           cache.set_path_pins r, result
           pins.concat result
         end
-      end
-      if required.include?('yaml') && required.include?('psych')
-        # HACK: Hardcoded YAML handling
-        # @todo Why can't this be handled with an override or a virtual pin?
-        pin = path_pin('YAML')
-        pin.instance_variable_set(:@return_type, ComplexType.parse('Module<Psych>')) unless pin.nil?
       end
       pins.concat environ.pins
     end

--- a/spec/rbs_map/core_map_spec.rb
+++ b/spec/rbs_map/core_map_spec.rb
@@ -22,4 +22,16 @@ describe Solargraph::RbsMap::CoreMap do
     expect(mutex_pin).to be_a(Solargraph::Pin::Constant)
     expect(mutex_pin.return_type.to_s).to eq("Class<Thread::Mutex>")
   end
+
+  it 'understands RBS global variables' do
+    map = Solargraph::RbsMap::CoreMap.new
+    store = Solargraph::ApiMap::Store.new(map.pins)
+    global_variable_pins = store.pins_by_class(Solargraph::Pin::GlobalVariable)
+    stderr_pins = global_variable_pins.select do |pin|
+      pin.name == '$stderr'
+    end
+    expect(stderr_pins.map(&:class)).to eq([Solargraph::Pin::GlobalVariable])
+    stderr_pin = stderr_pins.first
+    expect(stderr_pin.return_type.to_s).to eq('IO')
+  end
 end

--- a/spec/rbs_map/stdlib_map_spec.rb
+++ b/spec/rbs_map/stdlib_map_spec.rb
@@ -48,4 +48,40 @@ describe Solargraph::RbsMap::StdlibMap do
     expect(signature.parameters.map(&:return_type).map(&:to_s)).to match_array([an_instance_of(String), "Numeric, String", "Integer", "String", an_instance_of(String), "String", "Logger::_Formatter", "String", an_instance_of(String)])
   end
 
+  it 'processes RBS class variables' do
+    map = Solargraph::RbsMap::StdlibMap.load('rbs')
+    store = Solargraph::ApiMap::Store.new(map.pins)
+    class_variable_pins = store.pins_by_class(Solargraph::Pin::ClassVariable)
+    count_pins = class_variable_pins.select do |pin|
+      pin.name.to_s == '@@count' && pin.context.to_s == 'Class<RBS::Types::Variable>'
+    end
+    expect(count_pins.length).to eq(1)
+    count_pin = count_pins.first
+    expect(count_pin.return_type.to_s).to eq('Integer')
+  end
+
+  it 'processes RBS class instance variables' do
+    map = Solargraph::RbsMap::StdlibMap.load('rbs')
+    store = Solargraph::ApiMap::Store.new(map.pins)
+    instance_variable_pins = store.pins_by_class(Solargraph::Pin::InstanceVariable)
+    root_pins = instance_variable_pins.select do |pin|
+      pin.name.to_s == '@root' && pin.context.to_s == 'Class<RBS::Namespace>' && pin.scope == :class
+    end
+    expect(root_pins.length).to eq(1)
+    root_pin = root_pins.first
+    expect(root_pin.return_type.to_s).to eq('RBS::Namespace, nil')
+  end
+
+  it 'processes RBS module aliases' do
+    map = Solargraph::RbsMap::StdlibMap.load('yaml')
+    store = Solargraph::ApiMap::Store.new(map.pins)
+    constant_pins = store.get_constants('')
+    yaml_pins = constant_pins.select do |pin|
+      pin.name.to_s == 'YAML'
+    end
+    # depending on Ruby version, this might point to Psych or the YAML module
+    yaml_pins.map(&:return_type).map(&:to_s).each do |return_type|
+      expect(['Module<YAML>', 'Module<Psych>']).to include(return_type)
+    end
+  end
 end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -23,6 +23,15 @@ describe Solargraph::SourceMap::Clip do
     expect(comp.pins.map(&:name)).to include('@@foo')
   end
 
+  it 'completes class instance variables' do
+    source = Solargraph::Source.load_string('class Foo; @foo = 1; @f; end', 'test.rb')
+    api_map.map source
+    cursor = source.cursor_at(Solargraph::Position.new(0, 22))
+    clip = described_class.new(api_map, cursor)
+    comp = clip.complete
+    expect(comp.pins.map(&:name)).to include('@foo')
+  end
+
   it 'completes class variables in open scopes' do
     source = Solargraph::Source.load_string(%(
       class Foo
@@ -36,6 +45,21 @@ describe Solargraph::SourceMap::Clip do
     pins = clip.complete.pins
     expect(pins.length).to eq(1)
     expect(pins.first.name).to eq('@@bar')
+  end
+
+  it 'completes class instance variables in open scopes' do
+    source = Solargraph::Source.load_string(%(
+      class Foo
+        @bar = 'bar'
+        @b
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    clip = api_map.clip_at('test.rb', [3, 10])
+    pins = clip.complete.pins
+    expect(pins.length).to eq(1)
+    expect(pins.first.name).to eq('@bar')
   end
 
   it 'uses scope gates to detect class variables' do
@@ -53,6 +77,23 @@ describe Solargraph::SourceMap::Clip do
     api_map.map source
     clip = api_map.clip_at('test.rb', [6, 13])
     expect(clip.complete.pins).to be_empty
+  end
+
+  it 'uses scope gates to detect class instance variables' do
+    source = Solargraph::Source.load_string(%(
+      class Foo
+        @foo = 'foo'
+      end
+      class Bar
+        Foo.class_eval do
+          @f
+        end
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    clip = api_map.clip_at('test.rb', [6, 12])
+    expect(clip.complete.pins.map(&:name)).to eq (['@foo'])
   end
 
   it 'completes instance variables' do


### PR DESCRIPTION
Translate the following from RBS:

* globals: for stdlib/core, this gets us things like '$stdout'
* module alias: this gets us YAML as an alias for Module<Psych> without a hard-coded workaround
* class variable: mainly for completeness - only a few defined within the RBS code types themselves
* class instance variable: ditto