### PR TITLE
Resolve params from ref tags

### DIFF
--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -283,6 +283,7 @@ module Solargraph
       def try_merge! pin
         return false unless super
         @node = pin.node
+        @resolved_ref_tag = false
         true
       end
 
@@ -313,6 +314,24 @@ module Solargraph
 
       def anon_splat?
         @anon_splat
+      end
+
+      # @param [ApiMap]
+      # @return [self]
+      def resolve_ref_tag api_map
+        return self if @resolved_ref_tag
+
+        @resolved_ref_tag = true
+        return self unless docstring.ref_tags.any?
+        docstring.ref_tags.each do |tag|
+          pin = api_map.get_methods(namespace)
+                       .select { |pin| pin.path.end_with?(tag.owner.to_s) }
+                       .first
+          next unless pin
+
+          docstring.add_tag(*pin.docstring.tags(:param))
+        end
+        self
       end
 
       protected

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -324,12 +324,17 @@ module Solargraph
         @resolved_ref_tag = true
         return self unless docstring.ref_tags.any?
         docstring.ref_tags.each do |tag|
-          pin = api_map.get_methods(namespace)
-                       .select { |pin| pin.path.end_with?(tag.owner.to_s) }
-                       .first
-          next unless pin
+          ref = if tag.owner.to_s.start_with?(/[#\.]/)
+            api_map.get_methods(namespace)
+                   .select { |pin| pin.path.end_with?(tag.owner.to_s) }
+                   .first
+          else
+            # @todo Resolve relative namespaces
+            api_map.get_path_pins(tag.owner.to_s).first
+          end
+          next unless ref
 
-          docstring.add_tag(*pin.docstring.tags(:param))
+          docstring.add_tag(*ref.docstring.tags(:param))
         end
         self
       end

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -126,17 +126,11 @@ module Solargraph
 
       # @return [YARD::Tags::Tag, nil]
       def param_tag
-        found = nil
         params = closure.docstring.tags(:param)
         params.each do |p|
-          next unless p.name == name
-          found = p
-          break
+          return p if p.name == name
         end
-        if found.nil? and !index.nil?
-          found = params[index] if params[index] && (params[index].name.nil? || params[index].name.empty?)
-        end
-        found
+        params[index] if index && params[index] && (params[index].name.nil? || params[index].name.empty?)
       end
 
       # @param api_map [ApiMap]

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -461,6 +461,27 @@ describe Solargraph::Pin::Method do
     expect(pin.documentation).to include('# Call foo')
   end
 
+  it 'resolves ref tags' do
+    source = Solargraph::Source.load_string(%(
+      class Example
+        # @param param1 [String]
+        # @param param2 [Integer]
+        def foo param1, param2
+        end
+
+        # @param (see #foo)
+        def bar param1, param2
+        end
+      end
+    ))
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    pin = api_map.get_path_pins('Example#bar').first
+    pin.resolve_ref_tag(api_map)
+    expect(pin.docstring.tags(:param).map(&:name)).to eq(['param1', 'param2'])
+    expect(pin.docstring.tags(:param).map(&:type)).to eq(['String', 'Integer'])
+  end
+
   context 'as attribute' do
     it "is a kind of attribute/property" do
       source = Solargraph::Source.load_string(%(

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -482,6 +482,29 @@ describe Solargraph::Pin::Method do
     expect(pin.docstring.tags(:param).map(&:type)).to eq(['String', 'Integer'])
   end
 
+  it 'resolves ref tags with namespaces' do
+    source = Solargraph::Source.load_string(%(
+      class Example1
+        # @param param1 [String]
+        # @param param2 [Integer]
+        def foo param1, param2
+        end
+      end
+
+      class Example2
+        # @param (see Example1#foo)
+        def bar param1, param2
+        end
+      end
+    ))
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    pin = api_map.get_path_pins('Example2#bar').first
+    pin.resolve_ref_tag(api_map)
+    expect(pin.docstring.tags(:param).map(&:name)).to eq(['param1', 'param2'])
+    expect(pin.docstring.tags(:param).map(&:type)).to eq(['String', 'Integer'])
+  end
+
   context 'as attribute' do
     it "is a kind of attribute/property" do
       source = Solargraph::Source.load_string(%(


### PR DESCRIPTION
Closes #696 

Resolve parameters from see reference tags, e.g.:

```ruby
class Example
  # @param x [String]
  def foo(x); end

  # @param (see #foo)
  def bar(x); end
end
```
