### PR TITLE
[regression] Avoid non-deterministic behavior with better cache key

### DIFF
--- a/lib/solargraph.rb
+++ b/lib/solargraph.rb
@@ -42,6 +42,7 @@ module Solargraph
   autoload :Logging,          'solargraph/logging'
   autoload :TypeChecker,      'solargraph/type_checker'
   autoload :Environ,          'solargraph/environ'
+  autoload :Equality,         'solargraph/equality'
   autoload :Convention,       'solargraph/convention'
   autoload :Parser,           'solargraph/parser'
   autoload :RbsMap,           'solargraph/rbs_map'

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -7,6 +7,7 @@ module Solargraph
     GENERIC_TAG_NAME = 'generic'.freeze
     # @!parse
     #   include TypeMethods
+    include Equality
 
     autoload :TypeMethods, 'solargraph/complex_type/type_methods'
     autoload :UniqueType,  'solargraph/complex_type/unique_type'
@@ -18,17 +19,9 @@ module Solargraph
       @items = types.flat_map(&:items).uniq(&:to_s)
     end
 
-    def eql?(other)
-      self.class == other.class &&
-        @items == other.items
-    end
-
-    def ==(other)
-      self.eql?(other)
-    end
-
-    def hash
-      [self.class, @items].hash
+    # @sg-ignore Fix "Not enough arguments to Module#protected"
+    protected def equality_fields
+      [self.class, items]
     end
 
     # @param api_map [ApiMap]

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -7,8 +7,14 @@ module Solargraph
     #
     class UniqueType
       include TypeMethods
+      include Equality
 
       attr_reader :all_params, :subtypes, :key_types
+
+      # @sg-ignore Fix "Not enough arguments to Module#protected"
+      protected def equality_fields
+        [@name, @all_params, @subtypes, @key_types]
+      end
 
       # Create a UniqueType with the specified name and an optional substring.
       # The substring is the parameter section of a parametrized type, e.g.,

--- a/lib/solargraph/equality.rb
+++ b/lib/solargraph/equality.rb
@@ -1,0 +1,32 @@
+# frozen_string_literal: true
+
+module Solargraph
+  # @abstract This mixin relies on these -
+  #   methods:
+  #     equality_fields()
+  module Equality
+    # @!method equality_fields
+    #   @return [Array]
+
+    # @param other [Object]
+    # @return [Boolean]
+    def eql?(other)
+      self.class.eql?(other.class) &&
+        equality_fields.eql?(other.equality_fields)
+    end
+
+    # @param other [Object]
+    # @return [Boolean]
+    def ==(other)
+      self.eql?(other)
+    end
+
+    def hash
+      equality_fields.hash
+    end
+
+    def freeze
+      equality_fields.each(&:freeze)
+    end
+  end
+end

--- a/lib/solargraph/location.rb
+++ b/lib/solargraph/location.rb
@@ -5,6 +5,8 @@ module Solargraph
   # and Range.
   #
   class Location
+    include Equality
+
     # @return [String]
     attr_reader :filename
 
@@ -16,6 +18,11 @@ module Solargraph
     def initialize filename, range
       @filename = filename
       @range = range
+    end
+
+    # @sg-ignore Fix "Not enough arguments to Module#protected"
+    protected def equality_fields
+      [filename, range]
     end
 
     # @param location [self]

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -43,7 +43,8 @@ module Solargraph
 
       # @sg-ignore Fix "Not enough arguments to Module#protected"
       protected def equality_fields
-        [self.class, identity, code_object, location, type_location, name, path, source, comments, closure]
+        # 'source' not included so that top level namespaces are comparable, whether from RBS, code or a constant
+        [self.class, identity, code_object, location, type_location, name, path, comments, closure, presence_certain?, return_type]
       end
 
       # specialize some things from Equality mix-in

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -8,6 +8,7 @@ module Solargraph
       include Common
       include Conversions
       include Documenting
+      include Equality
 
       # @return [YARD::CodeObjects::Base]
       attr_reader :code_object
@@ -39,6 +40,21 @@ module Solargraph
         @name = name
         @comments = comments
       end
+
+      # @sg-ignore Fix "Not enough arguments to Module#protected"
+      protected def equality_fields
+        [self.class, identity, code_object, location, type_location, name, path, source, comments, closure]
+      end
+
+      # specialize some things from Equality mix-in
+
+      def eql?(other)
+        self.class.eql?(other.class) &&
+          equality_fields.eql?(other.equality_fields) &&
+          nearly?(other)
+      end
+
+      alias == eql?
 
       # @return [String]
       def comments
@@ -113,14 +129,6 @@ module Solargraph
       # @return [Location, nil]
       def best_location
         location || type_location
-      end
-
-      # Pin equality is determined using the #nearly? method and also
-      # requiring both pins to have the same location.
-      #
-      def == other
-        return false unless nearly? other
-        comments == other.comments and location == other.location
       end
 
       # True if the specified pin is a near match to this one. A near match
@@ -267,7 +275,7 @@ module Solargraph
 
       # @return [String]
       def identity
-        @identity ||= "#{closure.path}|#{name}"
+        @identity ||= "#{closure&.path}|#{name}"
       end
 
       # @return [String, nil]

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -44,7 +44,7 @@ module Solargraph
       # @sg-ignore Fix "Not enough arguments to Module#protected"
       protected def equality_fields
         # 'source' not included so that top level namespaces are comparable, whether from RBS, code or a constant
-        [self.class, identity, code_object, location, type_location, name, path, comments, closure, presence_certain?, return_type]
+        [self.class, identity, code_object, location, type_location, name, path, comments, closure, return_type]
       end
 
       # specialize some things from Equality mix-in

--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -21,6 +21,11 @@ module Solargraph
         @node = node
       end
 
+      # @sg-ignore Fix "Not enough arguments to Module#protected"
+      protected def equality_fields
+        super + [node, node&.location]
+      end
+
       # @param api_map [ApiMap]
       # @return [void]
       def rebind api_map

--- a/lib/solargraph/position.rb
+++ b/lib/solargraph/position.rb
@@ -4,6 +4,8 @@ module Solargraph
   # The zero-based line and column numbers of a position in a string.
   #
   class Position
+    include Equality
+
     # @return [Integer]
     attr_reader :line
 
@@ -17,6 +19,11 @@ module Solargraph
     def initialize line, character
       @line = line
       @character = character
+    end
+
+    # @sg-ignore Fix "Not enough arguments to Module#protected"
+    protected def equality_fields
+      [line, character]
     end
 
     # Get a hash of the position. This representation is suitable for use in

--- a/lib/solargraph/range.rb
+++ b/lib/solargraph/range.rb
@@ -4,6 +4,8 @@ module Solargraph
   # A pair of Positions that compose a section of text in code.
   #
   class Range
+    include Equality
+
     # @return [Position]
     attr_reader :start
 
@@ -15,6 +17,11 @@ module Solargraph
     def initialize start, ending
       @start = start
       @ending = ending
+    end
+
+    # @sg-ignore Fix "Not enough arguments to Module#protected"
+    protected def equality_fields
+      [start, ending]
     end
 
     # Get a hash of the range. This representation is suitable for use in

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -113,14 +113,14 @@ module Solargraph
       # @sg-ignore
       def infer api_map, name_pin, locals
         out = nil
-        cached = @@inference_cache[[node, node.location, links.map(&:word), name_pin&.return_type, locals]] unless node.nil?
+        cached = @@inference_cache[[node, node.location, links, name_pin&.return_type, locals]] unless node.nil?
         return cached if cached && @@inference_invalidation_key == api_map.hash
         out = infer_uncached api_map, name_pin, locals
         if @@inference_invalidation_key != api_map.hash
           @@inference_cache = {}
           @@inference_invalidation_key = api_map.hash
         end
-        @@inference_cache[[node, node.location, links.map(&:word), name_pin&.return_type, locals]] = out unless node.nil?
+        @@inference_cache[[node, node.location, links, name_pin&.return_type, locals]] = out unless node.nil?
         out
       end
 

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -14,10 +14,8 @@ module Solargraph
     # expression.
     #
     class Chain
-      #
-      # A chain of constants, variables, and method calls for inferring types of
-      # values.
-      #
+      include Equality
+
       autoload :Link,             'solargraph/source/chain/link'
       autoload :Call,             'solargraph/source/chain/call'
       autoload :QCall,            'solargraph/source/chain/q_call'
@@ -48,6 +46,11 @@ module Solargraph
       attr_reader :links
 
       attr_reader :node
+
+      # @sg-ignore Fix "Not enough arguments to Module#protected"
+      protected def equality_fields
+        [links, node]
+      end
 
       # @param node [Parser::AST::Node, nil]
       # @param links [::Array<Chain::Link>]
@@ -112,15 +115,20 @@ module Solargraph
       # @return [ComplexType]
       # @sg-ignore
       def infer api_map, name_pin, locals
-        out = nil
-        cached = @@inference_cache[[node, node.location, links, name_pin&.return_type, locals]] unless node.nil?
+        cache_key = [node, node&.location, links, name_pin&.return_type, locals]
+        cache_key_hash = cache_key.hash
+        cached = @@inference_cache[cache_key] unless node.nil?
         return cached if cached && @@inference_invalidation_key == api_map.hash
         out = infer_uncached api_map, name_pin, locals
         if @@inference_invalidation_key != api_map.hash
+          logger.debug { "Invalidating cache due to api_map change: #{api_map.hash}" }
           @@inference_cache = {}
           @@inference_invalidation_key = api_map.hash
         end
-        @@inference_cache[[node, node.location, links, name_pin&.return_type, locals]] = out unless node.nil?
+        unless node.nil?
+          logger.debug { "Chain#infer() - caching result - cache_key_hash=#{cache_key_hash}, links.map(&:hash)=#{links.map(&:hash)}, links=#{links}, cache_key.map(&:hash) = #{cache_key.map(&:hash)}, cache_key=#{cache_key}" }
+          @@inference_cache[cache_key] = out
+        end
         out
       end
 
@@ -159,6 +167,8 @@ module Solargraph
       def nullable?
         links.any?(&:nullable?)
       end
+
+      include Logging
 
       private
 

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -27,7 +27,7 @@ module Solargraph
 
         # @sg-ignore Fix "Not enough arguments to Module#protected"
         protected def equality_fields
-          super + [arguments, block]
+          super + [location, arguments, block]
         end
 
         def with_block?

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -27,7 +27,7 @@ module Solargraph
 
         # @sg-ignore Fix "Not enough arguments to Module#protected"
         protected def equality_fields
-          super + [location, arguments, block]
+          super + [arguments, block]
         end
 
         def with_block?

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -25,6 +25,11 @@ module Solargraph
           fix_block_pass
         end
 
+        # @sg-ignore Fix "Not enough arguments to Module#protected"
+        protected def equality_fields
+          super + [arguments, block]
+        end
+
         def with_block?
           !!@block
         end

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -11,6 +11,11 @@ module Solargraph
           @splatted = splatted
         end
 
+        # @sg-ignore Fix "Not enough arguments to Module#protected"
+        protected def equality_fields
+          super + [@splatted]
+        end
+
         def word
           @word ||= "<#{@type}>"
         end

--- a/lib/solargraph/source/chain/if.rb
+++ b/lib/solargraph/source/chain/if.rb
@@ -13,6 +13,11 @@ module Solargraph
           @links = links
         end
 
+        # @sg-ignore Fix "Not enough arguments to Module#protected"
+        protected def equality_fields
+          super + [links]
+        end
+
         def resolve api_map, name_pin, locals
           types = @links.map { |link| link.infer(api_map, name_pin, locals) }
           [Solargraph::Pin::ProxyType.anonymous(Solargraph::ComplexType.try_parse(types.map(&:tag).uniq.join(', ')))]

--- a/lib/solargraph/source/chain/if.rb
+++ b/lib/solargraph/source/chain/if.rb
@@ -15,7 +15,7 @@ module Solargraph
 
         # @sg-ignore Fix "Not enough arguments to Module#protected"
         protected def equality_fields
-          super + [links]
+          super + [@links]
         end
 
         def resolve api_map, name_pin, locals

--- a/lib/solargraph/source/chain/link.rb
+++ b/lib/solargraph/source/chain/link.rb
@@ -15,6 +15,24 @@ module Solargraph
           @word = word
         end
 
+        # @sg-ignore Fix "Not enough arguments to Module#protected"
+        protected def equality_fields
+          [self.class, word, last_context]
+        end
+
+        def eql?(other)
+          self.class == other.class &&
+            equality_fields == other.equality_fields
+        end
+
+        def ==(other)
+          self.eql?(other)
+        end
+
+        def hash
+          equality_fields.hash
+        end
+
         def undefined?
           word == '<undefined>'
         end
@@ -37,10 +55,6 @@ module Solargraph
 
         def head?
           @head ||= false
-        end
-
-        def == other
-          self.class == other.class and word == other.word
         end
 
         # Make a copy of this link marked as the head of a chain

--- a/lib/solargraph/source/chain/link.rb
+++ b/lib/solargraph/source/chain/link.rb
@@ -4,6 +4,8 @@ module Solargraph
   class Source
     class Chain
       class Link
+        include Equality
+
         # @return [String]
         attr_reader :word
 
@@ -17,20 +19,7 @@ module Solargraph
 
         # @sg-ignore Fix "Not enough arguments to Module#protected"
         protected def equality_fields
-          [self.class, word, last_context]
-        end
-
-        def eql?(other)
-          self.class == other.class &&
-            equality_fields == other.equality_fields
-        end
-
-        def ==(other)
-          self.eql?(other)
-        end
-
-        def hash
-          equality_fields.hash
+          [self.class, word]
         end
 
         def undefined?

--- a/lib/solargraph/source/chain/literal.rb
+++ b/lib/solargraph/source/chain/literal.rb
@@ -14,6 +14,11 @@ module Solargraph
           @complex_type = ComplexType.try_parse(type)
         end
 
+        # @sg-ignore Fix "Not enough arguments to Module#protected"
+        protected def equality_fields
+          super + [@value, @type, @literal_type, @complex_type]
+        end
+
         def resolve api_map, name_pin, locals
           [Pin::ProxyType.anonymous(@complex_type)]
         end

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -562,7 +562,7 @@ module Solargraph
       return [] unless pin.explicit?
       return [] if parameters.empty? && arguments.empty?
       return [] if pin.anon_splat?
-      unchecked = arguments.clone
+      unchecked = arguments.dup # creates copy of and unthaws array
       add_params = 0
       if unchecked.empty? && parameters.any? { |param| param.decl == :kwarg }
         return [Problem.new(location, "Missing keyword arguments to #{pin.path}")]

--- a/spec/type_checker_spec.rb
+++ b/spec/type_checker_spec.rb
@@ -1,3 +1,5 @@
+require 'timeout'
+
 describe Solargraph::TypeChecker do
   it 'does not raise errors checking unparsed sources' do
     expect {
@@ -16,5 +18,30 @@ describe Solargraph::TypeChecker do
       NotAClass
     ), nil, :strict)
     expect(checker.problems).to be_one
+  end
+
+  it 'uses caching in Solargraph::Chain to handle a degenerate case' do
+    checker = Solargraph::TypeChecker.load_string(%(
+      def documentation
+        @documentation = "a"
+        @documentation += "b"
+        @documentation += "c"
+        @documentation += "d"
+        @documentation += "e"
+        @documentation += "f"
+        @documentation += "g"
+        @documentation += "h"
+        @documentation += "i"
+        @documentation += "j"
+        @documentation += "k"
+        @documentation.to_s
+      end
+    ), nil, :strict)
+    timed_out = true
+    Timeout::timeout(5) do # seconds
+      checker.problems
+      timed_out = false
+    end
+    expect(timed_out).to be false
   end
 end


### PR DESCRIPTION
I've seen some dodgy non-repeatable behavior from Solargraph in the last few days.  I was able to pin it down (so to speak) to a particular use case I could repeat, and it seemed to be related to links being cached by their words alone in Chain.

Unfortunately, I did not record enough about the scenario to reproduce it :(

However, this change ought to strengthen the coherency of the links part of our cache key without affecting performance and hopefully squash this.