### PR TITLE
Drop Parser::ParserGem::ClassMethods#returns_from_node

### DIFF
--- a/lib/solargraph/parser/parser_gem/class_methods.rb
+++ b/lib/solargraph/parser/parser_gem/class_methods.rb
@@ -48,12 +48,6 @@ module Solargraph
           NodeProcessor.process(source.node, Region.new(source: source))
         end
 
-        # @param node [Parser::AST::Node]
-        # @return [Array<Parser::AST::Node>]
-        def returns_from node
-          NodeMethods.returns_from(node)
-        end
-
         # @param source [Source]
         # @param name [String]
         # @return [Array<Location>]


### PR DESCRIPTION
Strict typechecking revealed we have a dead method that refers to a method that has been split into multiple methods