### PR TITLE
Fix kwoptarg string in Parameter#to_rbs

### DIFF
--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -43,7 +43,7 @@ module Solargraph
         when :kwarg
           "#{name}: #{return_type.to_rbs}"
         when :kwoptarg
-          "#?{name}: #{return_type.to_rbs}"
+          "?#{name}: #{return_type.to_rbs}"
         when :restarg
           "*#{super}"
         when :kwrestarg


### PR DESCRIPTION
Small typo in the interpolated string for kwoptarg parameters.