### PR TITLE
Add support for generic includes via RBS

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -211,21 +211,36 @@ module Solargraph
       store.fqns_pins(qualify(namespace, context))
     end
 
-    # Get a fully qualified namespace name. This method will start the search
-    # in the specified context until it finds a match for the name.
+    # Determine fully qualified namespace for a tag. This method will
+    # start the search in the specified context until it finds a match
+    # for the name.
     #
-    # @param namespace [String, nil] The namespace to match
-    # @param context [String] The context to search
-    # @return [String, nil]
-    def qualify namespace, context = ''
-      return namespace if ['self', nil].include?(namespace)
+    # Does not recurse into qualifying the type parameters.
+    #
+    # @param tag [String, nil] The namespace to
+    #   match, complete with generic parameters set to appropriate
+    #   values if available
+    # @param context_tag [String] The context to search
+    # @return [String, nil] fully qualified tag
+    def qualify tag, context_tag = ''
+      return tag if ['self', nil].include?(tag)
+      # remove type parameters
+      context_type = ComplexType.parse(context_tag)
+      context = context_type.rooted_namespace
+      type = ComplexType.parse(tag)
+      namespace = type.rooted_namespace
       cached = cache.get_qualified_namespace(namespace, context)
       return cached.clone unless cached.nil?
-      result = if namespace.start_with?('::')
+      result = if tag.start_with?('::')
                  inner_qualify(namespace[2..-1], '', Set.new)
                else
                  inner_qualify(namespace, context, Set.new)
                end
+      result = if type.all_params.empty?
+        result
+      else
+        result + "<" + type.all_params.map(&:to_s).join(", ") + ">"
+      end
       cache.set_qualified_namespace(namespace, context, result)
       result
     end
@@ -269,32 +284,32 @@ module Solargraph
 
     # Get an array of methods available in a particular context.
     #
-    # @param fqns [String] The fully qualified namespace to search for methods
+    # @param rooted_tag [String] The fully qualified namespace to search for methods
     # @param scope [Symbol] :class or :instance
     # @param visibility [Array<Symbol>] :public, :protected, and/or :private
     # @param deep [Boolean] True to include superclasses, mixins, etc.
     # @return [Array<Solargraph::Pin::Method>]
-    def get_methods fqns, scope: :instance, visibility: [:public], deep: true
-      cached = cache.get_methods(fqns, scope, visibility, deep)
+    def get_methods rooted_tag, scope: :instance, visibility: [:public], deep: true
+      cached = cache.get_methods(rooted_tag, scope, visibility, deep)
       return cached.clone unless cached.nil?
       result = []
       skip = Set.new
-      if fqns == ''
+      if rooted_tag == ''
         # @todo Implement domains
         implicit.domains.each do |domain|
           type = ComplexType.try_parse(domain)
           next if type.undefined?
           result.concat inner_get_methods(type.name, type.scope, visibility, deep, skip)
         end
-        result.concat inner_get_methods(fqns, :class, visibility, deep, skip)
-        result.concat inner_get_methods(fqns, :instance, visibility, deep, skip)
+        result.concat inner_get_methods(rooted_tag, :class, visibility, deep, skip)
+        result.concat inner_get_methods(rooted_tag, :instance, visibility, deep, skip)
         result.concat inner_get_methods('Kernel', :instance, visibility, deep, skip)
       else
-        result.concat inner_get_methods(fqns, scope, visibility, deep, skip)
+        result.concat inner_get_methods(rooted_tag, scope, visibility, deep, skip)
         result.concat inner_get_methods('Kernel', :instance, [:public], deep, skip) if visibility.include?(:private)
       end
       resolved = resolve_method_aliases(result, visibility)
-      cache.set_methods(fqns, scope, visibility, deep, resolved)
+      cache.set_methods(rooted_tag, scope, visibility, deep, resolved)
       resolved
     end
 
@@ -332,27 +347,27 @@ module Solargraph
               visibility.push :protected
               visibility.push :private if internal
             end
-            result.merge get_methods(type.namespace, scope: type.scope, visibility: visibility)
+            result.merge get_methods(type.tag, scope: type.scope, visibility: visibility)
           end
         end
       end
       result.to_a
     end
 
-    # Get a stack of method pins for a method name in a namespace. The order
-    # of the pins corresponds to the ancestry chain, with highest precedence
-    # first.
+    # Get a stack of method pins for a method name in a potentially
+    # parameterized namespace. The order of the pins corresponds to
+    # the ancestry chain, with highest precedence first.
     #
     # @example
     #   api_map.get_method_stack('Subclass', 'method_name')
     #     #=> [ <Subclass#method_name pin>, <Superclass#method_name pin> ]
     #
-    # @param fqns [String]
-    # @param name [String]
+    # @param rooted_tag [String] Parameterized namespace, fully qualified
+    # @param name [String] Method name to look up
     # @param scope [Symbol] :instance or :class
     # @return [Array<Solargraph::Pin::Method>]
-    def get_method_stack fqns, name, scope: :instance
-      get_methods(fqns, scope: scope, visibility: [:private, :protected, :public]).select { |p| p.name == name }
+    def get_method_stack rooted_tag, name, scope: :instance
+      get_methods(rooted_tag, scope: scope, visibility: [:private, :protected, :public]).select { |p| p.name == name }
     end
 
     # Get an array of all suggestions that match the specified path.
@@ -481,13 +496,15 @@ module Solargraph
       false
     end
 
-    # Check if the host class includes the specified module.
+    # Check if the host class includes the specified module, ignoring
+    # type parameters used.
     #
-    # @param host [String] The class
-    # @param mod [String] The module
+    # @param host_ns [String] The class namesapce (no type parameters)
+    # @param module_ns [String] The module namespace (no type parameters)
+    #
     # @return [Boolean]
-    def type_include?(host, mod)
-      store.get_includes(host).include?(mod)
+    def type_include?(host_ns, module_ns)
+      store.get_includes(host_ns).map { ComplexType.parse(_1).name }.include?(module_ns)
     end
 
     private
@@ -513,14 +530,18 @@ module Solargraph
     # @return [Solargraph::ApiMap::Cache]
     attr_reader :cache
 
-    # @param fqns [String] A fully qualified namespace
+    # @param rooted_tag [String] A fully qualified namespace, with
+    #   generic parameter values if applicable
     # @param scope [Symbol] :class or :instance
     # @param visibility [Array<Symbol>] :public, :protected, and/or :private
     # @param deep [Boolean]
     # @param skip [Set<String>]
     # @param no_core [Boolean] Skip core classes if true
     # @return [Array<Pin::Base>]
-    def inner_get_methods fqns, scope, visibility, deep, skip, no_core = false
+    def inner_get_methods rooted_tag, scope, visibility, deep, skip, no_core = false
+      rooted_type = ComplexType.parse(rooted_tag)
+      fqns = rooted_type.namespace
+      fqns_generic_params = rooted_type.all_params
       return [] if no_core && fqns =~ /^(Object|BasicObject|Class|Module|Kernel)$/
       reqstr = "#{fqns}|#{scope}|#{visibility.sort}|#{deep}"
       return [] if skip.include?(reqstr)
@@ -532,12 +553,33 @@ module Solargraph
           result.concat inner_get_methods(fqim, scope, visibility, deep, skip, true) unless fqim.nil?
         end
       end
-      result.concat store.get_methods(fqns, scope: scope, visibility: visibility).sort{ |a, b| a.name <=> b.name }
+      # Store#get_methods doesn't know about full tags, just
+      # namespaces; resolving the generics in the method pins is this
+      # class' responsibility
+      raw_methods = store.get_methods(fqns, scope: scope, visibility: visibility).sort{ |a, b| a.name <=> b.name }
+      namespace_pin = store.get_path_pins(fqns).select{|p| p.is_a?(Pin::Namespace)}.first
+      methods = if rooted_tag != fqns
+                  methods = raw_methods.map do |method_pin|
+                    method_pin.resolve_generics(namespace_pin, rooted_type)
+                  end
+                else
+                  raw_methods
+                end
+      result.concat methods
       if deep
         if scope == :instance
-          store.get_includes(fqns).reverse.each do |im|
-            fqim = qualify(im, fqns)
-            result.concat inner_get_methods(fqim, scope, visibility, deep, skip, true) unless fqim.nil?
+          store.get_includes(fqns).reverse.each do |include_tag|
+            rooted_include_tag = qualify(include_tag, rooted_tag)
+            # Ensure the types returned by the included methods are
+            # relative to the generics passed to the include.  e.g.,
+            # Foo<String> might include Enumerable<String>
+            #
+            # @todo perform the same translation in the other areas
+            #  here after adding a spec and handling things correctly
+            #  in ApiMap::Store and RbsMap::Conversions
+            resolved_include_type = ComplexType.parse(rooted_include_tag).resolve_generics(namespace_pin, rooted_type)
+            methods = inner_get_methods(resolved_include_type.tag, scope, visibility, deep, skip, true)
+            result.concat methods
           end
           fqsc = qualify_superclass(fqns)
           unless fqsc.nil?
@@ -612,11 +654,12 @@ module Solargraph
       qualify(sup, parts.join('::'))
     end
 
-    # @param name [String]
-    # @param root [String]
-    # @param skip [Set<String>]
-    # @return [String, nil]
+    # @param name [String] Namespace to fully qualify
+    # @param root [String] The context to search
+    # @param skip [Set<String>] Contexts already searched
+    # @return [String, nil] Fully qualified ("rooted") namespace
     def inner_qualify name, root, skip
+      return name if name == ComplexType::GENERIC_TAG_NAME
       return nil if name.nil?
       return nil if skip.include?(root)
       skip.add root
@@ -699,7 +742,7 @@ module Solargraph
     def resolve_method_alias pin
       return pin if !pin.is_a?(Pin::MethodAlias) || @method_alias_stack.include?(pin.path)
       @method_alias_stack.push pin.path
-      origin = get_method_stack(pin.full_context.namespace, pin.original, scope: pin.scope).first
+      origin = get_method_stack(pin.full_context.tag, pin.original, scope: pin.scope).first
       @method_alias_stack.pop
       return pin if origin.nil?
       args = {

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -504,7 +504,7 @@ module Solargraph
     #
     # @return [Boolean]
     def type_include?(host_ns, module_ns)
-      store.get_includes(host_ns).map { ComplexType.parse(_1).name }.include?(module_ns)
+      store.get_includes(host_ns).map { |inc_tag| ComplexType.parse(inc_tag).name }.include?(module_ns)
     end
 
     private

--- a/lib/solargraph/complex_type/type_methods.rb
+++ b/lib/solargraph/complex_type/type_methods.rb
@@ -80,6 +80,12 @@ module Solargraph
         end.call
       end
 
+      # @return [String]
+      def rooted_namespace
+        return namespace unless rooted?
+        "::#{namespace}"
+      end
+
       # @return [::Symbol] :class or :instance
       def scope
         @scope ||= :instance if duck_type? || nil_type?

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -40,6 +40,20 @@ module Solargraph
         @comments ||= ''
       end
 
+      # Determine the concrete type for each of the generic type
+      # parameters used in this method based on the parameters passed
+      # into the its class and return a new method pin.
+      #
+      # @param definitions [Pin::Namespace] The module/class which uses generic types
+      # @param context_type [ComplexType] The receiver type
+      # @return [self]
+      def resolve_generics definitions, context_type
+        rt = @return_type.resolve_generics(definitions, context_type) if @return_type
+        pin = proxy rt
+        pin.context = context_type
+        pin
+      end
+
       # @return [String, nil]
       def filename
         return nil if location.nil?

--- a/lib/solargraph/pin/common.rb
+++ b/lib/solargraph/pin/common.rb
@@ -46,6 +46,10 @@ module Solargraph
         @path ||= name.empty? ? context.namespace : "#{context.namespace}::#{name}"
       end
 
+      protected
+
+      attr_writer :context
+
       private
 
       # @return [ComplexType]
@@ -56,7 +60,7 @@ module Solargraph
             return here.return_type
           elsif here.is_a?(Pin::Method)
             if here.scope == :instance
-              return ComplexType.try_parse(here.context.namespace)
+              return ComplexType.try_parse(here.context.tag)
             else
               return here.context
             end

--- a/lib/solargraph/pin/reference.rb
+++ b/lib/solargraph/pin/reference.rb
@@ -9,6 +9,14 @@ module Solargraph
       autoload :Prepend,    'solargraph/pin/reference/prepend'
       autoload :Extend,     'solargraph/pin/reference/extend'
       autoload :Override,   'solargraph/pin/reference/override'
+
+      attr_reader :generic_values
+
+      # @param generic_values [Array<String>]
+      def initialize generic_values: [], **splat
+        super(**splat)
+        @generic_values = generic_values
+      end
     end
   end
 end

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -19,6 +19,24 @@ module Solargraph
         @block = block
       end
 
+      # Probe the concrete type for each of the generic type
+      # parameters used in this method, and return a new method pin if
+      # possible.
+      #
+      # @param definitions [Pin::Namespace] The module/class which uses generic types
+      # @param context_type [ComplexType] The receiver type, including the parameters
+      #   we want to substitute into 'definitions'
+      # @return [self]
+      def resolve_generics definitions, context_type
+        signature = super
+        signature.parameters = signature.parameters.map do |param|
+          param.resolve_generics(definitions, context_type)
+        end
+        signature.block = block.resolve_generics(definitions, context_type) if signature.block?
+        signature.return_type = return_type.resolve_generics(definitions, context_type)
+        signature
+      end
+
       def identity
         @identity ||= "signature#{object_id}"
       end
@@ -26,6 +44,12 @@ module Solargraph
       def block?
         !!@block
       end
+
+      protected
+
+      attr_writer :block
+
+      attr_writer :parameters
     end
   end
 end

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -134,6 +134,9 @@ module Solargraph
           name: decl.name.relative!.to_s,
           closure: Solargraph::Pin::ROOT_PIN,
           comments: decl.comment&.string,
+          # @todo some type parameters in core/stdlib have default
+          #   values; Solargraph doesn't support that yet as so these
+          #   get treated as undefined if not specified
           generics: decl.type_params.map(&:name).map(&:to_s)
         )
         pins.push class_pin
@@ -154,6 +157,7 @@ module Solargraph
           name: decl.name.relative!.to_s,
           closure: Solargraph::Pin::ROOT_PIN,
           comments: decl.comment&.string,
+          generics: decl.type_params.map(&:name).map(&:to_s),
           # HACK: Using :hidden to keep interfaces from appearing in
           # autocompletion
           visibility: :hidden
@@ -386,8 +390,11 @@ module Solargraph
       # @param closure [Pin::Namespace]
       # @return [void]
       def include_to_pin decl, closure
+        type = generic_type(decl.name, decl.args)
+        generic_values = type.all_params.map(&:to_s)
         pins.push Solargraph::Pin::Reference::Include.new(
           name: decl.name.relative!.to_s,
+          generic_values: generic_values,
           closure: closure
         )
       end
@@ -441,7 +448,34 @@ module Solargraph
         end
       end
 
-      # @param type [Object]
+      # @param type_name [RBS::TypeName]
+      # @param type_args [Enumerable<RBS::Types::Bases::Base>]
+      # @return [ComplexType]
+      def generic_type(type_name, type_args)
+        base = RBS_TO_YARD_TYPE[type_name.relative!.to_s] || type_name.relative!.to_s
+        params = type_args.map { |a| other_type_to_tag(a) }.reject { |t| t == 'undefined' }
+        params_str = params.empty? ? '' : "<#{params.join(', ')}>"
+        type_string = "#{base}#{params_str}"
+        begin
+          ComplexType.parse(type_string)
+        rescue
+          # @todo Tuples of tuples aren't yet handled by the parser, and that appears in a few
+          #   minor cases in the core/stdlib rbs:
+          #   [WARN] Internal error parsing Array<Array(Integer, Symbol, String, Array(Integer, Integer, Integer, Integer))> from RBS
+          #   [WARN] Internal error parsing Array<Array(Array(Integer, Integer), Symbol, String, Ripper::Lexer::State)> from RBS
+          Solargraph.logger.info "Internal error parsing #{type_string} from RBS; treating as non-generic"
+          ComplexType.parse(base)
+        end
+      end
+
+      # @param type_name [RBS::TypeName]
+      # @param type_args [Enumerable<RBS::Types::Bases::Base>]
+      # @return [String]
+      def generic_type_tag(type_name, type_args)
+        generic_type(type_name, type_args).tag
+      end
+
+      # @param type [RBS::Types::Bases::Base]
       # @return [String]
       def other_type_to_tag type
         if type.is_a?(RBS::Types::Optional)
@@ -469,10 +503,7 @@ module Solargraph
         elsif type.is_a?(RBS::Types::Variable)
           "#{Solargraph::ComplexType::GENERIC_TAG_NAME}<#{type.name}>"
         elsif type.is_a?(RBS::Types::ClassInstance) #&& !type.args.empty?
-          base = RBS_TO_YARD_TYPE[type.name.relative!.to_s] || type.name.relative!.to_s
-          params = type.args.map { |a| other_type_to_tag(a) }.reject { |t| t == 'undefined' }
-          return base if params.empty?
-          "#{base}<#{params.join(', ')}>"
+          generic_type_tag(type.name, type.args)
         elsif type.is_a?(RBS::Types::Bases::Instance)
           'self'
         elsif type.is_a?(RBS::Types::Bases::Top)

--- a/lib/solargraph/type_checker/checks.rb
+++ b/lib/solargraph/type_checker/checks.rb
@@ -51,8 +51,13 @@ module Solargraph
       # @return [Boolean]
       def any_types_match? api_map, expected, inferred
         return duck_types_match?(api_map, expected, inferred) if expected.duck_type?
+        # walk through the union expected type and see if any members
+        # of the union match the inferred type
         expected.each do |exp|
           next if exp.duck_type?
+          # @todo: there should be a level of typechecking where all
+          #   unique types in the inferred must match one of the
+          #   expected unique types
           inferred.each do |inf|
             # return true if exp == inf || api_map.super_and_sub?(fuzz(inf), fuzz(exp))
             return true if exp == inf || either_way?(api_map, inf, exp)
@@ -103,9 +108,12 @@ module Solargraph
       # @param cls2 [ComplexType::UniqueType]
       # @return [Boolean]
       def either_way?(api_map, cls1, cls2)
-        f1 = fuzz(cls1)
-        f2 = fuzz(cls2)
+        # @todo there should be a level of typechecking which uses the
+        #   full tag with parameters to determine compatibility
+        f1 = cls1.name
+        f2 = cls2.name
         api_map.type_include?(f1, f2) || api_map.super_and_sub?(f1, f2) || api_map.super_and_sub?(f2, f1)
+        # api_map.type_include?(f1, f2) || api_map.super_and_sub?(f1, f2) || api_map.super_and_sub?(f2, f1)
       end
     end
   end

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -521,6 +521,18 @@ describe Solargraph::ApiMap do
     expect(fqns).to eq('Foo::Bar')
   end
 
+  it 'handles multiple type parameters without losing cache coherence' do
+    tag = @api_map.qualify('Array<String>')
+    expect(tag).to eq('Array<String>')
+    tag = @api_map.qualify('Array<Integer>')
+    expect(tag).to eq('Array<Integer>')
+  end
+
+  it 'handles multiple type parameters without losing cache coherence' do
+    tag = @api_map.qualify('Hash{Integer => String}')
+    expect(tag).to eq('Hash{Integer => String}')
+  end
+
   it 'qualifies namespaces with conflicting includes' do
     source = Solargraph::Source.load_string(%(
       module Bar; end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1541,4 +1541,19 @@ describe Solargraph::SourceMap::Clip do
     type = clip.infer
     expect(type.tag).to eq('String')
   end
+
+  # pending https://github.com/castwide/solargraph/pull/769
+  xit 'infers yield parameters from self type defined methods in RBS' do
+    source = Solargraph::Source.load_string(%(
+      # @type [Enumerable<String>]
+      a = ['a', 'b', 'c']
+      a.each do |s|
+        s
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [4, 8])
+    type = clip.infer
+    expect(type.to_s).to eq('String')
+  end
 end


### PR DESCRIPTION
Combined with https://github.com/castwide/solargraph/pull/769, this allows the _Each#each self-type-method block's parameter to be typed.

This also sets the stage for future generic references (e.g., subclassing Array<T>).