### PR TITLE
One-step source synchronization

### DIFF
--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -44,7 +44,6 @@ module Solargraph
         @stopped = false
         diagnoser.start
         cataloger.start
-        sources.start
         message_worker.start
       end
 
@@ -254,7 +253,7 @@ module Solargraph
       # @return [void]
       def change params
         updater = generate_updater(params)
-        sources.async_update params['textDocument']['uri'], updater
+        sources.update params['textDocument']['uri'], updater
         diagnoser.schedule params['textDocument']['uri']
       end
 
@@ -463,7 +462,6 @@ module Solargraph
         message_worker.stop
         cataloger.stop
         diagnoser.stop
-        sources.stop
         changed
         notify_observers
       end
@@ -858,7 +856,7 @@ module Solargraph
         progress.begin "0/#{total} files", 0
         progress.send self
         while library.next_map
-          pct = ((library.source_map_hash.keys.length.to_f / total.to_f) * 100).to_i
+          pct = ((library.source_map_hash.keys.length.to_f / total) * 100).to_i
           progress.report "#{library.source_map_hash.keys.length}/#{total} files", pct
           progress.send self
         end

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -27,7 +27,6 @@ module Solargraph
     def initialize workspace = Solargraph::Workspace.new, name = nil
       @workspace = workspace
       @name = name
-      @synchronized = false
     end
 
     def inspect
@@ -40,7 +39,7 @@ module Solargraph
     #
     # @return [Boolean]
     def synchronized?
-      @synchronized
+      !mutex.owned?
     end
 
     # Attach a source to the library.
@@ -57,7 +56,6 @@ module Solargraph
           source_map_hash.delete @current.filename
           source_map_external_require_hash.delete @current.filename
           @external_requires = nil
-          @synchronized = false
         end
         @current = source
         maybe_map @current
@@ -103,7 +101,6 @@ module Solargraph
       result = false
       mutex.synchronize do
         next unless contain?(filename) || open?(filename)
-        @synchronized = false
         source = Solargraph::Source.load_string(text, filename)
         workspace.merge(source)
         result = true
@@ -140,7 +137,6 @@ module Solargraph
         detach filename
         mutex.synchronize do
           result ||= workspace.remove(filename)
-          @synchronized = !result if synchronized?
         end
       end
       result
@@ -153,7 +149,6 @@ module Solargraph
     # @return [void]
     def close filename
       mutex.synchronize do
-        @synchronized = false
         @current = nil if @current && @current.filename == filename
         catalog
       end
@@ -242,45 +237,47 @@ module Solargraph
     # @return [Array<Solargraph::Range>]
     # @todo Take a Location instead of filename/line/column
     def references_from filename, line, column, strip: false, only: false
-      cursor = api_map.cursor_at(filename, Position.new(line, column))
-      clip = api_map.clip(cursor)
-      pin = clip.define.first
-      return [] unless pin
-      result = []
-      files = if only
-        [api_map.source_map(filename)]
-      else
-        (workspace.sources + (@current ? [@current] : []))
-      end
-      files.uniq(&:filename).each do |source|
-        found = source.references(pin.name)
-        found.select! do |loc|
-          referenced = definitions_at(loc.filename, loc.range.ending.line, loc.range.ending.character).first
-          referenced&.path == pin.path
+      mutex.synchronize do
+        cursor = api_map.cursor_at(filename, Position.new(line, column))
+        clip = api_map.clip(cursor)
+        pin = clip.define.first
+        return [] unless pin
+        result = []
+        files = if only
+          [api_map.source_map(filename)]
+        else
+          (workspace.sources + (@current ? [@current] : []))
         end
-        if pin.path == 'Class#new'
-          caller = cursor.chain.base.infer(api_map, clip.send(:block), clip.locals).first
-          if caller.defined?
-            found.select! do |loc|
-              clip = api_map.clip_at(loc.filename, loc.range.start)
-              other = clip.send(:cursor).chain.base.infer(api_map, clip.send(:block), clip.locals).first
-              caller == other
+        files.uniq(&:filename).each do |source|
+          found = source.references(pin.name)
+          found.select! do |loc|
+            referenced = definitions_at(loc.filename, loc.range.ending.line, loc.range.ending.character).first
+            referenced&.path == pin.path
+          end
+          if pin.path == 'Class#new'
+            caller = cursor.chain.base.infer(api_map, clip.send(:block), clip.locals).first
+            if caller.defined?
+              found.select! do |loc|
+                clip = api_map.clip_at(loc.filename, loc.range.start)
+                other = clip.send(:cursor).chain.base.infer(api_map, clip.send(:block), clip.locals).first
+                caller == other
+              end
+            else
+              found.clear
             end
-          else
-            found.clear
           end
-        end
-        # HACK: for language clients that exclude special characters from the start of variable names
-        if strip && match = cursor.word.match(/^[^a-z0-9_]+/i)
-          found.map! do |loc|
-            Solargraph::Location.new(loc.filename, Solargraph::Range.from_to(loc.range.start.line, loc.range.start.column + match[0].length, loc.range.ending.line, loc.range.ending.column))
+          # HACK: for language clients that exclude special characters from the start of variable names
+          if strip && match = cursor.word.match(/^[^a-z0-9_]+/i)
+            found.map! do |loc|
+              Solargraph::Location.new(loc.filename, Solargraph::Range.from_to(loc.range.start.line, loc.range.start.column + match[0].length, loc.range.ending.line, loc.range.ending.column))
+            end
           end
+          result.concat(found.sort do |a, b|
+            a.range.start.line <=> b.range.start.line
+          end)
         end
-        result.concat(found.sort do |a, b|
-          a.range.start.line <=> b.range.start.line
-        end)
+        result.uniq
       end
-      result.uniq
     end
 
     # Get the pins at the specified location or nil if the pin does not exist.
@@ -425,7 +422,6 @@ module Solargraph
 
       logger.info "Cataloging #{workspace.directory.empty? ? 'generic workspace' : workspace.directory}"
       api_map.catalog bench
-      @synchronized = true
       logger.info "Catalog complete (#{api_map.source_maps.length} files, #{api_map.pins.length} pins)"
       logger.info "#{api_map.uncached_gemspecs.length} uncached gemspecs"
       cache_next_gemspec
@@ -489,7 +485,6 @@ module Solargraph
     def next_map
       return false if mapped?
       mutex.synchronize do
-        @synchronized = false
         src = workspace.sources.find { |s| !source_map_hash.key?(s.filename) }
         if src
           Logging.logger.debug "Mapping #{src.filename}"
@@ -594,7 +589,6 @@ module Solargraph
           unless source_map_hash[source.filename].try_merge!(new_map)
             source_map_hash[source.filename] = new_map
             find_external_requires(source_map_hash[source.filename])
-            @synchronized = false
           end
         else
           # @todo Smelly instance variable access
@@ -603,7 +597,6 @@ module Solargraph
       else
         source_map_hash[source.filename] = Solargraph::SourceMap.map(source)
         find_external_requires(source_map_hash[source.filename])
-        @synchronized = false
       end
     end
 
@@ -631,7 +624,6 @@ module Solargraph
         cache_errors.add spec
         Solargraph.logger.warn "Error caching gemspec #{spec.name} #{spec.version}: [#{e.class}] #{e.message}"
       ensure
-        @synchronized = false
         @cache_pid = nil
         end_cache_progress if pending.zero?
       end

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -92,50 +92,6 @@ module Solargraph
       stack
     end
 
-    # Start synchronizing the source. This method updates the code without
-    # parsing a new AST. The resulting Source object will be marked not
-    # synchronized (#synchronized? == false).
-    #
-    # @param updater [Source::Updater]
-    # @return [Source]
-    def start_synchronize updater
-      raise 'Invalid synchronization' unless updater.filename == filename
-      real_code = updater.write(@code)
-      src = Source.allocate
-      src.filename = filename
-      src.code = real_code
-      src.version = updater.version
-      src.parsed = parsed?
-      src.repaired = updater.repair(@repaired)
-      src.synchronized = false
-      src.node = @node
-      src.comments = @comments
-      src.error_ranges = error_ranges
-      src.last_updater = updater
-      return src.finish_synchronize unless real_code.lines.length == @code.lines.length
-      src
-    end
-
-    # Finish synchronizing a source that was updated via #start_synchronize.
-    # This method returns self if the source is already synchronized. Otherwise
-    # it parses the AST and returns a new synchronized Source.
-    #
-    # @return [Source]
-    def finish_synchronize
-      return self if synchronized?
-      synced = Source.new(@code, filename)
-      if synced.parsed?
-        synced.version = version
-        return synced
-      end
-      synced = Source.new(@repaired, filename)
-      synced.error_ranges.concat (error_ranges + last_updater.changes.map(&:range))
-      synced.code = @code
-      synced.synchronized = true
-      synced.version = version
-      synced
-    end
-
     # Synchronize the Source with an update. This method applies changes to the
     # code, parses the new code's AST, and returns the resulting Source object.
     #

--- a/spec/language_server/host_spec.rb
+++ b/spec/language_server/host_spec.rb
@@ -250,8 +250,8 @@ describe Solargraph::LanguageServer::Host do
         }
       ]
     })
-    source = host.sources.find(uri).finish_synchronize
-    # @todo Smelly private variable access
+    source = host.sources.find(uri)
+    # @todo Smelly private method access
     expect(source.send(:repaired)).to eq('Foo::Bar ')
   end
 

--- a/spec/language_server/message/text_document/rename_spec.rb
+++ b/spec/language_server/message/text_document/rename_spec.rb
@@ -1,9 +1,5 @@
 # frozen_string_literal: true
 
-# @todo These tests use sleep to allow the host time to update the library with
-#   the newly opened file. It might be necessary for messages themselves to
-#   check if the host is still updating. Host#synchronizing? is not reliable,
-#   possibly because the library hasn't been added to the host yet.
 describe Solargraph::LanguageServer::Message::TextDocument::Rename do
   it "renames a symbol" do
     host = Solargraph::LanguageServer::Host.new
@@ -13,7 +9,6 @@ describe Solargraph::LanguageServer::Message::TextDocument::Rename do
       end
       foo = Foo.new
     ), 1)
-    sleep 0.01
     rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
       'id' => 1,
       'method' => 'textDocument/rename',
@@ -42,9 +37,8 @@ describe Solargraph::LanguageServer::Message::TextDocument::Rename do
       return bar
       end
     	end
-    	), 1)
-      sleep 0.01
-    	rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
+    ), 1)
+    rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
       'id' => 1,
       'method' => 'textDocument/rename',
       'params' => {
@@ -72,9 +66,8 @@ describe Solargraph::LanguageServer::Message::TextDocument::Rename do
       return bar
       end
     	end
-    	), 1)
-      sleep 0.01
-    	rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
+    ), 1)
+    rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
       'id' => 1,
       'method' => 'textDocument/rename',
       'params' => {
@@ -100,9 +93,8 @@ describe Solargraph::LanguageServer::Message::TextDocument::Rename do
       class Namespace::ExampleClass
       end
       obj = Namespace::ExampleClass.new
-    	), 1)
-      sleep 0.01
-    	rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
+    ), 1)
+    rename = Solargraph::LanguageServer::Message::TextDocument::Rename.new(host, {
       'id' => 1,
       'method' => 'textDocument/rename',
       'params' => {

--- a/spec/source/cursor_spec.rb
+++ b/spec/source/cursor_spec.rb
@@ -120,7 +120,7 @@ describe Solargraph::Source::Cursor do
     updater = Solargraph::Source::Updater.new('test.rb', 1, [
       Solargraph::Source::Change.new(Solargraph::Range.from_to(1, 12, 1, 12), '.')
     ])
-    updated = source.start_synchronize(updater)
+    updated = source.synchronize(updater)
     cursor = updated.cursor_at(Solargraph::Position.new(1, 13))
     expect(cursor).to be_string
   end

--- a/spec/source/source_chainer_spec.rb
+++ b/spec/source/source_chainer_spec.rb
@@ -190,7 +190,7 @@ describe Solargraph::Source::SourceChainer do
     source1 = Solargraph::Source.load_string(%(
       ''
     ))
-    source2 = source1.start_synchronize(Solargraph::Source::Updater.new(
+    source2 = source1.synchronize(Solargraph::Source::Updater.new(
       nil,
       2,
       [
@@ -223,7 +223,7 @@ describe Solargraph::Source::SourceChainer do
     updater = Solargraph::Source::Updater.new('test.rb', 1, [
       Solargraph::Source::Change.new(Solargraph::Range.from_to(2, 6, 2, 6), 'x.')
     ])
-    updated = source.start_synchronize(updater)
+    updated = source.synchronize(updater)
     cursor = updated.cursor_at(Solargraph::Position.new(2, 8))
     expect(cursor.chain.links.first.word).to eq('x')
   end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -851,25 +851,6 @@ describe Solargraph::SourceMap::Clip do
     expect(clip.complete.pins.map(&:path)).to include('First::Second::Sub#method2')
   end
 
-  it 'avoids completion inside strings for unsynchronized sources' do
-    source = Solargraph::Source.load_string(%(
-      'one two'
-    ), 'test.rb')
-    api_map = Solargraph::ApiMap.new
-    api_map.map source
-    updater = Solargraph::Source::Updater.new(
-      'test.rb',
-      1,
-      [
-        Solargraph::Source::Change.new(Solargraph::Range.from_to(1, 6, 1, 6), '.')
-      ]
-    )
-    updated = source.start_synchronize(updater)
-    cursor = updated.cursor_at(Solargraph::Position.new(1, 7))
-    clip = api_map.clip(cursor)
-    expect(clip.complete.pins).to be_empty
-  end
-
   it 'resolves self return types to the current scope' do
     source = Solargraph::Source.load_string(%(
       class Foo
@@ -1186,7 +1167,7 @@ describe Solargraph::SourceMap::Clip do
                                                   '.'
                                                 )
                                               ])
-    updated = source.start_synchronize(updater)
+    updated = source.synchronize(updater)
     api_map = Solargraph::ApiMap.new
     api_map.map updated
     clip = api_map.clip_at('test.rb', [1, 32])
@@ -1214,7 +1195,7 @@ describe Solargraph::SourceMap::Clip do
     updater = Solargraph::Source::Updater.new('test.rb', 1, [
                                                 Solargraph::Source::Change.new(Solargraph::Range.from_to(2, 6, 2, 6), 'x.')
                                               ])
-    updated = source.start_synchronize(updater)
+    updated = source.synchronize(updater)
     api_map.map updated
     clip = api_map.clip_at('test.rb', [2, 8])
     expect(clip.complete.pins.first.path).to start_with('Array#')
@@ -1368,7 +1349,7 @@ describe Solargraph::SourceMap::Clip do
         Solargraph::Source::Change.new(Solargraph::Range.from_to(7, 32, 7, 32), ',')
       ]
     )
-    updated = source.start_synchronize(updater)
+    updated = source.synchronize(updater)
     api_map = Solargraph::ApiMap.new
     api_map.map updated
     clip = api_map.clip_at('test.rb', [7, 33])
@@ -1420,7 +1401,7 @@ describe Solargraph::SourceMap::Clip do
         Solargraph::Source::Change.new(Solargraph::Range.from_to(7, 29, 7, 29), '()')
       ]
     )
-    updated = source.start_synchronize(updater)
+    updated = source.synchronize(updater)
     api_map = Solargraph::ApiMap.new
     api_map.map updated
     clip = api_map.clip_at('test.rb', [7, 30])
@@ -1494,7 +1475,7 @@ describe Solargraph::SourceMap::Clip do
         Solargraph::Source::Change.new(Solargraph::Range.from_to(7, 30, 7, 30), 'F')
       ]
     )
-    updated = source.start_synchronize(updater)
+    updated = source.synchronize(updater)
     api_map = Solargraph::ApiMap.new
     api_map.map updated
     clip = api_map.clip_at('test.rb', [7, 31])

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -242,25 +242,9 @@ e = d # inline
     expect(source.folding_ranges.first.start.line).to eq(4)
   end
 
-  it "returns unsynchronized sources for started synchronizations" do
-    source1 = Solargraph::Source.load_string('x = 1', 'test.rb')
-    source2 = source1.start_synchronize Solargraph::Source::Updater.new(
-      'test.rb',
-      2,
-      [
-        Solargraph::Source::Change.new(
-          Solargraph::Range.from_to(0, 5, 0, 5),
-          '2'
-        )
-      ]
-    )
-    expect(source2.code).to eq('x = 12')
-    expect(source2).not_to be_synchronized
-  end
-
   it "finishes synchronizations for unbalanced lines" do
     source1 = Solargraph::Source.load_string('x = 1', 'test.rb')
-    source2 = source1.start_synchronize Solargraph::Source::Updater.new(
+    source2 = source1.synchronize Solargraph::Source::Updater.new(
       'test.rb',
       2,
       [


### PR DESCRIPTION
Fixes #846

Locating references can raise an error when it tries to operate on an unsynchronized source. This can easily happen in the language server because it takes two steps to synchronize: (1) starting synchronization when it receives an update message, and (2) finishing it in a separate thread. The performance benefit from two-step synchronization is too trivial to warrant the resulting flakiness.

* Modify `Source` so it always performs updates in a single step.
* Use the `Library` mutex to synchronize queries from the language server.
