### PR TITLE
Reinstate Class core fills

### DIFF
--- a/lib/solargraph/rbs_map/core_fills.rb
+++ b/lib/solargraph/rbs_map/core_fills.rb
@@ -48,7 +48,10 @@ module Solargraph
       end
 
       CLASS_RETURN_TYPES = [
+        Override.method_return('Class#new', 'self'),
+        Override.method_return('Class.new', 'Class<BasicObject>'),
         Override.method_return('Class#allocate', 'self'),
+        Override.method_return('Class.allocate', 'Class<BasicObject>')
       ]
 
       # HACK: Add Errno exception classes

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1585,4 +1585,16 @@ describe Solargraph::SourceMap::Clip do
     type = clip.infer
     expect(type.to_s).to eq('String')
   end
+
+  it 'infers Object<self> from Class.new in core classes' do
+    # Correct inference of Class.new depends on CoreFills, but we're testing
+    # it here because it should eventually work from the core RBS alone.
+    source = Solargraph::Source.load_string(%(
+      Gem::Specification.new
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [1, 28])
+    type = clip.infer
+    expect(type.to_s).to eq('Gem::Specification')
+  end
 end


### PR DESCRIPTION
Version 0.52.0 removed most of the Class core fills, but there are some edge cases where they are still necessary. The specific case where I noticed it is `Gem::Specification.new`. Without the core fills, its inferred return type is `BasicObject`.