### PR TITLE
Remove redundant extend in Parser

### DIFF
--- a/lib/solargraph/parser.rb
+++ b/lib/solargraph/parser.rb
@@ -9,14 +9,11 @@ module Solargraph
     class SyntaxError < StandardError
     end
 
-    ClassMethods = ParserGem::ClassMethods
-
     # @deprecated
     Legacy = ParserGem
 
     ClassMethods = ParserGem::ClassMethods
-
-    extend ParserGem::ClassMethods
+    extend ClassMethods
 
     NodeMethods = ParserGem::NodeMethods
   end

--- a/lib/solargraph/parser.rb
+++ b/lib/solargraph/parser.rb
@@ -13,7 +13,9 @@ module Solargraph
     Legacy = ParserGem
 
     ClassMethods = ParserGem::ClassMethods
-    extend ClassMethods
+    # @todo should be able to just 'extend ClassMethods' here and
+    #   typecheck things off it in strict mode
+    extend ParserGem::ClassMethods
 
     NodeMethods = ParserGem::NodeMethods
   end


### PR DESCRIPTION
The redundant `extend` is reinitializing `ClassMethods` and emitting warnings.