### PR TITLE
At strong level, don't allow method calls off of nilable types

### DIFF
--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -28,6 +28,14 @@ module Solargraph
         decl == :restarg
       end
 
+      def mandatory_positional?
+        decl == :arg
+      end
+
+      def positional?
+        !keyword?
+      end
+
       def rest?
         decl == :restarg || decl == :kwrestarg
       end

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -156,7 +156,9 @@ module Solargraph
     # @return [void]
     def typecheck *files
       directory = File.realpath(options[:directory])
-      api_map = Solargraph::ApiMap.load_with_cache(directory)
+      level = options[:level].to_sym
+      rules = Solargraph::TypeChecker::Rules.new(level)
+      api_map = Solargraph::ApiMap.load_with_cache(directory, loose_unions: rules.loose_unions?)
       if files.empty?
         files = api_map.source_maps.map(&:filename)
       else
@@ -165,7 +167,7 @@ module Solargraph
       probcount = 0
       filecount = 0
       files.each do |file|
-        checker = TypeChecker.new(file, api_map: api_map, level: options[:level].to_sym)
+        checker = TypeChecker.new(file, api_map: api_map, rules: rules, level: level)
         problems = checker.problems
         next if problems.empty?
         problems.sort! { |a, b| a.location.range.start.line <=> b.location.range.start.line }

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -24,11 +24,13 @@ module Solargraph
     # @param filename [String]
     # @param api_map [ApiMap, nil]
     # @param level [Symbol]
-    def initialize filename, api_map: nil, level: :normal
+    def initialize filename, api_map: nil, level: :normal, rules: Rules.new(level)
       @filename = filename
       # @todo Smarter directory resolution
-      @api_map = api_map || Solargraph::ApiMap.load(File.dirname(filename))
-      @rules = Rules.new(level)
+      @rules = rules
+      @api_map = api_map || Solargraph::ApiMap.load(File.dirname(filename),
+                                                    loose_unions: rules.loose_unions?)
+
       @marked_ranges = []
     end
 
@@ -55,9 +57,10 @@ module Solargraph
       # @return [self]
       def load filename, level = :normal
         source = Solargraph::Source.load(filename)
-        api_map = Solargraph::ApiMap.new
+        rules = Rules.new(level)
+        api_map = Solargraph::ApiMap.new(loose_unions: rules.loose_unions?)
         api_map.map(source)
-        new(filename, api_map: api_map, level: level)
+        new(filename, api_map: api_map, level: level, rules: rules)
       end
 
       # @param code [String]
@@ -66,9 +69,10 @@ module Solargraph
       # @return [self]
       def load_string code, filename = nil, level = :normal
         source = Solargraph::Source.load_string(code, filename)
-        api_map = Solargraph::ApiMap.new
+        rules = Rules.new(level)
+        api_map = Solargraph::ApiMap.new(loose_unions: rules.loose_unions?)
         api_map.map(source)
-        new(filename, api_map: api_map, level: level)
+        new(filename, api_map: api_map, level: level, rules: rules)
       end
     end
 

--- a/lib/solargraph/type_checker/rules.rb
+++ b/lib/solargraph/type_checker/rules.rb
@@ -49,6 +49,10 @@ module Solargraph
         rank > LEVELS[:typed]
       end
 
+      def loose_unions?
+        rank < LEVELS[:strong]
+      end
+
       def validate_tags?
         rank > LEVELS[:normal]
       end

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -307,4 +307,34 @@ describe Solargraph::Source::Chain::Call do
     # @todo It would be more accurate to return `Enumerator<Array<Integer>>` here
     expect(type.tag).to eq('Enumerator<Integer, String, Array<Integer>>')
   end
+
+  it 'allows calls off of nilable objects by default' do
+    source = Solargraph::Source.load_string(%(
+      # @type [String, nil]
+      f = foo
+      a = f.upcase
+      a
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(4, 6))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    expect(type.tag).to eq('String')
+  end
+
+  it 'denies calls off of nilable objects when loose union mode is off' do
+    source = Solargraph::Source.load_string(%(
+      # @type [String, nil]
+      f = foo
+      a = f.upcase
+      a
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new(loose_unions: false)
+    api_map.map source
+
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(4, 6))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    expect(type.tag).to eq('undefined')
+  end
 end


### PR DESCRIPTION
Require that all unique types of a complex type offer the same method before it can match when "loose unions" mode is turned off.