### PR TITLE
Disable rbs_collection

### DIFF
--- a/lib/solargraph/rbs_map.rb
+++ b/lib/solargraph/rbs_map.rb
@@ -52,7 +52,9 @@ module Solargraph
 
     def repository
       @repository ||= RBS::Repository.new(no_stdlib: false).tap do |repo|
-        @directories.each { |dir| repo.add(Pathname.new(dir)) }
+        # @todo Temporarily ignoring external directories due to issues with
+        #   incomplete/broken gem_rbs_collection installations
+        # @directories.each { |dir| repo.add(Pathname.new(dir)) }
       end
     end
 


### PR DESCRIPTION
Temporarily disable use of rbs_collection in workspaces. Certain configurations throw constant errors in the language server. We'll need to figure out a solution before it's ready for production.