### PR TITLE
Add basic plugin integration testing

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -21,8 +21,7 @@ jobs:
         ruby-version: '3.0'
         bundler-cache: false
     - name: Install tools
-      run:
-        - sudo apt-get update -y && sudo apt-get install -y yq
+      run: sudo apt-get update -y && sudo apt-get install -y yq
     - name: Install gems
       run: |
         echo 'gem solargraph-rails' > .Gemfile

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -33,7 +33,7 @@ jobs:
       run: |
         bundle exec solargraph config
         yq -yi '.plugins += ["solargraph-rails"]' .solargraph.yml
-        yq -yi '.plugins += ["solargraph-rspec]' .solargraph.yml
+        yq -yi '.plugins += ["solargraph-rspec"]' .solargraph.yml
     - name: Ensure typechecking still works
       run: bundle exec solargraph typecheck --level typed
     - name: Ensure specs still run

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -1,0 +1,41 @@
+name: Plugin Backwards Compatibility Tests
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        ruby-version: '3.0'
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Ruby
+      uses: ruby/setup-ruby@v1
+      with:
+        ruby-version: ${{ matrix.ruby-version }}
+        bundler-cache: false
+    - name: Install tools
+      - sudo apt-get update -y && sudo apt-get install -y yq
+    - name: Install gems
+      run:
+        - echo 'gem solargraph-rails' > .Gemfile
+        - bundle install
+    - name: Configure to use plugins
+      run:
+        - bundle exec solargraph config
+        - yq -i '.plugins += "solargraph-rails"' .solargraph.yml
+        - yq -i '.plugins += "solargraph-rspec"' .solargraph.yml
+    - name: Ensure typechecking still works
+      run: bundle exec solargraph typecheck --level typed
+    - name: Ensure specs still run
+      run: bundle exec rake spec

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -22,17 +22,17 @@ jobs:
         bundler-cache: false
     - name: Install tools
       run:
-      - sudo apt-get update -y && sudo apt-get install -y yq
+        - sudo apt-get update -y && sudo apt-get install -y yq
     - name: Install gems
-      run:
-        - echo 'gem solargraph-rails' > .Gemfile
-        - echo 'gem solargraph-rspec' >> .Gemfile
-        - bundle install
+      run: |
+        echo 'gem solargraph-rails' > .Gemfile
+        echo 'gem solargraph-rspec' >> .Gemfile
+        bundle install
     - name: Configure to use plugins
-      run:
-        - bundle exec solargraph config
-        - yq -i '.plugins += "solargraph-rails"' .solargraph.yml
-        - yq -i '.plugins += "solargraph-rspec"' .solargraph.yml
+      run: |
+        bundle exec solargraph config
+        yq -i '.plugins += "solargraph-rails"' .solargraph.yml
+        yq -i '.plugins += "solargraph-rspec"' .solargraph.yml
     - name: Ensure typechecking still works
       run: bundle exec solargraph typecheck --level typed
     - name: Ensure specs still run

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -25,6 +25,7 @@ jobs:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: false
     - name: Install tools
+      run:
       - sudo apt-get update -y && sudo apt-get install -y yq
     - name: Install gems
       run:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -29,6 +29,7 @@ jobs:
     - name: Install gems
       run:
         - echo 'gem solargraph-rails' > .Gemfile
+        - echo 'gem solargraph-rspec' >> .Gemfile
         - bundle install
     - name: Configure to use plugins
       run:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -11,18 +11,14 @@ permissions:
 
 jobs:
   test:
-
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        ruby-version: '3.0'
 
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: ${{ matrix.ruby-version }}
+        ruby-version: '3.0'
         bundler-cache: false
     - name: Install tools
       run:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -20,8 +20,10 @@ jobs:
       with:
         ruby-version: '3.0'
         bundler-cache: false
-    - name: Install tools
-      run: sudo apt-get update -y && sudo apt-get install -y yq
+    - uses: awalsh128/cache-apt-pkgs-action@latest
+      with:
+        packages: yq
+        version: 1.0
     - name: Install gems
       run: |
         echo 'gem "solargraph-rails"' > .Gemfile
@@ -30,8 +32,8 @@ jobs:
     - name: Configure to use plugins
       run: |
         bundle exec solargraph config
-        yq -i '.plugins += "solargraph-rails"' .solargraph.yml
-        yq -i '.plugins += "solargraph-rspec"' .solargraph.yml
+        yq -yi '.plugins += ["solargraph-rails"]' .solargraph.yml
+        yq -yi '.plugins += ["solargraph-rspec]' .solargraph.yml
     - name: Ensure typechecking still works
       run: bundle exec solargraph typecheck --level typed
     - name: Ensure specs still run

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -24,8 +24,8 @@ jobs:
       run: sudo apt-get update -y && sudo apt-get install -y yq
     - name: Install gems
       run: |
-        echo 'gem solargraph-rails' > .Gemfile
-        echo 'gem solargraph-rspec' >> .Gemfile
+        echo 'gem "solargraph-rails"' > .Gemfile
+        echo 'gem "solargraph-rspec"' >> .Gemfile
         bundle install
     - name: Configure to use plugins
       run: |

--- a/README.md
+++ b/README.md
@@ -51,8 +51,13 @@ Plug-ins and extensions are available for the following editors:
 
 Solargraph's behavior can be controlled via optional [configuration](https://solargraph.org/guides/configuration) files. The highest priority file is a `.solargraph.yml` file at the root of the project. If not present, any global configuration at `~/.config/solargraph/config.yml` will apply. The path to the global configuration can be overridden with the `SOLARGRAPH_GLOBAL_CONFIG` environment variable.
 
-### Rails Support
+### Plugins
+
+Solargraph supports [plugins](https://solargraph.org/guides/plugins) that implements their own Solargraph features, such as diagnostics reporters and conventions to provide LSP features and type-checking, e.g. for frameworks which use metaprogramming and/or DSLs.
+
 For better Rails support, please consider using [solargraph-rails](https://github.com/iftheshoefritz/solargraph-rails/)
+
+The RSpec framework is supported via [solargraph-rspec](https://github.com/lekemula/solargraph-rspec/)
 
 ### Gem Support
 

--- a/lib/solargraph/parser.rb
+++ b/lib/solargraph/parser.rb
@@ -13,6 +13,11 @@ module Solargraph
       false
     end
 
+    # @deprecated
+    Legacy = ParserGem
+
+    ClassMethods = ParserGem::ClassMethods
+
     extend ParserGem::ClassMethods
 
     NodeMethods = ParserGem::NodeMethods


### PR DESCRIPTION
Add a GitHub Actions workflow to run very basic smoke tests for solargraph-rails and solargraph rspec (typechecking and then running solargraph's specs with it installed and configured)

Also:

* Document solargraph-rspec as a plugin in README.md