### PR TITLE
Surface variable names in documentation

### DIFF
--- a/lib/solargraph/language_server/message/text_document/hover.rb
+++ b/lib/solargraph/language_server/message/text_document/hover.rb
@@ -21,7 +21,7 @@ module Solargraph
               parts.push pin.documentation unless pin.documentation.nil? || pin.documentation.empty?
               unless parts.empty?
                 data = parts.join("\n\n")
-                next if contents.last && contents.last.end_with?(data)
+                next if contents.last&.end_with?(data)
                 contents.push data
               end
               last_link = this_link unless this_link.nil?

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -190,7 +190,14 @@ module Solargraph
           []
         end
       else
-        mutex.synchronize { api_map.clip(cursor).define.map { |pin| pin.realize(api_map) } }
+        mutex.synchronize do
+          clip = api_map.clip(cursor)
+          if cursor.assign?
+            [Pin::ProxyType.new(name: cursor.word, return_type: clip.infer)]
+          else
+            clip.define.map { |pin| pin.realize(api_map) }
+          end
+        end
       end
     rescue FileNotFoundError => e
       handle_file_not_found(filename, e)

--- a/lib/solargraph/pin/conversions.rb
+++ b/lib/solargraph/pin/conversions.rb
@@ -87,7 +87,7 @@ module Solargraph
 
       # @return [String, nil]
       def text_documentation
-        this_path = path || return_type.tag
+        this_path = path || name || return_type.tag
         return nil if this_path == 'undefined'
         escape_brackets this_path
       end
@@ -105,9 +105,10 @@ module Solargraph
 
       # @return [String, nil]
       def generate_link
-        this_path = path || return_type.tag
+        this_path = path || name || return_type.tag
         return nil if this_path == 'undefined'
         return nil if this_path.nil? || this_path == 'undefined'
+        return this_path if path.nil?
         "[#{escape_brackets(this_path).gsub('_', '\\\\_')}](solargraph:/document?query=#{CGI.escape(this_path)})"
       end
 

--- a/lib/solargraph/source/cursor.rb
+++ b/lib/solargraph/source/cursor.rb
@@ -103,6 +103,13 @@ module Solargraph
         @string ||= source.string_at?(position)
       end
 
+
+      # True if the cursor's chain is an assignment to a variable.
+      #
+      # When the chain is an assignment, `Cursor#word` will contain the
+      # variable name.
+      #
+      # @return [Boolean]
       def assign?
         [:lvasgn, :ivasgn, :gvasgn, :cvasgn].include? chain&.node&.type
       end

--- a/lib/solargraph/source/cursor.rb
+++ b/lib/solargraph/source/cursor.rb
@@ -103,6 +103,10 @@ module Solargraph
         @string ||= source.string_at?(position)
       end
 
+      def assign?
+        [:lvasgn, :ivasgn, :gvasgn, :cvasgn].include? chain&.node&.type
+      end
+
       # Get a cursor pointing to the method that receives the current statement
       # as an argument.
       #

--- a/spec/language_server/message/text_document/hover_spec.rb
+++ b/spec/language_server/message/text_document/hover_spec.rb
@@ -18,4 +18,29 @@ describe Solargraph::LanguageServer::Message::TextDocument::Hover do
     message.process
     expect(message.result).to be_nil
   end
+
+  it 'returns inferred types for variables' do
+    code = %(
+      def foo
+        'bar'
+      end
+      x = foo.upcase
+    )
+    host = Solargraph::LanguageServer::Host.new
+    host.open('file:///test.rb', code, 1)
+    host.catalog
+    message = Solargraph::LanguageServer::Message::TextDocument::Hover.new(host, {
+      'params' => {
+        'textDocument' => {
+          'uri' => 'file:///test.rb'
+        },
+        'position' => {
+          'line' => 4,
+          'character' => 6
+        }
+      }
+    })
+    message.process
+    expect(message.result[:contents][:value]).to eq("x\n\n`=> String`")
+  end
 end

--- a/spec/pin/base_spec.rb
+++ b/spec/pin/base_spec.rb
@@ -52,6 +52,6 @@ describe Solargraph::Pin::Base do
 
   it "does not link documentation for undefined return types" do
     pin = Solargraph::Pin::Base.new(name: 'Foo', comments: '@return [undefined]')
-    expect(pin.link_documentation).to be_nil
+    expect(pin.link_documentation).to eq('Foo')
   end
 end

--- a/spec/pin/instance_variable_spec.rb
+++ b/spec/pin/instance_variable_spec.rb
@@ -9,6 +9,6 @@ describe Solargraph::Pin::InstanceVariable do
 
   it "does not link documentation for undefined return types" do
     pin = Solargraph::Pin::InstanceVariable.new(name: '@bar')
-    expect(pin.link_documentation).to be_nil
+    expect(pin.link_documentation).to eq('@bar')
   end
 end


### PR DESCRIPTION
* Add the variable name to documentation for variable pins.
* `Library#definitions_at` returns a proxy with the variable name and type for use in LSP features like `textDocument/hover`.
