### PR TITLE
Remove redundant YIELDPARAMS backfills

### DIFF
--- a/lib/solargraph/rbs_map/core_fills.rb
+++ b/lib/solargraph/rbs_map/core_fills.rb
@@ -22,31 +22,6 @@ module Solargraph
                                     closure: Solargraph::Pin::Namespace.new(name: 'Object'), comments: '@return [Class<self>]')
       ]
 
-      YIELDPARAMS = [
-        Override.from_comment('Object#tap', %(
-@return [self]
-@yieldparam [self]
-        )),
-        Override.from_comment('String#each_line', %(
-@yieldparam [String]
-        ))
-      ]
-
-      methods_with_yieldparam_subtypes = %w[
-        Array#each Array#map Array#map! Array#any? Array#all? Array#index
-        Array#keep_if Array#delete_if
-        Enumerable#each_entry Enumerable#map Enumerable#any? Enumerable#all?
-        Enumerable#select Enumerable#reject
-        Set#each
-      ]
-
-      YIELDPARAM_SINGLE_PARAMETERS = methods_with_yieldparam_subtypes.map do |path|
-        Override.from_comment(path, <<~DOC
-          @yieldparam [generic<Elem>]
-        DOC
-        )
-      end
-
       CLASS_RETURN_TYPES = [
         Override.method_return('Class#allocate', 'self'),
       ]
@@ -60,7 +35,7 @@ module Solargraph
       end
       ERRNOS = errnos
 
-      ALL = KEYWORDS + MISSING + YIELDPARAMS + YIELDPARAM_SINGLE_PARAMETERS + CLASS_RETURN_TYPES + ERRNOS
+      ALL = KEYWORDS + MISSING + CLASS_RETURN_TYPES + ERRNOS
     end
   end
 end

--- a/spec/pin/parameter_spec.rb
+++ b/spec/pin/parameter_spec.rb
@@ -293,8 +293,8 @@ describe Solargraph::Pin::Parameter do
     expect(pin.documentation).not_to include('The bar method')
   end
 
-  it "typifies from generic yieldparams" do
-    # This test depends on the fact that Array#each has a generic yieldparam.
+  it "typifies from generic yield params" do
+    # This test depends on RBS definitions for Array#each with generic yield params
     source = Solargraph::Source.load_string(%(
       # @return [Array<String>]
       def list_strings; end


### PR DESCRIPTION
These should be generated by rbs signatures and should work properly after https://github.com/castwide/solargraph/pull/743 which makes them redundant.