### PR TITLE
Fix issue with wrong signature selection by call with block node

### DIFF
--- a/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
@@ -21,6 +21,7 @@ module Solargraph
             pins.push Solargraph::Pin::Block.new(
               location: location,
               closure: parent,
+              node: node,
               receiver: node.children[0],
               comments: comments_for(node),
               scope: region.scope || region.closure.context.scope

--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -3,19 +3,22 @@
 module Solargraph
   module Pin
     class Block < Closure
-      # The signature of the method that receives this block.
-      #
       # @return [Parser::AST::Node]
       attr_reader :receiver
 
+      # @return [Parser::AST::Node]
+      attr_reader :node
+
       # @param receiver [Parser::AST::Node, nil]
+      # @param node [Parser::AST::Node, nil]
       # @param context [ComplexType, nil]
       # @param args [::Array<Parameter>]
-      def initialize receiver: nil, args: [], context: nil, **splat
+      def initialize receiver: nil, args: [], context: nil, node: nil, **splat
         super(**splat)
         @receiver = receiver
         @context = context
         @parameters = args
+        @node = node
       end
 
       # @param api_map [ApiMap]

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -136,7 +136,7 @@ module Solargraph
       # @return [ComplexType]
       def typify_block_param api_map
         if closure.is_a?(Pin::Block) && closure.receiver
-          chain = Parser.chain(closure.receiver, filename)
+          chain = Parser.chain(closure.receiver, filename, closure.node)
           clip = api_map.clip_at(location.filename, location.range.start)
           locals = clip.locals - [self]
           meths = chain.define(api_map, closure, locals)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -72,10 +72,8 @@ module Solargraph
               match = true
 
               atypes = []
-              block_parameter = nil
               arguments.each_with_index do |arg, idx|
                 param = ol.parameters[idx]
-                atype = nil
                 if param.nil?
                   match = ol.parameters.any?(&:restarg?)
                   break
@@ -235,6 +233,8 @@ module Solargraph
           @block = @arguments.pop if argument.is_a?(BlockSymbol) || argument.is_a?(BlockVariable)
         end
 
+        # @param api_map [ApiMap]
+        # @param context [ComplexType]
         def block_call_type(api_map, context)
           return nil unless with_block?
 

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1849,7 +1849,7 @@ describe Solargraph::SourceMap::Clip do
     expect(type.rooted?).to be true
   end
 
-  xit 'infers block parameter type for Array#select' do
+  it 'infers block parameter type for Array#select' do
     source = Solargraph::Source.load_string(%(
       a = [1,2,3]
       a.select { |i| i }


### PR DESCRIPTION
We were picking the wrong signature for Enumerator#select and Enumerator#find because Chain::Call didn't have access to the block that was passed in and didn't think the arity matched as a result.