### PR TITLE
Enable users to provide RBS shims for their bundled gems

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,10 @@ If your project automatically requires bundled gems (e.g., `require 'bundler/req
 
 As of version 0.33.0, Solargraph includes a [type checker](https://github.com/castwide/solargraph/issues/192) that uses a combination of YARD tags and code analysis to report missing type definitions. In strict mode, it performs type inference to determine whether the tags match the types it detects from code.
 
+Solargraph processes type definitions from the gems in your bundle using their RBS signatures and YARD tags.
+
+If you'd like to specify your own shims to improve the type definitions in the gems your project uses, you can add them to the `sigs/shims` directory in your workspace.
+
 ### The Documentation Cache
 
 Solargraph uses a cache directory to store documentation for the Ruby core and gems. The default location is `~/.cache/solargraph`, e.g., `/home/<username>/.cache/solargraph` on Linux or `C:\Users\<username>\.cache\solargraph` on Windows.

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -17,6 +17,7 @@ module Solargraph
     attr_reader :unresolved_requires
 
     @@core_map = RbsMap::CoreMap.new
+    @@shim_pins = {}
 
     # @return [Array<String>]
     attr_reader :missing_docs
@@ -98,7 +99,7 @@ module Solargraph
         @unresolved_requires = unresolved_requires
         need_to_uncache = true
       end
-      @store = Store.new(@@core_map.pins + @doc_map.pins + implicit.pins + pins)
+      @store = Store.new(@@core_map.pins + shim_pins(bench.workspace) + @doc_map.pins + implicit.pins + pins)
       @cache.clear if need_to_uncache
 
       @missing_docs = [] # @todo Implement missing docs
@@ -115,6 +116,12 @@ module Solargraph
     # @return [::Array<Gem::Specification>]
     def uncached_gemspecs
       @doc_map&.uncached_gemspecs || []
+    end
+
+    # @return [Array<Pin::Base>]
+    def shim_pins(workspace)
+      shim_dir = workspace.config.shim_dir
+      @@shim_pins[shim_dir] ||= RbsMap::ShimMap.new(shim_dir).pins
     end
 
     # @return [Array<Pin::Base>]

--- a/lib/solargraph/rbs_map.rb
+++ b/lib/solargraph/rbs_map.rb
@@ -8,6 +8,7 @@ module Solargraph
     autoload :Conversions, 'solargraph/rbs_map/conversions'
     autoload :CoreMap,     'solargraph/rbs_map/core_map'
     autoload :CoreFills,   'solargraph/rbs_map/core_fills'
+    autoload :ShimMap,     'solargraph/rbs_map/shim_map'
     autoload :StdlibMap,   'solargraph/rbs_map/stdlib_map'
 
     include Conversions

--- a/lib/solargraph/rbs_map/shim_map.rb
+++ b/lib/solargraph/rbs_map/shim_map.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Solargraph
+  class RbsMap
+    # User-provided pins
+    #
+    class ShimMap
+      include Conversions
+
+      # @param shims_dir [String]
+      def initialize(shims_dir)
+        loader = RBS::EnvironmentLoader.new(core_root: nil)
+        loader.add(path: Pathname(shims_dir))
+        load_environment_to_pins(loader)
+        pins.each { |pin| pin.source = :shim }
+      end
+    end
+  end
+end

--- a/lib/solargraph/workspace/config.rb
+++ b/lib/solargraph/workspace/config.rb
@@ -96,6 +96,13 @@ module Solargraph
         raw_data['formatter']
       end
 
+      # @return [String]
+      def shim_dir
+        # @type [Hash{String => String}]
+        rbs_config = raw_data.fetch('rbs', {})
+        rbs_config.fetch('shims', 'sig/shims')
+      end
+
       # An array of plugins to require.
       #
       # @return [Array<String>]
@@ -163,6 +170,9 @@ module Solargraph
               'only' => [],
               'extra_args' =>[]
             }
+          },
+          'rbs' => {
+            'shims' => 'sig/shims'
           },
           'require_paths' => [],
           'plugins' => [],


### PR DESCRIPTION
Putting .rbs files in the sig/shims directory will allow users to add types for gems which do not provide them.