### PR TITLE
Fix typeDefinitions for neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ Plug-ins and extensions are available for the following editors:
     * Instructions: https://lsp.sublimetext.io/language_servers/#solargraph
 
 * **Vim**
+    * Github: `nvim-lspconfig`, https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#solargraph
     * GitHub: `LanguageClient-neovim`, https://github.com/autozimu/LanguageClient-neovim
     * GitHub: `coc`, https://github.com/neoclide/coc-solargraph
     * GitHub: `Vim-EasyComplete`, https://github.com/jayli/vim-easycomplete

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -783,6 +783,9 @@ module Solargraph
           'textDocument/definition' => {
             definitionProvider: true
           },
+          'textDocument/typeDefinition' => {
+            typeDefinitionProvider: true
+          },
           'textDocument/references' => {
             referencesProvider: true
           },

--- a/lib/solargraph/language_server/message/initialize.rb
+++ b/lib/solargraph/language_server/message/initialize.rb
@@ -123,9 +123,9 @@ module Solargraph
         end
 
         def static_type_definitions
-          return {} unless host.options['type_definitions']
+          return {} unless host.options['typeDefinitions']
           {
-            definitionProvider: true
+            typeDefinitionProvider: true
           }
         end
 

--- a/lib/solargraph/language_server/message/workspace/did_change_configuration.rb
+++ b/lib/solargraph/language_server/message/workspace/did_change_configuration.rb
@@ -12,6 +12,7 @@ module Solargraph::LanguageServer::Message::Workspace
     private
 
     def register_from_options
+      Solargraph.logger.debug "Registering capabilities from options: #{host.options.inspect}"
       # @type [Array<String>]
       y = []
       # @type [Array<String>]
@@ -22,6 +23,7 @@ module Solargraph::LanguageServer::Message::Workspace
       (host.options['formatting'] ? y : n).push('textDocument/formatting')
       (host.options['symbols'] ? y : n).push('textDocument/documentSymbol', 'workspace/symbol')
       (host.options['definitions'] ? y : n).push('textDocument/definition')
+      (host.options['typeDefinitions'] ? y : n).push('textDocument/typeDefinition')
       (host.options['references'] ? y : n).push('textDocument/references')
       (host.options['folding'] ? y : n).push('textDocument/folding')
       (host.options['highlights'] ? y : n).push('textDocument/documentHighlight')

--- a/spec/language_server/message/workspace/did_change_configuration_spec.rb
+++ b/spec/language_server/message/workspace/did_change_configuration_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+
+RSpec.describe Solargraph::LanguageServer::Message::Workspace::DidChangeConfiguration do
+  let(:host) { Solargraph::LanguageServer::Host.new }
+
+  describe '#process' do
+    context 'when no custom settings are provided' do
+      it 'uses default settings' do
+        message = { 'params' => { 'settings' => { 'solargraph' => {} } } }
+        described_class.new(host, message).process
+
+        expect(host.options).to eq(
+          'completion' => true,
+          'hover' => true,
+          'symbols' => true,
+          'definitions' => true,
+          'typeDefinitions' => true,
+          'rename' => true,
+          'references' => true,
+          'autoformat' => false,
+          'diagnostics' => true,
+          'formatting' => false,
+          'folding' => true,
+          'highlights' => true,
+          'logLevel' => 'warn'
+        )
+      end
+    end
+
+    context 'when custom settings are provided' do
+      it 'updates the provided settings' do
+        message = { 'params' => { 'settings' => { 'solargraph' => { 'logLevel' => 'debug' } } } }
+        described_class.new(host, message).process
+
+        expect(host.options['logLevel']).to eq('debug')
+      end
+
+      it 'retains the other default settings' do
+        message = { 'params' => { 'settings' => { 'solargraph' => { 'typeDefinitions' => false } } } }
+        described_class.new(host, message).process
+
+        expect(host.options).to eq(
+          'completion' => true,
+          'hover' => true,
+          'symbols' => true,
+          'definitions' => true,
+          'typeDefinitions' => false,
+          'rename' => true,
+          'references' => true,
+          'autoformat' => false,
+          'diagnostics' => true,
+          'formatting' => false,
+          'folding' => true,
+          'highlights' => true,
+          'logLevel' => 'warn'
+        )
+      end
+    end
+
+    context 'when a capability can be dynamically registered' do
+      before do
+        # This is defined in [Solargraph::LanguageServer::Message::Initialize] phase.
+        host.allow_registration('textDocument/completion')
+      end
+
+      it 'changes capabilities from options' do
+        message = { 'params' => { 'settings' => { 'solargraph' => { 'completion' => true } } } }
+
+        described_class.new(host, message).process
+
+        expect(
+          host.registered?('textDocument/completion')
+        ).to be_truthy, 'Expected textDocument/completion to be registered'
+      end
+    end
+
+    context 'when a capability can not be dynamically registered' do
+      it 'does not change capabilities from options' do
+        message = { 'params' => { 'settings' => { 'solargraph' => { 'completion' => true } } } }
+
+        described_class.new(host, message).process
+
+        expect(
+          host.registered?('textDocument/completion')
+        ).to be_falsy, 'Expected textDocument/completion to not be registered'
+      end
+    end
+  end
+end


### PR DESCRIPTION
Hi,

I happened to be migrating from Vim to Neovim recently when I noticed that go-to-type-definitions were not working with [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig/blob/master/doc/configs.md#solargraph) (default configs).

<img width="777" alt="image" src="https://github.com/user-attachments/assets/4d899b7f-f810-4e9f-92da-218ecd1b20ae" />

Looks like I had overlooked the capabilities registration in https://github.com/castwide/solargraph/pull/717, and apparently the VScode and coc.nvim plugins were more lenient hence didn't notice it.


