### PR TITLE
Early CancelRequest handling

### DIFF
--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -24,10 +24,8 @@ module Solargraph
       attr_writer :client_capabilities
 
       def initialize
-        @cancel_semaphore = Mutex.new
         @buffer_semaphore = Mutex.new
         @request_mutex = Mutex.new
-        @cancel = []
         @buffer = String.new
         @stopped = true
         @next_request_id = 1
@@ -65,7 +63,7 @@ module Solargraph
       # @param id [Integer]
       # @return [void]
       def cancel id
-        @cancel_semaphore.synchronize { @cancel.push id }
+        cancelled.push id
       end
 
       # True if the host received a request to cancel the method with the
@@ -74,9 +72,7 @@ module Solargraph
       # @param id [Integer]
       # @return [Boolean]
       def cancel? id
-        result = false
-        @cancel_semaphore.synchronize { result = @cancel.include? id }
-        result
+        cancelled.include? id
       end
 
       # Delete the specified ID from the list of cancelled IDs if it exists.
@@ -84,7 +80,7 @@ module Solargraph
       # @param id [Integer]
       # @return [void]
       def clear id
-        @cancel_semaphore.synchronize { @cancel.delete id }
+        cancelled.delete id
       end
 
       # Called by adapter, to handle the request
@@ -101,11 +97,11 @@ module Solargraph
       # @return [Solargraph::LanguageServer::Message::Base, nil] The message handler.
       def receive request
         if request['method']
-          logger.info "Server received #{request['method']}"
+          logger.info "Host received ##{request['id']} #{request['method']}"
           logger.debug request
           message = Message.select(request['method']).new(self, request)
           begin
-            message.process
+            message.process unless cancel?(request['id'])
           rescue StandardError => e
             logger.warn "Error processing request: [#{e.class}] #{e.message}"
             logger.warn e.backtrace.join("\n")
@@ -381,7 +377,6 @@ module Solargraph
           envelope = "Content-Length: #{json.bytesize}\r\n\r\n#{json}"
           queue envelope
           @next_request_id += 1
-          logger.info "Server sent #{method}"
           logger.debug params
         end
       end
@@ -692,6 +687,11 @@ module Solargraph
       end
 
       private
+
+      # @return [Array<Integer>]
+      def cancelled
+        @cancelled ||= []
+      end
 
       # @return [MessageWorker]
       def message_worker

--- a/lib/solargraph/language_server/host/message_worker.rb
+++ b/lib/solargraph/language_server/host/message_worker.rb
@@ -3,12 +3,14 @@
 module Solargraph
   module LanguageServer
     class Host
-      # A serial worker Thread to handle message.
-      #
-      # this make check pending message possible, and maybe cancelled to speedup process
+      # A serial worker Thread to handle incoming messages.
       #
       class MessageWorker
-        UPDATE_METHODS = ['textDocument/didOpen', 'textDocument/didChange', 'workspace/didChangeWatchedFiles'].freeze
+        UPDATE_METHODS = [
+          'textDocument/didOpen',
+          'textDocument/didChange',
+          'workspace/didChangeWatchedFiles'
+        ].freeze
 
         # @param host [Host]
         def initialize(host)
@@ -64,12 +66,24 @@ module Solargraph
         private
 
         def next_message
+          cancel_message || next_priority
+        end
+
+        def cancel_message
+          # Handle cancellations first
+          idx = messages.find_index { |msg| msg['method'] == '$/cancelRequest' }
+          return unless idx
+
+          msg = messages[idx]
+          messages.delete_at idx
+          msg
+        end
+
+        def next_priority
           # Prioritize updates and version-dependent messages for performance
           idx = messages.find_index do |msg|
             UPDATE_METHODS.include?(msg['method']) || version_dependent?(msg)
           end
-          # @todo We might want to clear duplicate instances of this message
-          #   that occur before the next update
           return messages.shift unless idx
 
           msg = messages[idx]

--- a/lib/solargraph/language_server/message/base.rb
+++ b/lib/solargraph/language_server/message/base.rb
@@ -61,18 +61,11 @@ module Solargraph
         # @return [void]
         def send_response
           return if id.nil?
-          if host.cancel?(id)
-            # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#cancelRequest
-            # cancel should send response RequestCancelled
-            Solargraph::Logging.logger.info "Cancelled response to #{method}"
-            set_result nil
-            set_error ErrorCodes::REQUEST_CANCELLED, "cancelled by client"
-          else
-            Solargraph::Logging.logger.info "Sending response to #{method}"
-          end
+
+          accept_or_cancel
           response = {
-            jsonrpc: "2.0",
-            id: id,
+            jsonrpc: '2.0',
+            id: id
           }
           response[:result] = result unless result.nil?
           response[:error] = error unless error.nil?
@@ -82,6 +75,20 @@ module Solargraph
           Solargraph.logger.debug envelope
           host.queue envelope
           host.clear id
+        end
+
+        private
+
+        def accept_or_cancel
+          if host.cancel?(id)
+            # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#cancelRequest
+            # cancel should send response RequestCancelled
+            Solargraph::Logging.logger.info "Cancelled response to ##{id} #{method}"
+            set_result nil
+            set_error ErrorCodes::REQUEST_CANCELLED, 'Cancelled by client'
+          else
+            Solargraph::Logging.logger.info "Sending response to ##{id} #{method}"
+          end
         end
       end
     end

--- a/lib/solargraph/language_server/message/text_document/completion.rb
+++ b/lib/solargraph/language_server/message/text_document/completion.rb
@@ -12,9 +12,6 @@ module Solargraph
             col = params['position']['character']
             begin
               completion = host.completions_at(params['textDocument']['uri'], line, col)
-              if host.cancel?(id)
-                return set_result(empty_result) if host.cancel?(id)
-              end
               items = []
               last_context = nil
               idx = -1


### PR DESCRIPTION
Prioritize `$/cancelRequest` messages so the host can avoid processing the message before sending the response.