### PR TITLE
Destructure partial yield types

### DIFF
--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -36,14 +36,12 @@ module Solargraph
       #
       # @return [::Array<ComplexType>]
       def destructure_yield_types(yield_types, parameters)
-        return yield_types if yield_types.length == parameters.length
-
         # yielding a tuple into a block will destructure the tuple
         if yield_types.length == 1
           yield_type = yield_types.first
           return yield_type.all_params if yield_type.tuple? && yield_type.all_params.length == parameters.length
         end
-        parameters.map { ComplexType::UNDEFINED }
+        parameters.map.with_index { |_, idx| yield_types[idx] || ComplexType::UNDEFINED }
       end
 
       # @param api_map [ApiMap]

--- a/spec/pin/parameter_spec.rb
+++ b/spec/pin/parameter_spec.rb
@@ -13,6 +13,21 @@ describe Solargraph::Pin::Parameter do
     expect(clip.infer.tag).to eq('Array')
   end
 
+  it 'infers @yieldparam tags with skipped arguments' do
+    api_map = Solargraph::ApiMap.new
+    source = Solargraph::Source.load_string(%(
+      # @yieldparam [String]
+      # @yieldparam [Integer]
+      def yielder; end
+      yielder do |things|
+        things
+      end
+    ), 'file.rb')
+    api_map.map source
+    clip = api_map.clip_at('file.rb', Solargraph::Position.new(5, 9))
+    expect(clip.infer.tag).to eq('String')
+  end
+
   it 'infers generic types' do
     source = Solargraph::Source.load_string(%(
       # @generic GenericTypeParam


### PR DESCRIPTION
Allow for block arguments that only include a subset of the receiver's `@yieldparam` tags.

```ruby
# @yieldparam [String]
# @yieldparam [Integer]
def foo; end

foo do |arg|
  arg # inferred as String
end
```
