### PR TITLE
[breaking] Reimplement global conventions

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -109,6 +109,10 @@ module Solargraph
       [self.class, @source_map_hash, implicit, @doc_map, @unresolved_requires]
     end
 
+    def doc_map
+      @doc_map ||= DocMap.new([], [])
+    end
+
     # @return [::Array<Gem::Specification>]
     def uncached_gemspecs
       @doc_map&.uncached_gemspecs || []

--- a/lib/solargraph/convention.rb
+++ b/lib/solargraph/convention.rb
@@ -31,12 +31,12 @@ module Solargraph
       result
     end
 
-    # @param yard_map [YardMap]
+    # @param yard_map [DocMap]
     # @return [Environ]
-    def self.for_global(yard_map)
+    def self.for_global(doc_map)
       result = Environ.new
       @@conventions.each do |conv|
-        result.merge conv.global(yard_map)
+        result.merge conv.global(doc_map)
       end
       result
     end

--- a/lib/solargraph/convention/base.rb
+++ b/lib/solargraph/convention/base.rb
@@ -20,12 +20,12 @@ module Solargraph
         EMPTY_ENVIRON
       end
 
-      # The Environ for a YARD map.
+      # The Environ for a DocMap.
       # Subclasses can override this method.
       #
-      # @param yard_map [YardMap]
+      # @param doc_map [DocMap]
       # @return [Environ]
-      def global yard_map
+      def global doc_map
         EMPTY_ENVIRON
       end
     end

--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -225,7 +225,6 @@ module Solargraph
 
     def gemspecs_required_from_external_bundle
       logger.info 'Fetching gemspecs required from external bundle'
-      puts workspace.inspect
       return [] unless workspace&.directory
 
       Solargraph.with_clean_env do

--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -31,6 +31,7 @@ module Solargraph
     def initialize(requires, preferences, workspace = nil)
       @requires = requires.compact
       @preferences = preferences.compact
+      @workspace = workspace
       @rbs_path = workspace&.rbs_collection_path
       @environ = Convention.for_global(self)
       generate_gem_pins
@@ -224,6 +225,7 @@ module Solargraph
 
     def gemspecs_required_from_external_bundle
       logger.info 'Fetching gemspecs required from external bundle'
+      puts workspace.inspect
       return [] unless workspace&.directory
 
       Solargraph.with_clean_env do

--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -33,8 +33,6 @@ module Solargraph
       @preferences = preferences.compact
       @rbs_path = workspace&.rbs_collection_path
       @environ = Convention.for_global(self)
-      @requires.concat @environ.requires
-      @requires.uniq
       generate_gem_pins
       pins.concat @environ.pins
     end

--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -8,6 +8,7 @@ module Solargraph
 
     # @return [Array<String>]
     attr_reader :requires
+    alias required requires
 
     # @return [Array<Gem::Specification>]
     attr_reader :preferences
@@ -21,14 +22,21 @@ module Solargraph
     # @return [Workspace, nil]
     attr_reader :workspace
 
+    # @return [Environ]
+    attr_reader :environ
+
     # @param requires [Array<String>]
     # @param preferences [Array<Gem::Specification>]
     # @param workspace [Workspace, nil]
     def initialize(requires, preferences, workspace = nil)
       @requires = requires.compact
       @preferences = preferences.compact
-      @workspace = workspace
-      generate
+      @rbs_path = workspace&.rbs_collection_path
+      @environ = Convention.for_global(self)
+      @requires.concat @environ.requires
+      @requires.uniq
+      generate_gem_pins
+      pins.concat @environ.pins
     end
 
     # @return [Array<Gem::Specification>]
@@ -54,7 +62,7 @@ module Solargraph
     private
 
     # @return [void]
-    def generate
+    def generate_gem_pins
       @pins = []
       @uncached_gemspecs = []
       required_gems_map.each do |path, gemspecs|

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -399,7 +399,7 @@ describe Solargraph::ApiMap do
       require 'invalid'
     ), 'app.rb')
     @api_map.catalog Solargraph::Bench.new(source_maps: [source1, source2], external_requires: ['invalid'])
-    expect(@api_map.unresolved_requires).to eq(['invalid'])
+    expect(@api_map.unresolved_requires).to eq(['invalid'] + @api_map.doc_map.environ.requires)
   end
 
   it 'gets instance variables from superclasses' do

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -399,7 +399,7 @@ describe Solargraph::ApiMap do
       require 'invalid'
     ), 'app.rb')
     @api_map.catalog Solargraph::Bench.new(source_maps: [source1, source2], external_requires: ['invalid'])
-    expect(@api_map.unresolved_requires).to eq(['invalid'] + @api_map.doc_map.environ.requires)
+    expect(@api_map.unresolved_requires).to eq(['invalid'])
   end
 
   it 'gets instance variables from superclasses' do

--- a/spec/doc_map_spec.rb
+++ b/spec/doc_map_spec.rb
@@ -16,7 +16,7 @@ describe Solargraph::DocMap do
 
   it 'tracks unresolved requires' do
     doc_map = Solargraph::DocMap.new(['not_a_gem'], [])
-    expect(doc_map.unresolved_requires).to eq(['not_a_gem'] + doc_map.environ.requires)
+    expect(doc_map.unresolved_requires).to eq(['not_a_gem'])
   end
 
   it 'tracks uncached_gemspecs' do

--- a/spec/doc_map_spec.rb
+++ b/spec/doc_map_spec.rb
@@ -16,7 +16,7 @@ describe Solargraph::DocMap do
 
   it 'tracks unresolved requires' do
     doc_map = Solargraph::DocMap.new(['not_a_gem'], [])
-    expect(doc_map.unresolved_requires).to eq(['not_a_gem'])
+    expect(doc_map.unresolved_requires).to eq(['not_a_gem'] + doc_map.environ.requires)
   end
 
   it 'tracks uncached_gemspecs' do
@@ -24,7 +24,7 @@ describe Solargraph::DocMap do
       spec.name = 'not_a_gem'
       spec.version = '1.0.0'
     end
-    allow(Gem::Specification).to receive(:find_by_path).with('not_a_gem').and_return(gemspec)
+    allow(Gem::Specification).to receive(:find_by_path).and_return(gemspec)
     doc_map = Solargraph::DocMap.new(['not_a_gem'], [gemspec])
     expect(doc_map.uncached_gemspecs).to eq([gemspec])
   end
@@ -40,7 +40,7 @@ describe Solargraph::DocMap do
   it 'does not warn for redundant requires' do
     # Requiring 'set' is unnecessary because it's already included in core. It
     # might make sense to log redundant requires, but a warning is overkill.
-    expect(Solargraph.logger).not_to receive(:warn)
+    expect(Solargraph.logger).not_to receive(:warn).with(/path set/)
     Solargraph::DocMap.new(['set'], [])
   end
 


### PR DESCRIPTION
As mentioned in a [comment in #781](https://github.com/castwide/solargraph/pull/781#discussion_r2030116341), the switch from `YardMap` to `DocMap` blocked processing of global conventions. We need a way forward for plugins that depend on it. The proposal here is that `Convention::Base#global` accept a `DocMap` argument. Plugins that expect a `YardMap` will need to be updated accordingly.