### PR TITLE
Fix flaky rename specs

### DIFF
--- a/spec/language_server/message/text_document/rename_spec.rb
+++ b/spec/language_server/message/text_document/rename_spec.rb
@@ -1,3 +1,9 @@
+# frozen_string_literal: true
+
+# @todo These tests use sleep to allow the host time to update the library with
+#   the newly opened file. It might be necessary for messages themselves to
+#   check if the host is still updating. Host#synchronizing? is not reliable,
+#   possibly because the library hasn't been added to the host yet.
 describe Solargraph::LanguageServer::Message::TextDocument::Rename do
   it "renames a symbol" do
     host = Solargraph::LanguageServer::Host.new
@@ -7,6 +13,7 @@ describe Solargraph::LanguageServer::Message::TextDocument::Rename do
       end
       foo = Foo.new
     ), 1)
+    sleep 0.01
     rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
       'id' => 1,
       'method' => 'textDocument/rename',
@@ -36,6 +43,7 @@ describe Solargraph::LanguageServer::Message::TextDocument::Rename do
       end
     	end
     	), 1)
+      sleep 0.01
     	rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
       'id' => 1,
       'method' => 'textDocument/rename',
@@ -65,6 +73,7 @@ describe Solargraph::LanguageServer::Message::TextDocument::Rename do
       end
     	end
     	), 1)
+      sleep 0.01
     	rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
       'id' => 1,
       'method' => 'textDocument/rename',
@@ -92,6 +101,7 @@ describe Solargraph::LanguageServer::Message::TextDocument::Rename do
       end
       obj = Namespace::ExampleClass.new
     	), 1)
+      sleep 0.01
     	rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
       'id' => 1,
       'method' => 'textDocument/rename',


### PR DESCRIPTION
Rename specs occasionally fail because the host is still updating when the test creates the rename message.