### PR TITLE
Require Ruby >= 3

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'head']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4', 'head']
 
     steps:
     - uses: actions/checkout@v3

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.metadata["changelog_uri"]   = "https://github.com/castwide/solargraph/blob/master/CHANGELOG.md"
   s.metadata["source_code_uri"] = "https://github.com/castwide/solargraph"
 
-  s.required_ruby_version = '>= 2.6'
+  s.required_ruby_version = '>= 3.0'
 
   s.add_runtime_dependency 'backport', '~> 1.2'
   s.add_runtime_dependency 'benchmark'
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'observer', '~> 0.1'
   s.add_runtime_dependency 'ostruct', '~> 0.6'
   s.add_runtime_dependency 'parser', '~> 3.0'
-  s.add_runtime_dependency 'rbs', '~> 3.0'
+  s.add_runtime_dependency 'rbs', '~> 3.3'
   s.add_runtime_dependency 'reverse_markdown', '>= 2.0', '< 4'
   s.add_runtime_dependency 'rubocop', '~> 1.38'
   s.add_runtime_dependency 'thor', '~> 1.0'


### PR DESCRIPTION
#781 encountered a bug in RBS versions < 3.3. In order to continue development of RBS support, we'll have to require Ruby >=3 and drop support for 2.6/7.