### PR TITLE
Remove redundant YIELDPARAMS backfills

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby-version: ['2.6', '2.7', '3.0', '3.1', '3.2', '3.3', '3.4', 'head']
+        ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4', 'head']
 
     steps:
     - uses: actions/checkout@v3

--- a/lib/solargraph/rbs_map/core_fills.rb
+++ b/lib/solargraph/rbs_map/core_fills.rb
@@ -22,31 +22,6 @@ module Solargraph
                                     closure: Solargraph::Pin::Namespace.new(name: 'Object'), comments: '@return [Class<self>]')
       ]
 
-      YIELDPARAMS = [
-        Override.from_comment('Object#tap', %(
-@return [self]
-@yieldparam [self]
-        )),
-        Override.from_comment('String#each_line', %(
-@yieldparam [String]
-        ))
-      ]
-
-      methods_with_yieldparam_subtypes = %w[
-        Array#each Array#map Array#map! Array#any? Array#all? Array#index
-        Array#keep_if Array#delete_if
-        Enumerable#each_entry Enumerable#map Enumerable#any? Enumerable#all?
-        Enumerable#select Enumerable#reject
-        Set#each
-      ]
-
-      YIELDPARAM_SINGLE_PARAMETERS = methods_with_yieldparam_subtypes.map do |path|
-        Override.from_comment(path, <<~DOC
-          @yieldparam [generic<Elem>]
-        DOC
-        )
-      end
-
       CLASS_RETURN_TYPES = [
         Override.method_return('Class#new', 'self'),
         Override.method_return('Class.new', 'Class<BasicObject>'),
@@ -63,7 +38,7 @@ module Solargraph
       end
       ERRNOS = errnos
 
-      ALL = KEYWORDS + MISSING + YIELDPARAMS + YIELDPARAM_SINGLE_PARAMETERS + CLASS_RETURN_TYPES + ERRNOS
+      ALL = KEYWORDS + MISSING + CLASS_RETURN_TYPES + ERRNOS
     end
   end
 end

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |s|
   s.metadata["changelog_uri"]   = "https://github.com/castwide/solargraph/blob/master/CHANGELOG.md"
   s.metadata["source_code_uri"] = "https://github.com/castwide/solargraph"
 
-  s.required_ruby_version = '>= 2.6'
+  s.required_ruby_version = '>= 3.0'
 
   s.add_runtime_dependency 'backport', '~> 1.2'
   s.add_runtime_dependency 'benchmark'
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'observer', '~> 0.1'
   s.add_runtime_dependency 'ostruct', '~> 0.6'
   s.add_runtime_dependency 'parser', '~> 3.0'
-  s.add_runtime_dependency 'rbs', '~> 3.0'
+  s.add_runtime_dependency 'rbs', '~> 3.3'
   s.add_runtime_dependency 'reverse_markdown', '>= 2.0', '< 4'
   s.add_runtime_dependency 'rubocop', '~> 1.38'
   s.add_runtime_dependency 'thor', '~> 1.0'

--- a/spec/pin/parameter_spec.rb
+++ b/spec/pin/parameter_spec.rb
@@ -293,8 +293,8 @@ describe Solargraph::Pin::Parameter do
     expect(pin.documentation).not_to include('The bar method')
   end
 
-  it "typifies from generic yieldparams" do
-    # This test depends on the fact that Array#each has a generic yieldparam.
+  it "typifies from generic yield params" do
+    # This test depends on RBS definitions for Array#each with generic yield params
     source = Solargraph::Source.load_string(%(
       # @return [Array<String>]
       def list_strings; end


### PR DESCRIPTION
These should be generated by rbs signatures and should work properly after https://github.com/castwide/solargraph/pull/743

Testing with ruby >=3.0 https://github.com/castwide/solargraph/pull/791#issuecomment-2727641878 ➡️  ✅ [passed](https://github.com/castwide/solargraph/actions/runs/13908424703/job/38916779646?pr=796) 