### PR TITLE
Infer block-pass symbols

### DIFF
--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -128,7 +128,11 @@ module Solargraph
               # added in Ruby 3.1 - https://bugs.ruby-lang.org/issues/11256
               result.push Chain::BlockVariable.new(nil)
             else
-              result.push Chain::BlockVariable.new("&#{block_variable_name_node.children[0].to_s}")
+              if block_variable_name_node.type == :sym
+                result.push Chain::BlockSymbol.new("#{block_variable_name_node.children[0].to_s}")
+              else
+                result.push Chain::BlockVariable.new("&#{block_variable_name_node.children[0].to_s}")
+              end
             end
           elsif n.type == :hash
             result.push Chain::Hash.new('::Hash', hash_is_splatted?(n))

--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -50,7 +50,7 @@ module Solargraph
             clip = api_map.clip_at(location.filename, pos)
             # Use the return node for inference. The clip might infer from the
             # first node in a method call instead of the entire call.
-            chain = Parser.chain(node, nil, clip.in_block?)
+            chain = Parser.chain(node, nil, nil)
             result = chain.infer(api_map, closure, clip.locals)
             types.push result unless result.undefined?
           end

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -346,7 +346,7 @@ module Solargraph
 
       # @return [ComplexType]
       def generate_complex_type
-        tags = docstring.tags(:return).map(&:types).flatten.reject(&:nil?)
+        tags = docstring.tags(:return).map(&:types).flatten.compact
         return ComplexType::UNDEFINED if tags.empty?
         ComplexType.try_parse *tags
       end

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -435,21 +435,14 @@ module Solargraph
     def inner_tree_at node, position, stack
       return if node.nil?
       here = Range.from_node(node)
-      if here.contain?(position) || colonized(here, position, node)
+      if here.contain?(position)
         stack.unshift node
         node.children.each do |c|
           next unless Parser.is_ast_node?(c)
-          next if !Parser.rubyvm? && c.loc.expression.nil?
+          next if c.loc.expression.nil?
           inner_tree_at(c, position, stack)
         end
       end
-    end
-
-    def colonized range, position, node
-      node.type == :COLON2 &&
-        range.ending.line == position.line &&
-        range.ending.character == position.character - 2 &&
-        code[Position.to_offset(code, Position.new(position.line, position.character - 2)), 2] == '::'
     end
 
     protected

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -21,6 +21,7 @@ module Solargraph
       autoload :Head,             'solargraph/source/chain/head'
       autoload :Or,               'solargraph/source/chain/or'
       autoload :BlockVariable,    'solargraph/source/chain/block_variable'
+      autoload :BlockSymbol,      'solargraph/source/chain/block_symbol'
       autoload :ZSuper,           'solargraph/source/chain/z_super'
       autoload :Hash,             'solargraph/source/chain/hash'
       autoload :Array,            'solargraph/source/chain/array'

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -170,7 +170,7 @@ module Solargraph
         end
         return ComplexType::UNDEFINED if possibles.empty?
 
-        if possibles.first.map(&:name).include?('Enumerator') && links.last&.arguments&.first&.links&.first.is_a?(BlockSymbol)
+        if possibles.first.map(&:name).include?('Enumerator') && links.last.is_a?(Call) && links.last&.arguments&.first&.links&.first.is_a?(BlockSymbol)
           ComplexType.parse(possibles.first.items.find { |sub| sub.name != 'Enumerator' }.to_s)
         else
           type = if possibles.length > 1

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -170,8 +170,9 @@ module Solargraph
         end
         return ComplexType::UNDEFINED if possibles.empty?
 
-        if possibles.first.map(&:name).include?('Enumerator') && links.last.is_a?(Call) && links.last&.arguments&.first&.links&.first.is_a?(BlockSymbol)
-          ComplexType.parse(possibles.first.items.find { |sub| sub.name != 'Enumerator' }.to_s)
+        type = if possibles.length > 1
+          sorted = possibles.map { |t| t.rooted? ? "::#{t}" : t.to_s }.sort { |a, _| a == 'nil' ? 1 : 0 }
+          ComplexType.parse(*sorted)
         else
           type = if possibles.length > 1
             sorted = possibles.map { |t| t.rooted? ? "::#{t}" : t.to_s }.sort { |a, _| a == 'nil' ? 1 : 0 }

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -170,9 +170,8 @@ module Solargraph
         end
         return ComplexType::UNDEFINED if possibles.empty?
 
-        type = if possibles.length > 1
-          sorted = possibles.map { |t| t.rooted? ? "::#{t}" : t.to_s }.sort { |a, _| a == 'nil' ? 1 : 0 }
-          ComplexType.parse(*sorted)
+        if possibles.first.map(&:name).include?('Enumerator') && links.last.is_a?(Call) && links.last&.arguments&.first&.links&.first.is_a?(BlockSymbol)
+          ComplexType.parse(possibles.first.items.find { |sub| sub.name != 'Enumerator' }.to_s)
         else
           type = if possibles.length > 1
             sorted = possibles.map { |t| t.rooted? ? "::#{t}" : t.to_s }.sort { |a, _| a == 'nil' ? 1 : 0 }

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -170,19 +170,15 @@ module Solargraph
         end
         return ComplexType::UNDEFINED if possibles.empty?
 
-        if possibles.first.map(&:name).include?('Enumerator') && links.last.is_a?(Call) && links.last&.arguments&.first&.links&.first.is_a?(BlockSymbol)
-          ComplexType.parse(possibles.first.items.find { |sub| sub.name != 'Enumerator' }.to_s)
+        type = if possibles.length > 1
+          sorted = possibles.map { |t| t.rooted? ? "::#{t}" : t.to_s }.sort { |a, _| a == 'nil' ? 1 : 0 }
+          ComplexType.parse(*sorted)
         else
-          type = if possibles.length > 1
-            sorted = possibles.map { |t| t.rooted? ? "::#{t}" : t.to_s }.sort { |a, _| a == 'nil' ? 1 : 0 }
-            ComplexType.parse(*sorted)
-          else
-            ComplexType.parse(possibles.map(&:to_s).join(', '))
-          end
-          return type if context.nil? || context.return_type.undefined?
-
-          type.self_to(context.return_type.tag)
+          ComplexType.parse(possibles.map(&:to_s).join(', '))
         end
+        return type if context.nil? || context.return_type.undefined?
+
+        type.self_to(context.return_type.tag)
       end
 
       # @param type [ComplexType]

--- a/lib/solargraph/source/chain/block_symbol.rb
+++ b/lib/solargraph/source/chain/block_symbol.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module Solargraph
+  class Source
+    class Chain
+      class BlockSymbol < Link
+        def resolve api_map, name_pin, locals
+          [Pin::ProxyType.anonymous(ComplexType.try_parse('Proc'))]
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -10,18 +10,23 @@ module Solargraph
         # @return [::Array<Chain>]
         attr_reader :arguments
 
+        # @return [Chain, nil]
+        attr_reader :block
+
         # @param word [String]
         # @param arguments [::Array<Chain>]
         # @param with_block [Boolean] True if the chain is inside a block
-        # @param head [Boolean] True if the call is the start of its chain
-        def initialize word, arguments = [], with_block = false
+        # @param block [Chain, nil]
+        def initialize word, arguments = [], with_block = false, block = nil
           @word = word
           @arguments = arguments
           @with_block = with_block
+          @block = block
+          fix_block_pass
         end
 
         def with_block?
-          @with_block
+          !!@block
         end
 
         # @param api_map [ApiMap]
@@ -233,6 +238,11 @@ module Solargraph
         def with_params type, context
           return type unless type.to_s.include?('$')
           ComplexType.try_parse(type.to_s.gsub('$', context.value_types.map(&:tag).join(', ')).gsub('<>', ''))
+        end
+
+        def fix_block_pass
+          argument = @arguments.last&.links&.first
+          @block = @arguments.pop if argument.is_a?(BlockSymbol) || argument.is_a?(BlockVariable)
         end
       end
     end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -15,12 +15,10 @@ module Solargraph
 
         # @param word [String]
         # @param arguments [::Array<Chain>]
-        # @param with_block [Boolean] True if the chain is inside a block
         # @param block [Chain, nil]
-        def initialize word, arguments = [], with_block = false, block = nil
+        def initialize word, arguments = [], block = nil
           @word = word
           @arguments = arguments
-          @with_block = with_block
           @block = block
           fix_block_pass
         end

--- a/lib/solargraph/source/source_chainer.rb
+++ b/lib/solargraph/source/source_chainer.rb
@@ -14,10 +14,10 @@ module Solargraph
 
       class << self
         # @param source [Source]
-        # @param position [Position]
+        # @param position [Position, Array(Integer, Integer)]
         # @return [Source::Chain]
         def chain source, position
-          new(source, position).chain
+          new(source, Solargraph::Position.normalize(position)).chain
         end
       end
 
@@ -41,8 +41,6 @@ module Solargraph
           parent = nil
           if !source.repaired? && source.parsed? && source.synchronized?
             tree = source.tree_at(position.line, position.column)
-            # node, parent = source.tree_at(position.line, position.column)[0..2]
-            tree.shift while tree.length > 1 && tree.first.type == :SCOPE
             node, parent = tree[0..2]
           elsif source.parsed? && source.repaired? && end_of_phrase == '.'
             node, parent = source.tree_at(fixed_position.line, fixed_position.column)[0..2]
@@ -60,7 +58,7 @@ module Solargraph
         end
         return Chain.new([Chain::UNDEFINED_CALL]) if node.nil? || (node.type == :sym && !phrase.start_with?(':'))
         # chain = NodeChainer.chain(node, source.filename, parent && parent.type == :block)
-        chain = Parser.chain(node, source.filename, parent && [:ITER, :block].include?(parent.type))
+        chain = Parser.chain(node, source.filename, parent)
         if source.repaired? || !source.parsed? || !source.synchronized?
           if end_of_phrase.strip == '.'
             chain.links.push Chain::UNDEFINED_CALL

--- a/spec/parser/node_chainer_spec.rb
+++ b/spec/parser/node_chainer_spec.rb
@@ -112,6 +112,15 @@ describe 'NodeChainer' do
     expect(chain.links.first.arguments.length).to eq(2)
   end
 
+  it 'tracks block-pass symbols' do
+    source = Solargraph::Source.load_string(%(
+      foo(&:bar)
+    ))
+    chain = Solargraph::Parser.chain(source.node)
+    arg = chain.links.first.arguments.first.links.first
+    expect(arg).to be_a(Solargraph::Source::Chain::BlockSymbol)
+  end
+
   # feature added in Ruby 3.1
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1')
     it 'tracks anonymous block forwarding' do

--- a/spec/parser/node_chainer_spec.rb
+++ b/spec/parser/node_chainer_spec.rb
@@ -109,7 +109,8 @@ describe 'NodeChainer' do
       foo(bar, &baz)
     ))
     chain = Solargraph::Parser.chain(source.node)
-    expect(chain.links.first.arguments.length).to eq(2)
+    expect(chain.links.first.arguments.length).to eq(1)
+    expect(chain.links.first).to be_with_block
   end
 
   it 'tracks block-pass symbols' do
@@ -117,8 +118,8 @@ describe 'NodeChainer' do
       foo(&:bar)
     ))
     chain = Solargraph::Parser.chain(source.node)
-    arg = chain.links.first.arguments.first.links.first
-    expect(arg).to be_a(Solargraph::Source::Chain::BlockSymbol)
+    expect(chain.links.first.block).to be_a(Solargraph::Source::Chain)
+    expect(chain.links.first.block.links.first).to be_a(Solargraph::Source::Chain::BlockSymbol)
   end
 
   # feature added in Ruby 3.1

--- a/spec/parser/node_chainer_spec.rb
+++ b/spec/parser/node_chainer_spec.rb
@@ -127,7 +127,7 @@ describe 'NodeChainer' do
       foo(&:bar)
     ))
     chain = Solargraph::Parser.chain(source.node)
-    arg = chain.links.first.arguments.first.links.first
+    arg = chain.links.first.block.links.first
     expect(arg).to be_a(Solargraph::Source::Chain::BlockSymbol)
   end
 

--- a/spec/parser/node_chainer_spec.rb
+++ b/spec/parser/node_chainer_spec.rb
@@ -122,6 +122,15 @@ describe 'NodeChainer' do
     expect(chain.links.first.block.links.first).to be_a(Solargraph::Source::Chain::BlockSymbol)
   end
 
+  it 'tracks block-pass symbols' do
+    source = Solargraph::Source.load_string(%(
+      foo(&:bar)
+    ))
+    chain = Solargraph::Parser.chain(source.node)
+    arg = chain.links.first.arguments.first.links.first
+    expect(arg).to be_a(Solargraph::Source::Chain::BlockSymbol)
+  end
+
   # feature added in Ruby 3.1
   if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('3.1')
     it 'tracks anonymous block forwarding' do

--- a/spec/source/source_chainer_spec.rb
+++ b/spec/source/source_chainer_spec.rb
@@ -326,4 +326,14 @@ describe Solargraph::Source::SourceChainer do
     expect(chain.node.type).to be(:send)
     expect(chain.node.children[1]).to be(:s)
   end
+
+  it 'adds blocks to calls' do
+    source = Solargraph::Source.load_string(%(
+      x.y do
+        z
+      end
+    ))
+    chain = Solargraph::Source::SourceChainer.chain(source, [1, 9])
+    expect(chain.links.last.block).to be
+  end
 end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1765,4 +1765,26 @@ describe Solargraph::SourceMap::Clip do
     type = clip.infer
     expect(type.to_s).to eq('undefined')
   end
+
+  it 'infers block-pass symbols from generics' do
+    source = Solargraph::Source.load_string(%(
+      array = [0, 1, 2]
+      array.max_by(&:abs)
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [2, 13])
+    type = clip.infer
+    expect(type.to_s).to eq('Integer')
+  end
+
+  it 'infers block-pass symbols with variant yields' do
+    source = Solargraph::Source.load_string(%(
+      array = [0]
+      array.map(&:to_s)
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [2, 13])
+    type = clip.infer
+    expect(type.to_s).to eq('Array<String>')
+  end
 end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1774,7 +1774,7 @@ describe Solargraph::SourceMap::Clip do
     api_map = Solargraph::ApiMap.new.map(source)
     clip = api_map.clip_at('test.rb', [2, 13])
     type = clip.infer
-    expect(type.to_s).to eq('Integer')
+    expect(type.to_s).to eq('Integer, nil')
   end
 
   it 'infers block-pass symbols with variant yields' do


### PR DESCRIPTION
ref #777 

Example:
```ruby
array = [1, 2, 3]
array.map(&:to_s) # Inferred type is `Array<String>`
```

Requirements:
- [x] Chains recognize the block-pass symbol syntax
- [x] Modify `Chain` and `Call` to support `Block` and `BlockSymbol` links
- [x] Chain#infer resolves types from `BlockSymbol` and resolves the return type's generics

This is going to involve some non-trivial refactoring of source chains. `Call` links should be responsible for resolving block returns, so they need direct access to `Block`, `BlockVariable`, and `BlockSymbol` links passed into them. `BlockSymbol` and `BlockVariable` should not be included in `Call#arguments`. There should be a `Call#block` attribute instead. Resolution of the call's return type can then be moved to `Call#resolve` instead of `Chain#infer`.