### PR TITLE
Resolve return type of block symbols and use for method resolution

### DIFF
--- a/lib/solargraph/source/chain/block_symbol.rb
+++ b/lib/solargraph/source/chain/block_symbol.rb
@@ -5,7 +5,14 @@ module Solargraph
     class Chain
       class BlockSymbol < Link
         def resolve api_map, name_pin, locals
-          [Pin::ProxyType.anonymous(ComplexType.try_parse('Proc'))]
+          return [Pin::ProxyType.anonymous(ComplexType::UNDEFINED)] if locals.empty?
+          first_arg_return_type = locals.first.return_type
+          first_arg_return_type.items.flat_map do |unique_type|
+            api_map.get_method_stack(unique_type.tag, word).map do |method_pin|
+
+              Pin::ProxyType.anonymous(method_pin.return_type)
+            end
+          end
         end
       end
     end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -98,7 +98,8 @@ module Solargraph
                 end
               end
               if match
-                new_signature_pin = ol.resolve_generics_from_context_until_complete(ol.generics, atypes)
+                block_return_type = block.infer(api_map, Pin::ProxyType.anonymous(context), ol.block.parameters) if block && ol.block
+                new_signature_pin = ol.resolve_generics_from_context_until_complete(ol.generics, atypes, nil, nil, block_return_type)
                 new_return_type = new_signature_pin.return_type
                 type = with_params(new_return_type.self_to(context.to_s), context).qualify(api_map, context.namespace) if new_return_type.defined?
                 type ||= ComplexType::UNDEFINED

--- a/spec/source/chain_spec.rb
+++ b/spec/source/chain_spec.rb
@@ -210,7 +210,7 @@ describe Solargraph::Source::Chain do
     expect(type.to_s).to eq('Array, String')
   end
 
-  it 'infers Procs from block-pass nodes' do
+  it 'infers undefined from block-pass node with no caller' do
     source = Solargraph::Source.load_string(%(
       x = []
       x.map(&:foo)
@@ -220,9 +220,7 @@ describe Solargraph::Source::Chain do
     node = source.node_at(2, 12)
     chain = Solargraph::Parser.chain(node, 'test.rb')
     pin = chain.define(api_map, Solargraph::Pin::ROOT_PIN, []).first
-    expect(pin.return_type.tag).to eq('Proc')
-    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, [])
-    expect(type.tag).to eq('Proc')
+    expect(pin.return_type.tag).to eq('undefined')
   end
 
   it 'infers Boolean from true' do


### PR DESCRIPTION
Builds on #793 as a diff against the infer-block-symbol branch