### PR TITLE
Remove accidental inclusion of Module's methods in objects

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -371,7 +371,7 @@ module Solargraph
           end
         end
         result.concat inner_get_methods('Kernel', :instance, [:public], deep, skip) if visibility.include?(:private)
-        result.concat inner_get_methods('Module', scope, visibility, deep, skip)
+        result.concat inner_get_methods('Module', scope, visibility, deep, skip) if scope == :module
       end
       resolved = resolve_method_aliases(result, visibility)
       cache.set_methods(rooted_tag, scope, visibility, deep, resolved)

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1605,13 +1605,13 @@ describe Solargraph::SourceMap::Clip do
         # @return [String, Array]
         def foo; end
       end
-      Thing.new.foo.an
+      Thing.new.foo.bytes
       Thing.new.foo.up
     ), 'test.rb')
     api_map = Solargraph::ApiMap.new.map(source)
 
     array_names = api_map.clip_at('test.rb', [5, 22]).complete.pins.map(&:name)
-    expect(array_names).to eq(['ancestors', 'any?'])
+    expect(array_names).to eq(["byteindex", "byterindex", "bytes", "bytesize", "byteslice", "bytesplice"])
 
     string_names = api_map.clip_at('test.rb', [6, 22]).complete.pins.map(&:name)
     expect(string_names).to eq(['upcase', 'upcase!', 'upto'])
@@ -2246,5 +2246,24 @@ describe Solargraph::SourceMap::Clip do
     clip = api_map.clip_at('test.rb', [7, 6])
     # The order of the types can vary between platforms
     expect(clip.infer.items.map(&:to_s).sort).to eq(%w[Integer String Symbol])
+  end
+
+  it 'does not map Module methods into an Object' do
+    source = Solargraph::Source.load_string(%(
+      class Nah
+        # name is also a method in Module class that returns String
+        def name
+        end
+      end
+
+      def blah
+        n = Nah.new
+        o = n.name
+        o
+     end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [10, 8])
+    expect(clip.infer.to_s).to eq('nil')
   end
 end


### PR DESCRIPTION
The instance methods on 'Module' aren't available on arbitrary objects - don't include them in the api_map as such.

The inaccurate method list was causing problems at type-checking time - when an external gem (RBS, in this case) had a method ("name") that we didn't have a type for, it could look for the types on a method in Method--in this case Method#name, which returns String.  Since RBS has its own class ("TypeName"), this would fail to typecheck at :strict.

Also update a clip_spec test, which was expecting incorrect behavior in completions.