### PR TITLE
Fix type sent into YARD method

### DIFF
--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -283,8 +283,8 @@ module Solargraph
             get_path_pins(pin.path.sub(/#initialize/, '.new')).first
           end
           (ovr.tags.map(&:tag_name) + ovr.delete).uniq.each do |tag|
-            pin.docstring.delete_tags tag.to_sym
-            new_pin.docstring.delete_tags tag.to_sym if new_pin
+            pin.docstring.delete_tags tag
+            new_pin.docstring.delete_tags tag if new_pin
           end
           ovr.tags.each do |tag|
             pin.docstring.add_tag(tag)


### PR DESCRIPTION
While it declares itself wanting a String, in reality the YARD method takes #to_s, so this change just squashes a typechecking warning