### PR TITLE
Add :if support to NodeChainer for if statements as lvalues

### DIFF
--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -119,6 +119,8 @@ module Solargraph
             result.concat generate_links(n.children.last)
           elsif n.type == :or
             result.push Chain::Or.new([NodeChainer.chain(n.children[0], @filename), NodeChainer.chain(n.children[1], @filename)])
+          elsif n.type == :if
+            result.push Chain::If.new([NodeChainer.chain(n.children[1], @filename), NodeChainer.chain(n.children[2], @filename)])
           elsif [:begin, :kwbegin].include?(n.type)
             result.concat generate_links(n.children.last)
           elsif n.type == :block_pass

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -19,6 +19,7 @@ module Solargraph
       autoload :GlobalVariable,   'solargraph/source/chain/global_variable'
       autoload :Literal,          'solargraph/source/chain/literal'
       autoload :Head,             'solargraph/source/chain/head'
+      autoload :If,               'solargraph/source/chain/if'
       autoload :Or,               'solargraph/source/chain/or'
       autoload :BlockVariable,    'solargraph/source/chain/block_variable'
       autoload :ZSuper,           'solargraph/source/chain/z_super'

--- a/lib/solargraph/source/chain/if.rb
+++ b/lib/solargraph/source/chain/if.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+module Solargraph
+  class Source
+    class Chain
+      class If < Link
+        def word
+          '<if>'
+        end
+
+        # @param links [::Array<Link>]
+        def initialize links
+          @links = links
+        end
+
+        def resolve api_map, name_pin, locals
+          types = @links.map { |link| link.infer(api_map, name_pin, locals) }
+          [Solargraph::Pin::ProxyType.anonymous(Solargraph::ComplexType.try_parse(types.map(&:tag).uniq.join(', ')))]
+        end
+      end
+    end
+  end
+end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -977,6 +977,33 @@ describe Solargraph::SourceMap::Clip do
     expect(clip.complete.pins.map(&:name)).to include('baz:')
   end
 
+  it 'infers unique variable type from ternary operator when used as lvalue' do
+    source = Solargraph::Source.load_string(%(
+      def foo a
+        a = (true ? 'foo' : 'bar') + 'baz'
+        a
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    clip = api_map.clip_at('test.rb', [3, 8])
+    expect(clip.infer.to_s).to eq('String')
+  end
+
+  xit 'infers complex variable type from ternary operator' do
+    source = Solargraph::Source.load_string(%(
+      def foo a
+        type = (a == 123 ? 'foo' : 456)
+        type
+      end
+      foo(932)
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    clip = api_map.clip_at('test.rb', [5, 14])
+    expect(clip.infer.to_s).to eq('String, Integer')
+  end
+
   it 'includes tagged params for trailing hashes' do
     source = Solargraph::Source.load_string(%(
       class Foo


### PR DESCRIPTION
Example:

```ruby
        # the output of the "if" here is the receiver of the String#+ method
        a = (b ? 'foo' : 'bar') + 'baz' 
```

Previously the :if node in the chain would become an undefined link, breaking the chain and resulting in an `Unresolved call to +` error in strict typechecking