### PR TITLE
Use configured command path to spawn solargraph processes

### DIFF
--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -292,7 +292,8 @@ module Solargraph
         path = ''
         path = normalize_separators(directory) unless directory.nil?
         begin
-          lib = Solargraph::Library.load(path, name)
+          workspace = Solargraph::Workspace.new(path, nil, options)
+          lib = Solargraph::Library.new(workspace, name)
           libraries.push lib
           async_library_map lib
         rescue WorkspaceTooLargeError => e

--- a/lib/solargraph/language_server/host/dispatch.rb
+++ b/lib/solargraph/language_server/host/dispatch.rb
@@ -95,6 +95,10 @@ module Solargraph
           nil
         end
 
+        def options
+          @options ||= {}.freeze
+        end
+
         # Get a generic library for the given URI and attach the corresponding
         # source.
         #
@@ -109,7 +113,7 @@ module Solargraph
 
         # @return [Library]
         def generic_library
-          @generic_library ||= Solargraph::Library.new
+          @generic_library ||= Solargraph::Library.new(Solargraph::Workspace.new('', nil, options), nil)
         end
       end
     end

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -603,7 +603,7 @@ module Solargraph
 
       logger.info "Caching #{spec.name} #{spec.version}"
       Thread.new do
-        @cache_pid = Process.spawn('solargraph', 'cache', spec.name, spec.version.to_s)
+        @cache_pid = Process.spawn(workspace.command_path, 'cache', spec.name, spec.version.to_s)
         Process.wait(@cache_pid)
         logger.info "Cached #{spec.name} #{spec.version}"
         @synchronized = false

--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -25,9 +25,11 @@ module Solargraph
 
     # @param directory [String]
     # @param config [Config, nil]
-    def initialize directory = '', config = nil
+    # @param server [Hash]
+    def initialize directory = '', config = nil, server = {}
       @directory = directory
       @config = config
+      @server = server
       load_sources
       @gemnames = []
       @require_paths = generate_require_paths
@@ -134,7 +136,18 @@ module Solargraph
       source_hash[updater.filename] = source_hash[updater.filename].synchronize(updater)
     end
 
+    # @return [String]
+    def command_path
+      server['commandPath'] || 'solargraph'
+    end
+
     private
+
+    # The language server configuration (or an empty hash if the workspace was
+    # not initialized from a server).
+    #
+    # @return [Hash]
+    attr_reader :server
 
     # @return [Hash{String => Solargraph::Source}]
     def source_hash


### PR DESCRIPTION
Language servers can configure the path to the `solargraph` command. The `Library` should use the configured path when it spawns processes to cache gems.