### PR TITLE
Rescue exceptions in docstring parsing

### DIFF
--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -512,6 +512,10 @@ module Solargraph
         # HACK: Pass a dummy code object to the parser for plugins that
         # expect it not to be nil
         YARD::Docstring.parser.parse(comments, YARD::CodeObjects::Base.new(:root, 'stub'))
+      rescue StandardError => e
+        Solargraph.logger.info "YARD failed to parse docstring: [#{e.class}] #{e.message}"
+        Solargraph.logger.debug "Unparsed comment: #{comments}"
+        YARD::Docstring.parser
       end
     end
   end

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -323,4 +323,10 @@ y = 1 #foo
     )
     expect(source.string_ranges.length).to eq(4)
   end
+
+  it 'handles errors in docstrings' do
+    # YARD has a known problem with empty @overload tags
+    comments = "@overload\n@return [String]"
+    expect { Solargraph::Source.parse_docstring(comments) }.not_to raise_error
+  end
 end


### PR DESCRIPTION
fixes #829

Rescue exceptions from `YARD::Docstring.parser.parse` and return an empty parser instead.