### PR TITLE
Create implicit .new pins in namespace method queries

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -311,6 +311,26 @@ module Solargraph
         result.concat inner_get_methods('Kernel', :instance, visibility, deep, skip)
       else
         result.concat inner_get_methods(rooted_tag, scope, visibility, deep, skip)
+        unless %w[Class Class<Class>].include?(rooted_tag)
+          result.map! do |pin|
+            next pin unless pin.path == 'Class#new'
+            init_pin = get_method_stack(rooted_tag, 'initialize').first
+            next pin unless init_pin
+
+            type = ComplexType.try_parse(ComplexType.try_parse(rooted_tag).namespace)
+            Pin::Method.new(
+              name: 'new',
+              scope: :class,
+              location: init_pin.location,
+              parameters: init_pin.parameters,
+              signatures: init_pin.signatures.map { |sig| sig.proxy(type) },
+              return_type: type,
+              comments: init_pin.comments,
+              closure: init_pin.closure
+            # @todo Hack to force TypeChecker#internal_or_core?
+            ).tap { |pin| pin.source = :rbs }
+          end
+        end
         result.concat inner_get_methods('Kernel', :instance, [:public], deep, skip) if visibility.include?(:private)
         result.concat inner_get_methods('Module', scope, visibility, deep, skip)
       end
@@ -724,23 +744,22 @@ module Solargraph
     # @param visibility [Enumerable<Symbol>]
     # @return [Array<Pin::Base>]
     def resolve_method_aliases pins, visibility = [:public, :private, :protected]
-      result = []
-      pins.each do |pin|
+      pins.map do |pin|
         resolved = resolve_method_alias(pin)
-        next if resolved.respond_to?(:visibility) && !visibility.include?(resolved.visibility)
-        result.push resolved
-      end
-      result
+        next pin if resolved.respond_to?(:visibility) && !visibility.include?(resolved.visibility)
+        resolved
+      end.compact
     end
 
     # @param pin [Pin::MethodAlias, Pin::Base]
     # @return [Pin::Method]
     def resolve_method_alias pin
-      return pin if !pin.is_a?(Pin::MethodAlias) || @method_alias_stack.include?(pin.path)
+      return pin unless pin.is_a?(Pin::MethodAlias)
+      return nil if @method_alias_stack.include?(pin.path)
       @method_alias_stack.push pin.path
       origin = get_method_stack(pin.full_context.tag, pin.original, scope: pin.scope).first
       @method_alias_stack.pop
-      return pin if origin.nil?
+      return nil if origin.nil?
       args = {
         location: pin.location,
         closure: pin.closure,

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -493,6 +493,21 @@ module Solargraph
         end
         if params['data']['path']
           result.concat library.path_pins(params['data']['path'])
+          if result.empty? && params['data']['path'] =~ /\.new$/
+            result.concat(library.path_pins(params['data']['path'].sub(/\.new$/, '#initialize')).map do |pin|
+              next pin unless pin.name == 'initialize'
+
+              Pin::Method.new(
+                name: 'new',
+                scope: :class,
+                location: pin.location,
+                parameters: pin.parameters,
+                return_type: ComplexType.try_parse(params['data']['path']),
+                comments: pin.comments,
+                closure: pin.closure
+              )
+            end)
+          end
         end
         # Selecting by both location and path can result in duplicate pins
         result.uniq { |p| [p.path, p.location] }

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -493,6 +493,9 @@ module Solargraph
         end
         if params['data']['path']
           result.concat library.path_pins(params['data']['path'])
+          # @todo This exception is necessary because `Library#path_pins` does
+          #   not perform a namespace method query, so the implicit `.new` pin
+          #   might not exist.
           if result.empty? && params['data']['path'] =~ /\.new$/
             result.concat(library.path_pins(params['data']['path'].sub(/\.new$/, '#initialize')).map do |pin|
               next pin unless pin.name == 'initialize'

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1173,7 +1173,7 @@ describe Solargraph::SourceMap::Clip do
 
     clip = api_map.clip_at('test.rb', [7, 17])
     pin = clip.complete.pins.select { |p| p.name == 'new' }.first
-    expect(pin.path).to eq('Class#new')
+    expect(pin.path).to eq('BasicObject.new')
   end
 
   it 'completes clips from repaired sources ending with a period' do

--- a/spec/type_checker/levels/typed_spec.rb
+++ b/spec/type_checker/levels/typed_spec.rb
@@ -358,7 +358,7 @@ describe Solargraph::TypeChecker do
         class Bar < Foo; end
         Bar.new
       ))
-      expect(checker.problems.map(&:message)).to eq(['Not enough arguments to Foo#initialize'])
+      expect(checker.problems.map(&:message)).to eq(['Not enough arguments to Foo.new'])
     end
 
     it 'validates constuctor arities when not overridden by subtype' do


### PR DESCRIPTION
Due to the inherent nature of `Class#new` and `BasicObject#initialize`, the need for some kind of exceptional handling is inevitable. For now, we're creating implicit `.new` pins to override `Class#new` in namespace method queries.