### PR TITLE
Library sync and cache invalidation

### DIFF
--- a/lib/solargraph/language_server/host/message_worker.rb
+++ b/lib/solargraph/language_server/host/message_worker.rb
@@ -6,7 +6,10 @@ module Solargraph
       # A serial worker Thread to handle message.
       #
       # this make check pending message possible, and maybe cancelled to speedup process
+      #
       class MessageWorker
+        UPDATE_METHODS = ['textDocument/didOpen', 'textDocument/didChange', 'workspace/didChangeWatchedFiles'].freeze
+
         # @param host [Host]
         def initialize(host)
           @host = host
@@ -30,7 +33,7 @@ module Solargraph
           @stopped = true
         end
 
-        # @param message [Hash] The message should be handle. will pass back to Host#receive
+        # @param message [Hash] The message to handle. Will be forwarded to Host#receive
         # @return [void]
         def queue(message)
           @mutex.synchronize do
@@ -52,10 +55,33 @@ module Solargraph
         def tick
           message = @mutex.synchronize do
             @resource.wait(@mutex) if messages.empty?
-            messages.shift
+            next_message
           end
           handler = @host.receive(message)
-          handler && handler.send_response
+          handler&.send_response
+        end
+
+        private
+
+        def next_message
+          # Prioritize updates and version-dependent messages for performance
+          idx = messages.find_index do |msg|
+            UPDATE_METHODS.include?(msg['method']) || version_dependent?(msg)
+          end
+          # @todo We might want to clear duplicate instances of this message
+          #   that occur before the next update
+          return messages.shift unless idx
+
+          msg = messages[idx]
+          messages.delete_at idx
+          msg
+        end
+
+        # True if the message requires a previous update to have executed in
+        # order to work correctly.
+        #
+        def version_dependent? msg
+          msg['textDocument'] && msg['position']
         end
       end
     end

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -174,9 +174,9 @@ module Solargraph
     # @return [Array<Solargraph::Pin::Base>, nil]
     # @todo Take filename/position instead of filename/line/column
     def definitions_at filename, line, column
+      sync_catalog
       position = Position.new(line, column)
       cursor = Source::Cursor.new(read(filename), position)
-      sync_catalog
       if cursor.comment?
         source = read(filename)
         offset = Solargraph::Position.to_offset(source.code, Solargraph::Position.new(line, column))
@@ -205,9 +205,9 @@ module Solargraph
     # @return [Array<Solargraph::Pin::Base>, nil]
     # @todo Take filename/position instead of filename/line/column
     def type_definitions_at filename, line, column
+      sync_catalog
       position = Position.new(line, column)
       cursor = Source::Cursor.new(read(filename), position)
-      sync_catalog
       mutex.synchronize { api_map.clip(cursor).types }
     rescue FileNotFoundError => e
       handle_file_not_found filename, e
@@ -222,9 +222,9 @@ module Solargraph
     # @return [Array<Solargraph::Pin::Base>]
     # @todo Take filename/position instead of filename/line/column
     def signatures_at filename, line, column
+      sync_catalog
       position = Position.new(line, column)
       cursor = Source::Cursor.new(read(filename), position)
-      sync_catalog
       mutex.synchronize { api_map.clip(cursor).signify }
     end
 

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -565,9 +565,7 @@ module Solargraph
       return unless @current == source || workspace.has_file?(source.filename)
       if source_map_hash.key?(source.filename)
         new_map = Solargraph::SourceMap.map(source)
-        unless source_map_hash[source.filename].try_merge!(new_map)
-          source_map_hash[source.filename] = new_map
-        end
+        source_map_hash[source.filename] = new_map
       else
         source_map_hash[source.filename] = Solargraph::SourceMap.map(source)
       end

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -566,18 +566,10 @@ module Solargraph
       return unless source
       return unless @current == source || workspace.has_file?(source.filename)
       if source_map_hash.key?(source.filename)
-        return if source_map_hash[source.filename].code == source.code &&
-          source_map_hash[source.filename].source.synchronized? &&
-          source.synchronized?
-        if source.synchronized?
-          new_map = Solargraph::SourceMap.map(source)
-          unless source_map_hash[source.filename].try_merge!(new_map)
-            source_map_hash[source.filename] = new_map
-            find_external_requires(source_map_hash[source.filename])
-          end
-        else
-          # @todo Smelly instance variable access
-          source_map_hash[source.filename].instance_variable_set(:@source, source)
+        new_map = Solargraph::SourceMap.map(source)
+        unless source_map_hash[source.filename].try_merge!(new_map)
+          source_map_hash[source.filename] = new_map
+          find_external_requires(source_map_hash[source.filename])
         end
       else
         source_map_hash[source.filename] = Solargraph::SourceMap.map(source)

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -485,6 +485,7 @@ module Solargraph
     def map!
       workspace.sources.each do |src|
         source_map_hash[src.filename] = Solargraph::SourceMap.map(src)
+        find_external_requires source_map_hash[src.filename]
       end
       self
     end

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -598,6 +598,7 @@ module Solargraph
       ensure
         end_cache_progress
         catalog
+        sync_catalog
       end
     end
 

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -640,7 +640,7 @@ module Solargraph
     end
 
     def sync_catalog
-      return if @sync_count == 0
+      return if mutex.synchronize { @sync_count == 0 }
 
       mutex.synchronize do
         logger.info "Cataloging #{workspace.directory.empty? ? 'generic workspace' : workspace.directory}"

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -475,7 +475,6 @@ module Solargraph
       if src
         Logging.logger.debug "Mapping #{src.filename}"
         source_map_hash[src.filename] = Solargraph::SourceMap.map(src)
-        find_external_requires(source_map_hash[src.filename])
         source_map_hash[src.filename]
       else
         false
@@ -486,7 +485,6 @@ module Solargraph
     def map!
       workspace.sources.each do |src|
         source_map_hash[src.filename] = Solargraph::SourceMap.map(src)
-        find_external_requires(source_map_hash[src.filename])
       end
       self
     end
@@ -569,11 +567,9 @@ module Solargraph
         new_map = Solargraph::SourceMap.map(source)
         unless source_map_hash[source.filename].try_merge!(new_map)
           source_map_hash[source.filename] = new_map
-          find_external_requires(source_map_hash[source.filename])
         end
       else
         source_map_hash[source.filename] = Solargraph::SourceMap.map(source)
-        find_external_requires(source_map_hash[source.filename])
       end
     end
 
@@ -649,6 +645,7 @@ module Solargraph
       mutex.synchronize do
         logger.info "Cataloging #{workspace.directory.empty? ? 'generic workspace' : workspace.directory}"
         api_map.catalog bench
+        source_map_hash.values.each { |map| find_external_requires(map) }
         logger.info "Catalog complete (#{api_map.source_maps.length} files, #{api_map.pins.length} pins)"
         logger.info "#{api_map.uncached_gemspecs.length} uncached gemspecs"
         cache_next_gemspec

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -418,7 +418,6 @@ module Solargraph
     def catalog
       @threads.delete_if(&:stop?)
       @threads.push(Thread.new do
-        sleep 0.05 if RUBY_PLATFORM =~ /mingw/
         next unless @threads.last == Thread.current
 
         mutex.synchronize do
@@ -429,7 +428,6 @@ module Solargraph
           cache_next_gemspec
         end
       end)
-      @threads.last.run if RUBY_PLATFORM =~ /mingw/
     end
 
     # @return [Bench]
@@ -467,7 +465,6 @@ module Solargraph
     # @param source [Source]
     # @return [Boolean] True if the source was merged into the workspace.
     def merge source
-      Logging.logger.debug "Merging source: #{source.filename}"
       result = workspace.merge(source)
       maybe_map source
       result

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -263,9 +263,9 @@ module Solargraph
       end
 
       def nearly? other
-        return false unless super
-        parameters == other.parameters and
-          scope == other.scope and
+        super &&
+          parameters == other.parameters &&
+          scope == other.scope &&
           visibility == other.visibility
       end
 

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -24,7 +24,7 @@ module Solargraph
       @code
     end
 
-    # @return [Parser::AST::Node]
+    # @return [Parser::AST::Node, nil]
     def node
       finalize
       @node

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -39,7 +39,6 @@ module Solargraph
       @repaired = code
       @filename = filename
       @version = version
-      @domains = []
       begin
         @node, @comments = Solargraph::Parser.parse_with_comments(@code, filename)
         @parsed = true

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -101,7 +101,7 @@ module Solargraph
         @version = updater.version
         return self
       end
-      Source.new(code, filename, updater.version).tap do |src|
+      Source.new(@code, filename, updater.version).tap do |src|
         src.repaired = @repaired
         src.error_ranges.concat error_ranges
         src.changes.concat(changes + updater.changes)
@@ -227,7 +227,6 @@ module Solargraph
     end
 
     def synchronized?
-      finalize
       true
     end
 

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -436,7 +436,12 @@ module Solargraph
     attr_writer :error_ranges
 
     # @return [String]
-    attr_accessor :repaired
+    attr_writer :repaired
+
+    def repaired
+      finalize
+      @repaired
+    end
 
     # @return [Boolean]
     attr_writer :parsed

--- a/lib/solargraph/source.rb
+++ b/lib/solargraph/source.rb
@@ -452,9 +452,6 @@ module Solargraph
     # @return [Boolean]
     attr_writer :synchronized
 
-    # @return [Source::Updater]
-    attr_accessor :last_updater
-
     private
 
     # @return [Array<String>]

--- a/lib/solargraph/source_map.rb
+++ b/lib/solargraph/source_map.rb
@@ -48,7 +48,7 @@ module Solargraph
     #
     # @return [Integer]
     def api_hash
-      @api_hash ||= (pins_by_class(Pin::Constant) + pins_by_class(Pin::Namespace).select { |pin| pin.namespace.to_s > '' } + pins_by_class(Pin::Reference) + pins_by_class(Pin::Method).map(&:node)).hash
+      @api_hash ||= (pins_by_class(Pin::Constant) + pins_by_class(Pin::Namespace).select { |pin| pin.namespace.to_s > '' } + pins_by_class(Pin::Reference) + pins_by_class(Pin::Method).map(&:node) + locals).hash
     end
 
     # @return [String]

--- a/lib/solargraph/source_map.rb
+++ b/lib/solargraph/source_map.rb
@@ -11,34 +11,34 @@ module Solargraph
     autoload :Mapper,        'solargraph/source_map/mapper'
     autoload :Clip,          'solargraph/source_map/clip'
     autoload :Completion,    'solargraph/source_map/completion'
+    autoload :Data,          'solargraph/source_map/data'
 
     # @return [Source]
     attr_reader :source
 
     # @return [Array<Pin::Base>]
-    attr_reader :pins
+    def pins
+      data.pins
+    end
 
     # @return [Array<Pin::LocalVariable>]
-    attr_reader :locals
+    def locals
+      data.locals
+    end
 
     # @param source [Source]
-    # @param pins [Array<Pin::Base>]
-    # @param locals [Array<Pin::Base>]
-    def initialize source, pins, locals
-      # HACK: Keep the library from changing this
-      @source = source.dup
-      @pins = pins
-      @locals = locals
+    def initialize source
+      @source = source
+
       environ.merge Convention.for_local(self) unless filename.nil?
       self.convention_pins = environ.pins
-      @pin_class_hash = pins.to_set.classify(&:class).transform_values(&:to_a)
       @pin_select_cache = {}
     end
 
     # @param klass [Class]
     # @return [Array<Pin::Base>]
     def pins_by_class klass
-      @pin_select_cache[klass] ||= @pin_class_hash.select { |key, _| key <= klass }.values.flatten
+      @pin_select_cache[klass] ||= pin_class_hash.select { |key, _| key <= klass }.values.flatten
     end
 
     # A hash representing the state of the source map's API.
@@ -118,18 +118,11 @@ module Solargraph
       _locate_pin line, character, Pin::Namespace, Pin::Method, Pin::Block
     end
 
+    # @deprecated
     # @param other_map [SourceMap]
     # @return [Boolean]
     def try_merge! other_map
-      return false if pins.length != other_map.pins.length || locals.length != other_map.locals.length || requires.map(&:name).uniq.sort != other_map.requires.map(&:name).uniq.sort
-      pins.each_index do |i|
-        return false unless pins[i].try_merge!(other_map.pins[i])
-      end
-      locals.each_index do |i|
-        return false unless locals[i].try_merge!(other_map.locals[i])
-      end
-      @source = other_map.source
-      true
+      false
     end
 
     # @param name [String]
@@ -162,15 +155,23 @@ module Solargraph
         SourceMap.map(source)
       end
 
+      # @deprecated
       # @param source [Source]
       # @return [SourceMap]
       def map source
-        result = SourceMap::Mapper.map(source)
-        new(source, *result)
+        new(source)
       end
     end
 
     private
+
+    def pin_class_hash
+      @pin_class_hash ||= pins.to_set.classify(&:class).transform_values(&:to_a)
+    end
+
+    def data
+      @data ||= Data.new(source)
+    end
 
     # @return [Array<Pin::Base>]
     def convention_pins
@@ -180,7 +181,7 @@ module Solargraph
     # @param pins [Array<Pin::Base>]
     # @return [Array<Pin::Base>]
     def convention_pins=(pins)
-      # unmemoizing the document_symbols in case it was called from any of convnetions
+      # unmemoizing the document_symbols in case it was called from any of conventions
       @document_symbols = nil
       @convention_pins = pins
     end

--- a/lib/solargraph/source_map.rb
+++ b/lib/solargraph/source_map.rb
@@ -118,11 +118,21 @@ module Solargraph
       _locate_pin line, character, Pin::Namespace, Pin::Method, Pin::Block
     end
 
-    # @deprecated
+    # @todo Candidate for deprecation
+    #
     # @param other_map [SourceMap]
     # @return [Boolean]
     def try_merge! other_map
-      false
+      return false if pins.length != other_map.pins.length || locals.length != other_map.locals.length || requires.map(&:name).uniq.sort != other_map.requires.map(&:name).uniq.sort
+
+      pins.each_index do |i|
+        return false unless pins[i].try_merge!(other_map.pins[i])
+      end
+      locals.each_index do |i|
+        return false unless locals[i].try_merge!(other_map.locals[i])
+      end
+      @source = other_map.source
+      true
     end
 
     # @param name [String]

--- a/lib/solargraph/source_map/data.rb
+++ b/lib/solargraph/source_map/data.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Solargraph
+  class SourceMap
+    class Data
+      def initialize source
+        @source = source
+      end
+
+      def pins
+        generate
+        @pins || []
+      end
+
+      def locals
+        generate
+        @locals || []
+      end
+
+      private
+
+      def generate
+        return if @generated
+
+        @generated = true
+        @pins, @locals = Mapper.map(@source)
+      end
+    end
+  end
+end

--- a/spec/language_server/host/message_worker_spec.rb
+++ b/spec/language_server/host/message_worker_spec.rb
@@ -1,7 +1,7 @@
 describe Solargraph::LanguageServer::Host::MessageWorker do
   it "handle requests on queue" do
     host = double(Solargraph::LanguageServer::Host)
-    message = double()
+    message = {'method' => '$/example'}
     expect(host).to receive(:receive).with(message).and_return(nil)
 
     worker = Solargraph::LanguageServer::Host::MessageWorker.new(host)

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -1,51 +1,51 @@
 describe Solargraph::Pin::Method do
-  it "tracks code parameters" do
+  it 'tracks code parameters' do
     source = Solargraph::Source.new(%(
       def foo bar, baz = MyClass.new
       end
     ))
     map = Solargraph::SourceMap.map(source)
-    pin = map.pins.select{|pin| pin.path == '#foo'}.first
+    pin = map.pins.select { |pin| pin.path == '#foo' }.first
     expect(pin.parameters.length).to eq(2)
     expect(pin.parameters[0].name).to eq('bar')
     expect(pin.parameters[1].name).to eq('baz')
     expect(pin.parameter_names).to eq(%w[bar baz])
   end
 
-  it "tracks keyword parameters" do
+  it 'tracks keyword parameters' do
     source = Solargraph::Source.new(%(
       def foo bar:, baz: MyClass.new
       end
     ))
     map = Solargraph::SourceMap.map(source)
-    pin = map.pins.select{|pin| pin.path == '#foo'}.first
+    pin = map.pins.select { |pin| pin.path == '#foo' }.first
     expect(pin.parameters.length).to eq(2)
     expect(pin.parameters[0].name).to eq('bar')
     expect(pin.parameters[1].name).to eq('baz')
     expect(pin.parameter_names).to eq(%w[bar baz])
   end
 
-  it "tracks implicit block parameters when types included" do
+  it 'tracks implicit block parameters when types included' do
     source = Solargraph::Source.new(%(
       # @yieldparam bing [Integer]
       def foo bar:, baz: MyClass.new
       end
     ))
     map = Solargraph::SourceMap.map(source)
-    pin = map.pins.select{|pin| pin.path == '#foo'}.first
+    pin = map.pins.select { |pin| pin.path == '#foo' }.first
     expect(pin.class).to eq(Solargraph::Pin::Method)
     method_pin = pin
     expect(method_pin.signatures.length).to eq(1)
     method_signature = method_pin.signatures.first
     expect(method_signature.block).not_to be_nil
-    method_parameters = method_pin.parameters
+    method_pin.parameters
     expect(pin.block).not_to be_nil
     block = pin.block
     expect(block.parameters.map(&:name)).to eq(['bing'])
     expect(block.parameters.map(&:return_type).map(&:to_s)).to eq(['Integer'])
   end
 
-  it "includes param tags in documentation" do
+  it 'includes param tags in documentation' do
     # Yard wants to be handed data without comment markers or leading
     # whitespace, so we use <<~
     comments = <<~COMMENTS
@@ -62,7 +62,7 @@ describe Solargraph::Pin::Method do
     expect(pin.documentation).to include('description2')
   end
 
-  it "tracks rooted status in return types" do
+  it 'tracks rooted status in return types' do
     source = Solargraph::Source.new(<<~COMMENTS)
       class Foo; end
       module Bar
@@ -76,13 +76,13 @@ describe Solargraph::Pin::Method do
       end
     COMMENTS
     map = Solargraph::SourceMap.map(source)
-    bazzle = map.pins.select{|pin| pin.path == 'Bar::Baz#bazzle'}.first
+    bazzle = map.pins.select { |pin| pin.path == 'Bar::Baz#bazzle' }.first
     expect(bazzle.return_type.rooted?).to eq(false)
-    bing = map.pins.select{|pin| pin.path == 'Bar::Baz#bing'}.first
+    bing = map.pins.select { |pin| pin.path == 'Bar::Baz#bing' }.first
     expect(bing.return_type.rooted?).to eq(true)
   end
 
-  it "includes yieldparam tags in documentation" do
+  it 'includes yieldparam tags in documentation' do
     comments = <<~COMMENTS
       @yieldparam one [First] description1
       @yieldparam two [Second] description2
@@ -96,7 +96,7 @@ describe Solargraph::Pin::Method do
     expect(pin.documentation).to include('description2')
   end
 
-  it "includes yieldreturn tag in documentation" do
+  it 'includes yieldreturn tag in documentation' do
     comments = <<~COMMENTS
       @yieldreturn [YRet] yretdescription
       @return [String]
@@ -106,30 +106,36 @@ describe Solargraph::Pin::Method do
     expect(pin.documentation).to include('yretdescription')
   end
 
-  it "detects return types from tags" do
+  it 'detects return types from tags' do
     pin = Solargraph::Pin::Method.new(comments: '@return [Hash]')
     expect(pin.return_type.tag).to eq('Hash')
   end
 
-  it "ignores malformed return tags" do
+  it 'ignores malformed return tags' do
     pin = Solargraph::Pin::Method.new(name: 'bar', comments: '@return [Array<String')
     expect(pin.return_type).to be_undefined
   end
 
-  it "will not merge with changes in parameters" do
+  it 'will not merge with changes in parameters' do
     # @todo Method pin parameters are pins now
-    pin1 = Solargraph::Pin::Method.new(name: 'bar', parameters: ['one', 'two'])
+    pin1 = Solargraph::Pin::Method.new(name: 'bar', parameters: %w[one two])
     pin2 = Solargraph::Pin::Method.new(name: 'bar', parameters: ['three'])
     expect(pin1.nearly?(pin2)).to be(false)
   end
 
-  it "adds param tags to documentation" do
+  it 'will not merge with changes in YARD return types' do
+    pin1 = Solargraph::Pin::Method.new(name: 'foo', comments: '@return [String]')
+    pin2 = Solargraph::Pin::Method.new(name: 'foo', comments: '@return [Integer]')
+    expect(pin1.nearly?(pin2)).to be(false)
+  end
+
+  it 'adds param tags to documentation' do
     # @todo Method pin parameters are pins now
     pin = Solargraph::Pin::Method.new(name: 'bar', comments: '@param one [String]', parameters: ['args'])
     expect(pin.documentation).to include('one', '[String]')
   end
 
-  it "infers return types from reference tags" do
+  it 'infers return types from reference tags' do
     source = Solargraph::Source.load_string(%(
       class Foo1
         # @return [Hash]
@@ -148,7 +154,7 @@ describe Solargraph::Pin::Method do
     expect(type.tag).to eq('Hash')
   end
 
-  it "infers return types from relative reference tags" do
+  it 'infers return types from relative reference tags' do
     source = Solargraph::Source.load_string(%(
       module Container
         class Foo1
@@ -169,7 +175,7 @@ describe Solargraph::Pin::Method do
     expect(type.tag).to eq('Hash')
   end
 
-  it "infers return types from method reference tags" do
+  it 'infers return types from method reference tags' do
     source = Solargraph::Source.load_string(%(
       class Foo
         # @return [Hash]
@@ -185,7 +191,7 @@ describe Solargraph::Pin::Method do
     expect(type.tag).to eq('Hash')
   end
 
-  it "infers return types from top-level reference tags" do
+  it 'infers return types from top-level reference tags' do
     source = Solargraph::Source.load_string(%(
       class Other
         # @return [Hash]
@@ -203,7 +209,7 @@ describe Solargraph::Pin::Method do
     expect(type.tag).to eq('Hash')
   end
 
-  it "infers return types from constants" do
+  it 'infers return types from constants' do
     source = Solargraph::Source.load_string(%(
       class Foo
         # @param [String] a
@@ -219,7 +225,7 @@ describe Solargraph::Pin::Method do
     expect(type.tag).to eq('Integer')
   end
 
-  it "infers return types from other parameters" do
+  it 'infers return types from other parameters' do
     source = Solargraph::Source.load_string(%(
       class Foo
         # @param [String] a
@@ -235,7 +241,7 @@ describe Solargraph::Pin::Method do
     expect(type.tag).to eq('String')
   end
 
-  it "infers return types from block return declarations" do
+  it 'infers return types from block return declarations' do
     source = Solargraph::Source.load_string(%(
       class Foo
         # @yieldreturn [Integer]
@@ -251,7 +257,7 @@ describe Solargraph::Pin::Method do
     expect(type.tag).to eq('Integer')
   end
 
-  it "typifies Booleans" do
+  it 'typifies Booleans' do
     pin = Solargraph::Pin::Method.new(name: 'foo', comments: '@return [Boolean]', scope: :instance)
     api_map = Solargraph::ApiMap.new
     type = pin.typify(api_map)
@@ -506,30 +512,30 @@ describe Solargraph::Pin::Method do
   end
 
   context 'as attribute' do
-    it "is a kind of attribute/property" do
+    it 'is a kind of attribute/property' do
       source = Solargraph::Source.load_string(%(
         class Foo
           attr_reader :bar
         end
       ))
       map = Solargraph::SourceMap.map(source)
-      pin = map.pins.select{|p| p.is_a?(Solargraph::Pin::Method)}.first
+      pin = map.pins.select { |p| p.is_a?(Solargraph::Pin::Method) }.first
       expect(pin).to be_attribute
       expect(pin.completion_item_kind).to eq(Solargraph::LanguageServer::CompletionItemKinds::PROPERTY)
       expect(pin.symbol_kind).to eq(Solargraph::LanguageServer::SymbolKinds::PROPERTY)
     end
 
-    it "uses return type tags" do
+    it 'uses return type tags' do
       pin = Solargraph::Pin::Method.new(name: 'bar', comments: '@return [File]', attribute: true)
       expect(pin.return_type.tag).to eq('File')
     end
 
-    it "detects undefined types" do
+    it 'detects undefined types' do
       pin = Solargraph::Pin::Method.new(name: 'bar', attribute: true)
       expect(pin.return_type).to be_undefined
     end
 
-    it "generates paths" do
+    it 'generates paths' do
       npin = Solargraph::Pin::Namespace.new(name: 'Foo', type: :class)
       ipin = Solargraph::Pin::Method.new(closure: npin, name: 'bar', attribute: true, scope: :instance)
       expect(ipin.path).to eq('Foo#bar')
@@ -537,7 +543,7 @@ describe Solargraph::Pin::Method do
       expect(cpin.path).to eq('Foo.bar')
     end
 
-    it "handles invalid return type tags" do
+    it 'handles invalid return type tags' do
       pin = Solargraph::Pin::Method.new(name: 'bar', comments: '@return [Array<]', attribute: true)
       expect(pin.return_type).to be_undefined
     end
@@ -576,7 +582,7 @@ describe Solargraph::Pin::Method do
       api_map.map source
       pin = api_map.get_path_pins('Foo#bar').first
       expect(pin.typify(api_map)).to be_undefined
-      expect(pin.probe(api_map).items.map(&:tag)).to eq(['String', 'Integer'])
+      expect(pin.probe(api_map).items.map(&:tag)).to eq(%w[String Integer])
     end
 
     it 'infers return types from begin rescue block' do
@@ -595,7 +601,7 @@ describe Solargraph::Pin::Method do
       api_map.map source
       pin = api_map.get_path_pins('Foo#bar').first
       expect(pin.typify(api_map)).to be_undefined
-      expect(pin.probe(api_map).items.map(&:tag)).to eq(['String', 'Integer'])
+      expect(pin.probe(api_map).items.map(&:tag)).to eq(%w[String Integer])
     end
 
     it 'infers return types from compound statements in conditionals' do
@@ -611,7 +617,7 @@ describe Solargraph::Pin::Method do
       api_map.map source
       pin = api_map.get_path_pins('Foo#bar').first
       expect(pin.typify(api_map)).to be_undefined
-      expect(pin.probe(api_map).items.map(&:tag)).to eq(['Symbol', 'Float', 'String', 'Integer'])
+      expect(pin.probe(api_map).items.map(&:tag)).to eq(%w[Symbol Float String Integer])
     end
 
     it 'ignores malformed overload tags' do

--- a/spec/source_map_spec.rb
+++ b/spec/source_map_spec.rb
@@ -74,6 +74,60 @@ describe Solargraph::SourceMap do
     expect(pin).to be_a(Solargraph::Pin::Block)
   end
 
+  it "merges comment changes" do
+    map1 = Solargraph::SourceMap.load_string(%(
+      class Foo
+        def bar; end
+      end
+    ))
+    map2 = Solargraph::SourceMap.load_string(%(
+      class Foo
+        # My bar method
+        def bar; end
+      end
+    ))
+    expect(map1.try_merge!(map2)).to be(true)
+  end
+
+  it "merges require equivalents" do
+    map1 = Solargraph::SourceMap.load_string("require 'foo'")
+    map2 = Solargraph::SourceMap.load_string("require 'foo' # Insignificant comment")
+    expect(map1.try_merge!(map2)).to be(true)
+  end
+
+  it "does not merge require changes" do
+    map1 = Solargraph::SourceMap.load_string("require 'foo'")
+    map2 = Solargraph::SourceMap.load_string("require 'bar'")
+    expect(map1.try_merge!(map2)).to be(false)
+  end
+
+  it "merges repaired changes" do
+    source1 = Solargraph::Source.load_string(%(
+      list.each do |item|
+       i
+      end
+    ))
+    updater = Solargraph::Source::Updater.new(
+      nil,
+      2,
+      [
+        Solargraph::Source::Change.new(
+          Solargraph::Range.from_to(2, 8, 2, 8),
+          'f '
+        )
+      ]
+    )
+    source2 = source1.synchronize(updater)
+    map1 = Solargraph::SourceMap.map(source1)
+    pos1 = Solargraph::Position.new(2, 8)
+    pin1 = map1.pins.select{|p| p.location.range.contain?(pos1)}.first
+    map2 = Solargraph::SourceMap.map(source2)
+    expect(map1.try_merge!(map2)).to be(true)
+    pos2 = Solargraph::Position.new(2, 10)
+    pin2 = map1.pins.select{|p| p.location.range.contain?(pos2)}.first
+    expect(pin1).to eq(pin2)
+  end
+
   it 'scopes local variables correctly from root def blocks' do
     map = Solargraph::SourceMap.load_string(%(
       x = 'string'

--- a/spec/source_map_spec.rb
+++ b/spec/source_map_spec.rb
@@ -74,58 +74,10 @@ describe Solargraph::SourceMap do
     expect(pin).to be_a(Solargraph::Pin::Block)
   end
 
-  it "merges comment changes" do
-    map1 = Solargraph::SourceMap.load_string(%(
-      class Foo
-        def bar; end
-      end
-    ))
-    map2 = Solargraph::SourceMap.load_string(%(
-      class Foo
-        # My bar method
-        def bar; end
-      end
-    ))
-    expect(map1.try_merge!(map2)).to be(true)
-  end
-
-  it "merges require equivalents" do
-    map1 = Solargraph::SourceMap.load_string("require 'foo'")
-    map2 = Solargraph::SourceMap.load_string("require 'foo' # Insignificant comment")
-    expect(map1.try_merge!(map2)).to be(true)
-  end
-
   it "does not merge require changes" do
     map1 = Solargraph::SourceMap.load_string("require 'foo'")
     map2 = Solargraph::SourceMap.load_string("require 'bar'")
     expect(map1.try_merge!(map2)).to be(false)
-  end
-
-  it "merges repaired changes" do
-    source1 = Solargraph::Source.load_string(%(
-      list.each do |item|
-       i
-      end
-    ))
-    updater = Solargraph::Source::Updater.new(
-      nil,
-      2,
-      [
-        Solargraph::Source::Change.new(
-          Solargraph::Range.from_to(2, 8, 2, 8),
-          'f '
-        )
-      ]
-    )
-    source2 = source1.synchronize(updater)
-    map1 = Solargraph::SourceMap.map(source1)
-    pos1 = Solargraph::Position.new(2, 8)
-    pin1 = map1.pins.select{|p| p.location.range.contain?(pos1)}.first
-    map2 = Solargraph::SourceMap.map(source2)
-    expect(map1.try_merge!(map2)).to be(true)
-    pos2 = Solargraph::Position.new(2, 10)
-    pin2 = map1.pins.select{|p| p.location.range.contain?(pos2)}.first
-    expect(pin1).to eq(pin2)
   end
 
   it 'scopes local variables correctly from root def blocks' do

--- a/spec/source_map_spec.rb
+++ b/spec/source_map_spec.rb
@@ -74,12 +74,6 @@ describe Solargraph::SourceMap do
     expect(pin).to be_a(Solargraph::Pin::Block)
   end
 
-  it "does not merge require changes" do
-    map1 = Solargraph::SourceMap.load_string("require 'foo'")
-    map2 = Solargraph::SourceMap.load_string("require 'bar'")
-    expect(map1.try_merge!(map2)).to be(false)
-  end
-
   it 'scopes local variables correctly from root def blocks' do
     map = Solargraph::SourceMap.load_string(%(
       x = 'string'


### PR DESCRIPTION
* Library methods that use cursors need to sync_catalog first.
* Ensure that changing a method's return type in YARD tags resets the inference cache.
* Ensure that changes to local pins in source maps reset the inference cache.
* Host attaches opened and unmerged sources to libraries