### PR TITLE
Remove clip caches

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -466,9 +466,6 @@ module Solargraph
     def clip cursor
       raise FileNotFoundError, "ApiMap did not catalog #{cursor.filename}" unless source_map_hash.key?(cursor.filename)
 
-      # @todo Clip caches are disabled pending resolution of a stale cache bug
-      # cache.get_clip(cursor) ||
-      #   SourceMap::Clip.new(self, cursor).tap { |clip| cache.set_clip(cursor, clip) }
       SourceMap::Clip.new(self, cursor)
     end
 

--- a/lib/solargraph/api_map/cache.rb
+++ b/lib/solargraph/api_map/cache.rb
@@ -78,18 +78,6 @@ module Solargraph
         @receiver_definitions[path] = pin
       end
 
-      # @param cursor [Source::Cursor]
-      # @return [SourceMap::Clip, nil]
-      def get_clip(cursor)
-        @clips["#{cursor.filename}|#{cursor.range.inspect}|#{cursor.node&.to_sexp}"]
-      end
-
-      # @param cursor [Source::Cursor]
-      # @param clip [SourceMap::Clip]
-      def set_clip(cursor, clip)
-        @clips["#{cursor.filename}|#{cursor.range.inspect}|#{cursor.node&.to_sexp}"] = clip
-      end
-
       # @return [void]
       def clear
         all_caches.each(&:clear)


### PR DESCRIPTION
Removing the clip caching from `ApiMap::Cache` in favor of chain inference caches.