### PR TITLE
Show cache progress in shell commands

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -157,13 +157,14 @@ module Solargraph
     # any missing gems.
     #
     # @param directory [String]
+    # @param out [IO] The output stream for messages
     # @return [ApiMap]
-    def self.load_with_cache directory
+    def self.load_with_cache directory, out = File::NULL
       api_map = load(directory)
       return api_map if api_map.uncached_gemspecs.empty?
 
       api_map.uncached_gemspecs.each do |gemspec|
-        Solargraph.logger.info "Caching #{gemspec.name} #{gemspec.version}..."
+        out.puts "Caching gem #{gemspec.name} #{gemspec.version}"
         pins = GemPins.build(gemspec)
         Solargraph::Cache.save('gems', "#{gemspec.name}-#{gemspec.version}.ser", pins)
       end
@@ -598,7 +599,7 @@ module Solargraph
       # namespaces; resolving the generics in the method pins is this
       # class' responsibility
       raw_methods = store.get_methods(fqns, scope: scope, visibility: visibility).sort{ |a, b| a.name <=> b.name }
-      namespace_pin = store.get_path_pins(fqns).select{|p| p.is_a?(Pin::Namespace)}.first
+      namespace_pin = store.get_path_pins(fqns).select { |p| p.is_a?(Pin::Namespace) }.first
       methods = if rooted_tag != fqns
                   methods = raw_methods.map do |method_pin|
                     method_pin.resolve_generics(namespace_pin, rooted_type)

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -156,10 +156,14 @@ module Solargraph
     # Create an ApiMap with a workspace in the specified directory and cache
     # any missing gems.
     #
+    #
+    # @todo IO::NULL is incorrectly inferred to be a String.
+    # @sg-ignore
+    #
     # @param directory [String]
     # @param out [IO] The output stream for messages
     # @return [ApiMap]
-    def self.load_with_cache directory, out = File::NULL
+    def self.load_with_cache directory, out = IO::NULL
       api_map = load(directory)
       return api_map if api_map.uncached_gemspecs.empty?
 

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -150,7 +150,7 @@ module Solargraph
     # @return [void]
     def typecheck *files
       directory = File.realpath(options[:directory])
-      api_map = Solargraph::ApiMap.load_with_cache(directory)
+      api_map = Solargraph::ApiMap.load_with_cache(directory, $stdout)
       probcount = 0
       if files.empty?
         files = api_map.source_maps.map(&:filename)
@@ -191,7 +191,7 @@ module Solargraph
       directory = File.realpath(options[:directory])
       api_map = nil
       time = Benchmark.measure {
-        api_map = Solargraph::ApiMap.load_with_cache(directory)
+        api_map = Solargraph::ApiMap.load_with_cache(directory, $stdout)
         api_map.pins.each do |pin|
           begin
             puts pin_description(pin) if options[:verbose]


### PR DESCRIPTION
The `scan` and `typecheck` commands report gem caching progress.