### PR TITLE
Handle nil reference offsets

### DIFF
--- a/lib/solargraph/parser/parser_gem/class_methods.rb
+++ b/lib/solargraph/parser/parser_gem/class_methods.rb
@@ -66,12 +66,14 @@ module Solargraph
           else
             # @param code [String]
             # @param offset [Integer]
-            extract_offset = ->(code, offset) { [soff = code.index(name, offset), soff + name.length] }
+            extract_offset = ->(code, offset) { [soff = code.index(name, offset), soff&.+(name.length)] }
           end
           inner_node_references(name, source.node).map do |n|
             rng = Range.from_node(n)
             offset = Position.to_offset(source.code, rng.start)
             soff, eoff = extract_offset[source.code, offset]
+            next unless soff && eoff
+
             Location.new(
               source.filename,
               Range.new(
@@ -80,6 +82,7 @@ module Solargraph
               )
             )
           end
+          .compact
         end
 
         # @param name [String]


### PR DESCRIPTION
Closes #846 

I don't have a reproducible example, but it seems safe to ignore reference locations without valid offsets.