### PR TITLE
Sync Library#diagnose

### DIFF
--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -207,7 +207,7 @@ module Solargraph
       def diagnose uri
         if sources.include?(uri)
           library = library_for(uri)
-          if library.mapped?
+          if library.mapped? && library.synchronized?
             logger.info "Diagnosing #{uri}"
             begin
               results = library.diagnose uri_to_file(uri)

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -383,6 +383,7 @@ module Solargraph
       #   everything in the workspace should get diagnosed, or if there should
       #   be an option to do so.
       #
+      sync_catalog
       return [] unless open?(filename)
       result = []
       source = read(filename)
@@ -402,7 +403,7 @@ module Solargraph
         end
       end
       repargs.each_pair do |reporter, args|
-        result.concat reporter.new(*args.uniq).diagnose(source, mutex.synchronize { api_map })
+        result.concat reporter.new(*args.uniq).diagnose(source, api_map)
       end
       result
     end


### PR DESCRIPTION
Fixes #879

This issue is related to the other problems with unsynchronized sources that were addressed in #876. We need to apply the same fix to `Library#diagnose`.