### PR TITLE
Disable ApiMap clip cache

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -460,8 +460,10 @@ module Solargraph
     def clip cursor
       raise FileNotFoundError, "ApiMap did not catalog #{cursor.filename}" unless source_map_hash.key?(cursor.filename)
 
-      cache.get_clip(cursor) ||
-        SourceMap::Clip.new(self, cursor).tap { |clip| cache.set_clip(cursor, clip) }
+      # @todo Clip caches are disabled pending resolution of a stale cache bug
+      # cache.get_clip(cursor) ||
+      #   SourceMap::Clip.new(self, cursor).tap { |clip| cache.set_clip(cursor, clip) }
+      SourceMap::Clip.new(self, cursor)
     end
 
     # Get an array of document symbols from a file.


### PR DESCRIPTION
ApiMap clip caches have a tendency to lag behind source synchronization. I'm disabling them pending either improvement or deprecation.