### PR TITLE
Add a YARD-based shim for the parser gem

### DIFF
--- a/lib/solargraph/parser/parser_gem/class_methods.rb
+++ b/lib/solargraph/parser/parser_gem/class_methods.rb
@@ -3,6 +3,15 @@
 require 'parser/current'
 require 'parser/source/buffer'
 
+# Awaiting ability to use a version containing https://github.com/whitequark/parser/pull/1076
+#
+# @!parse
+#   class ::Parser::Base < ::Parser::Builder
+#     # @return [Integer]
+#     def version; end
+#   end
+#   class ::Parser::CurrentRuby < ::Parser::Base; end
+
 module Solargraph
   module Parser
     module ParserGem


### PR DESCRIPTION
This gets rid of some strict-level violations while typechecking the Solargraph source itself