### PR TITLE
Fix pin inference stack

### DIFF
--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -265,6 +265,7 @@ module Solargraph
         result
       end
 
+      # @deprecated
       # @return [String]
       def identity
         @identity ||= "#{closure.path}|#{name}"

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -182,9 +182,9 @@ module Solargraph
         # @param pin [Pin::Base]
         pins.each do |pin|
           # Avoid infinite recursion
-          next if @@inference_stack.include?(pin.identity)
+          next if @@inference_stack.include?(pin)
 
-          @@inference_stack.push pin.identity
+          @@inference_stack.push pin
           type = pin.typify(api_map)
           @@inference_stack.pop
           if type.defined?
@@ -208,9 +208,9 @@ module Solargraph
           # @param pin [Pin::Base]
           pins.each do |pin|
             # Avoid infinite recursion
-            next if @@inference_stack.include?(pin.identity)
+            next if @@inference_stack.include?(pin)
 
-            @@inference_stack.push pin.identity
+            @@inference_stack.push pin
             type = pin.probe(api_map)
             @@inference_stack.pop
             if type.defined?

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -436,7 +436,7 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(6, 14))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    expect(type.rooted_tags).to eq('::A::B').or eq('::A::B, ::A::C')
+    expect(type.rooted_tags).to eq('::A::B').or eq('::A::B, ::A::C').or eq('::A::C, ::A::B')
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(11, 14))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
@@ -444,7 +444,7 @@ describe Solargraph::Source::Chain::Call do
     #   * emit type checker warning when adding [B.new] and type whole thing as '::A::B'
     #   * type whole thing as '::A::B, A::C'
     #   * type as undefined
-    expect(type.rooted_tags).to eq('::A::B, ::A::C').or be_undefined
+    expect(type.rooted_tags).to eq('::A::B, ::A::C').or eq('::A::C, ::A::B').or be_undefined
     expect(type.rooted_tags).not_to eq('::A::C')
   end
 

--- a/spec/source/chain_spec.rb
+++ b/spec/source/chain_spec.rb
@@ -411,4 +411,25 @@ describe Solargraph::Source::Chain do
     # type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, [])
     # expect(type.to_s).to eq('String')
   end
+
+  it 'resolves variable and method name collisions' do
+    source = Solargraph::Source.load_string(%(
+      class Example
+        # @return [String]
+        def stringify; end
+
+        class << self
+          # @return [Example]
+          def obj(foo); end
+        end
+      end
+
+      obj = Example.obj
+      str = obj.stringify
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(12, 6))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    expect(type.to_s).to eq('String')
+  end
 end


### PR DESCRIPTION
Chain inference can encounter pin identity collisions when a variable and a method have the same name. Change the inference stack to use normal object equality instead.