### PR TITLE
Map mixins from RBS

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -550,7 +550,7 @@ module Solargraph
       rooted_type = ComplexType.parse(rooted_tag)
       fqns = rooted_type.namespace
       fqns_generic_params = rooted_type.all_params
-      return [] if no_core && fqns =~ /^(Object|BasicObject|Class|Module|Kernel)$/
+      return [] if no_core && fqns =~ /^(Object|BasicObject|Class|Module)$/
       reqstr = "#{fqns}|#{scope}|#{visibility.sort}|#{deep}"
       return [] if skip.include?(reqstr)
       skip.add reqstr

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -133,7 +133,7 @@ module Solargraph
       # @param context_type [ComplexType] The receiver type
       # @return [UniqueType, ComplexType]
       def resolve_generics definitions, context_type
-        return self if definitions.generics.empty?
+        return self if definitions.nil? || definitions.generics.empty?
 
         transform(name) do |t|
           if t.name == GENERIC_TAG_NAME

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -173,15 +173,7 @@ module Solargraph
             name: decl.super_class.name.relative!.to_s
           )
         end
-
-        decl.each_mixin do |mixin|
-          klass = mixin.is_a?(RBS::AST::Members::Include) ? Pin::Reference::Include : Pin::Reference::Extend
-          pins.push klass.new(
-            name: mixin.name.relative!.to_s,
-            location: rbs_location_to_location(mixin.location),
-            closure: class_pin.closure
-          )
-        end
+        add_mixins decl, class_pin.closure
         convert_members_to_pins decl, class_pin
       end
 
@@ -218,14 +210,7 @@ module Solargraph
         convert_self_types_to_pins decl, module_pin
         convert_members_to_pins decl, module_pin
 
-        decl.each_mixin do |mixin|
-          klass = mixin.is_a?(RBS::AST::Members::Include) ? Pin::Reference::Include : Pin::Reference::Extend
-          pins.push klass.new(
-            name: mixin.name.relative!.to_s,
-            location: rbs_location_to_location(mixin.location),
-            closure: module_pin.closure
-          )
-        end
+        add_mixins decl, module_pin.closure
       end
 
       # @param name [String]
@@ -641,6 +626,19 @@ module Solargraph
         else
           Solargraph.logger.warn "Unrecognized RBS type: #{type.class} at #{type.location}"
           'undefined'
+        end
+      end
+
+      # @param decl [RBS::AST::Declarations::Class, RBS::AST::Declarations::Module]
+      # @param closure [Pin::Closure]
+      def add_mixins decl, closure
+        decl.each_mixin do |mixin|
+          klass = mixin.is_a?(RBS::AST::Members::Include) ? Pin::Reference::Include : Pin::Reference::Extend
+          pins.push klass.new(
+            name: mixin.name.relative!.to_s,
+            location: rbs_location_to_location(mixin.location),
+            closure: closure
+          )
         end
       end
     end

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -145,7 +145,7 @@ describe Solargraph::ApiMap do
 
   it 'includes Kernel methods in the root namespace' do
     @api_map.index []
-    pins = @api_map.get_methods('')
+    pins = @api_map.get_methods('', visibility: [:private])
     expect(pins.map(&:path)).to include('Kernel#puts')
   end
 


### PR DESCRIPTION
Modify RBS conversions to add reference pins for mixins.

Making the core map more accurate should let us reduce some of the special case handling in `ApiMap` method queries.
