### PR TITLE
[regression] Restore 'Unresolved call' typecheck for stdlib objects

### DIFF
--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -38,6 +38,8 @@ module Solargraph
         environment = RBS::Environment.from_loader(loader).resolve_type_names
         cursor = pins.length
         environment.declarations.each { |decl| convert_decl_to_pin(decl, Solargraph::Pin::ROOT_PIN) }
+        added_pins = pins[cursor..-1]
+        added_pins.each { |pin| pin.source = :rbs }
       end
 
       # @param decl [RBS::AST::Declarations::Base]

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -268,6 +268,7 @@ module Solargraph
             base = base.base
           end
           closest = found.typify(api_map) if found
+          # @todo remove the internal_or_core? check at a higher-than-strict level
           if !found || found.is_a?(Pin::BaseVariable) || (closest.defined? && internal_or_core?(found))
             unless closest.generic? || ignored_pins.include?(found)
               result.push Problem.new(location, "Unresolved call to #{missing.links.last.word}")

--- a/spec/rbs_map/stdlib_map_spec.rb
+++ b/spec/rbs_map/stdlib_map_spec.rb
@@ -56,4 +56,12 @@ describe Solargraph::RbsMap::StdlibMap do
       expect(['Module<YAML>', 'Module<Psych>']).to include(return_type)
     end
   end
+
+  it 'pins are marked as coming from RBS parsing' do
+    map = Solargraph::RbsMap::StdlibMap.load('yaml')
+    store = Solargraph::ApiMap::Store.new(map.pins)
+    constant_pins = store.get_constants('')
+    pin = constant_pins.first
+    expect(pin.source).to eq(:rbs)
+  end
 end


### PR DESCRIPTION
The 'Unresolved call to' typecheck suppresses warnings for calls against non-RBS-origin pins.  However, the labeling assigning :rbs as the source of pins from conversions.rb was recently removed as part of an unrelated cleanup.