### PR TITLE
Refactor pin equality for performance

### DIFF
--- a/lib/solargraph/equality.rb
+++ b/lib/solargraph/equality.rb
@@ -27,6 +27,7 @@ module Solargraph
 
     def freeze
       equality_fields.each(&:freeze)
+      super
     end
   end
 end

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -134,11 +134,10 @@ module Solargraph
       # Pin equality is determined using the #nearly? method and also
       # requiring both pins to have the same location.
       #
-      def eql? other
+      def == other
         return false unless nearly? other
         comments == other.comments && location == other.location
       end
-      alias == eql?
 
       # The pin's return type.
       #

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -8,7 +8,6 @@ module Solargraph
       include Common
       include Conversions
       include Documenting
-      include Equality
 
       # @return [YARD::CodeObjects::Base]
       attr_reader :code_object
@@ -40,22 +39,6 @@ module Solargraph
         @name = name
         @comments = comments
       end
-
-      # @sg-ignore Fix "Not enough arguments to Module#protected"
-      protected def equality_fields
-        # 'source' not included so that top level namespaces are comparable, whether from RBS, code or a constant
-        [self.class, identity, code_object, location, type_location, name, path, comments, closure, return_type]
-      end
-
-      # specialize some things from Equality mix-in
-
-      def eql?(other)
-        self.class.eql?(other.class) &&
-          equality_fields.eql?(other.equality_fields) &&
-          nearly?(other)
-      end
-
-      alias == eql?
 
       # @return [String]
       def comments
@@ -147,6 +130,15 @@ module Solargraph
             compare_docstring_tags(docstring, other.docstring))
           )
       end
+
+      # Pin equality is determined using the #nearly? method and also
+      # requiring both pins to have the same location.
+      #
+      def eql? other
+        return false unless nearly? other
+        comments == other.comments && location == other.location
+      end
+      alias == eql?
 
       # The pin's return type.
       #

--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -21,11 +21,6 @@ module Solargraph
         @node = node
       end
 
-      # @sg-ignore Fix "Not enough arguments to Module#protected"
-      protected def equality_fields
-        super + [node, node&.location]
-      end
-
       # @param api_map [ApiMap]
       # @return [void]
       def rebind api_map

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -116,20 +116,16 @@ module Solargraph
       # @sg-ignore
       def infer api_map, name_pin, locals
         cache_key = [node, node&.location, links, name_pin&.return_type, locals]
-        cache_key_hash = cache_key.hash
-        cached = @@inference_cache[cache_key] unless node.nil?
-        return cached if cached && @@inference_invalidation_key == api_map.hash
-        out = infer_uncached api_map, name_pin, locals
-        if @@inference_invalidation_key != api_map.hash
-          logger.debug { "Invalidating cache due to api_map change: #{api_map.hash}" }
-          @@inference_cache = {}
+        if @@inference_invalidation_key == api_map.hash
+          cached = @@inference_cache[cache_key]
+          return cached if cached
+        else
           @@inference_invalidation_key = api_map.hash
+          @@inference_cache = {}
         end
-        unless node.nil?
-          logger.debug { "Chain#infer() - caching result - cache_key_hash=#{cache_key_hash}, links.map(&:hash)=#{links.map(&:hash)}, links=#{links}, cache_key.map(&:hash) = #{cache_key.map(&:hash)}, cache_key=#{cache_key}" }
-          @@inference_cache[cache_key] = out
-        end
-        out
+        out = infer_uncached api_map, name_pin, locals
+        logger.debug { "Chain#infer() - caching result - cache_key_hash=#{cache_key.hash}, links.map(&:hash)=#{links.map(&:hash)}, links=#{links}, cache_key.map(&:hash) = #{cache_key.map(&:hash)}, cache_key=#{cache_key}" }
+        @@inference_cache[cache_key] = out
       end
 
       # @param api_map [ApiMap]


### PR DESCRIPTION
#922 introduced changes to the chain inference stack that caused some performance issues in conjunction with changes to pin equality evaluation in #917.

* Pin equality evaluation uses the faster `nearly?` version instead of `Equality`.
* `Chain#inference` is refactored for clarity.
