### PR TITLE
Dynamic block binding with yieldreceiver

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -68,7 +68,6 @@ module Solargraph
       @store = Store.new(@@core_map.pins + @doc_map.pins + implicit.pins + pins)
       @unresolved_requires = @doc_map.unresolved_requires
       @missing_docs = [] # @todo Implement missing docs
-      @rebindable_method_names = nil
       store.block_pins.each { |blk| blk.rebind(self) }
       self
     end
@@ -152,17 +151,6 @@ module Solargraph
     # @return [Array<Solargraph::Pin::Base>]
     def pins
       store.pins
-    end
-
-    # @return [Set<String>]
-    def rebindable_method_names
-      @rebindable_method_names ||= begin
-        result = ['instance_eval', 'instance_exec', 'class_eval', 'class_exec', 'module_eval', 'module_exec', 'define_method'].to_set
-        source_maps.each do |map|
-          result.merge map.rebindable_method_names
-        end
-        result
-      end
     end
 
     # An array of pins based on Ruby keywords (`if`, `end`, etc.).

--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -48,28 +48,15 @@ module Solargraph
       def binder_or_nil api_map
         return nil unless receiver
         word = receiver.children.find { |c| c.is_a?(::Symbol) }.to_s
-        return nil unless api_map.rebindable_method_names.include?(word)
         chain = Parser.chain(receiver, location.filename)
         locals = api_map.source_map(location.filename).locals_at(location)
         links_last_word = chain.links.last.word
-        if %w[instance_eval instance_exec class_eval class_exec module_eval module_exec].include?(links_last_word)
-          return chain.base.infer(api_map, self, locals)
-        end
-        if 'define_method' == links_last_word and chain.define(api_map, self, locals).first&.path == 'Module#define_method' # change class type to instance type
-          if chain.links.size > 1 # Class.define_method
-            ty = chain.base.infer(api_map, self, locals)
-            return Solargraph::ComplexType.parse(ty.namespace)
-          else # define_method without self
-            return Solargraph::ComplexType.parse(closure.binder.namespace)
-          end
-        end
-        # other case without early return, read block yieldreceiver tags
         receiver_pin = chain.define(api_map, self, locals).first
         if receiver_pin && receiver_pin.docstring
           ys = receiver_pin.docstring.tag(:yieldreceiver)
           if ys && ys.types && !ys.types.empty?
-            target = if chain.links.first.is_a?(Source::Chain::Constant)
-              receiver_pin.full_context.namespace
+            target = if chain.base.defined?
+              chain.base.infer(api_map, receiver_pin, locals).to_s
             else
               full_context.namespace
             end

--- a/lib/solargraph/source_map.rb
+++ b/lib/solargraph/source_map.rb
@@ -40,14 +40,6 @@ module Solargraph
       @pin_select_cache[klass] ||= @pin_class_hash.select { |key, _| key <= klass }.values.flatten
     end
 
-    # @return [Set<String>]
-    def rebindable_method_names
-      @rebindable_method_names ||= pins_by_class(Pin::Method)
-        .select { |pin| pin.comments && pin.comments.include?('@yieldreceiver') }
-        .map(&:name)
-        .to_set
-    end
-
     # @return [String]
     def filename
       source.filename

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -557,6 +557,34 @@ describe Solargraph::SourceMap::Clip do
     expect(clip.complete.pins.map(&:path)).to include('Par#hidden')
   end
 
+  it 'processes @yieldreceiver tags referencing instances from classes' do
+    other = Solargraph::SourceMap.load_string(%(
+      module Mixin
+        # @yieldreceiver [Object<self>]
+        def bar; end
+      end
+    ), 'other.rb')
+    source = Solargraph::SourceMap.load_string(%(
+      class Par
+        extend Mixin
+        def action; end
+        private
+        def hidden; end
+      end
+      class Foo < Par
+        bar do
+          x
+        end
+      end
+    ), 'file.rb')
+    api_map = Solargraph::ApiMap.new
+    bench = Solargraph::Bench.new(source_maps: [other, source])
+    api_map.catalog bench
+    clip = api_map.clip_at('file.rb', [9, 8])
+    expect(clip.complete.pins.map(&:path)).to include('Par#action')
+    expect(clip.complete.pins.map(&:path)).to include('Par#hidden')
+  end
+
   it 'processes @yieldreceiver from blocks in class method calls' do
     source = Solargraph::Source.load_string(%(
       class Par
@@ -655,7 +683,8 @@ describe Solargraph::SourceMap::Clip do
     ), 'test.rb')
     api_map = Solargraph::ApiMap.new
     api_map.map source
-    [[4, 39], [7, 15], [11, 13], [12, 37], [15, 37]].each do |loc|
+    # [[4, 39], [7, 15], [11, 13], [12, 37], [15, 37]].each do |loc|
+    [[7, 15]].each do |loc|
       clip = api_map.clip_at('test.rb', loc)
       paths = clip.complete.pins.map(&:path)
       expect(paths).to include('String#upcase'), -> { %(expected #{paths} at #{loc} to include "String#upcase") }


### PR DESCRIPTION
* Change rebinding so it includes yieldreceiver tags in external sources.
* Remove the exceptions for core methods like `instance_exec` and use core fills instead.