### PR TITLE
Improve ApiMap catalog speed by preserving static pin indexes

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -12,6 +12,7 @@ module Solargraph
     autoload :Cache,          'solargraph/api_map/cache'
     autoload :SourceToYard,   'solargraph/api_map/source_to_yard'
     autoload :Store,          'solargraph/api_map/store'
+    autoload :Index,          'solargraph/api_map/index'
 
     # @return [Array<String>]
     attr_reader :unresolved_requires
@@ -48,14 +49,14 @@ module Solargraph
       equality_fields.hash
     end
 
-     def to_s
-       self.class.to_s
-     end
+    def to_s
+      self.class.to_s
+    end
 
-     # avoid enormous dump
-     def inspect
-       to_s
-     end
+    # avoid enormous dump
+    def inspect
+      to_s
+    end
 
     # @param pins [Array<Pin::Base>]
     # @return [self]
@@ -65,7 +66,7 @@ module Solargraph
       @source_map_hash = {}
       implicit.clear
       cache.clear
-      @store = Store.new(@@core_map.pins + pins)
+      store.update! @@core_map.pins, pins
       self
     end
 
@@ -86,7 +87,7 @@ module Solargraph
     def catalog bench
       old_api_hash = @source_map_hash&.values&.map(&:api_hash)
       need_to_uncache = (old_api_hash != bench.source_maps.map(&:api_hash))
-      @source_map_hash = bench.source_maps.map { |s| [s.filename, s] }.to_h
+      @source_map_hash = bench.source_maps.to_h { |s| [s.filename, s] }
       pins = bench.source_maps.flat_map(&:pins).flatten
       implicit.clear
       source_map_hash.each_value do |map|
@@ -98,7 +99,7 @@ module Solargraph
         @unresolved_requires = unresolved_requires
         need_to_uncache = true
       end
-      @store = Store.new(@@core_map.pins + @doc_map.pins + implicit.pins + pins)
+      store.update! @@core_map.pins + @doc_map.pins, implicit.pins + pins
       @cache.clear if need_to_uncache
 
       @missing_docs = [] # @todo Implement missing docs
@@ -195,7 +196,7 @@ module Solargraph
 
     # @return [Array<Solargraph::Pin::Base>]
     def pins
-      store.pins
+      store.pins.clone.freeze
     end
 
     # An array of pins based on Ruby keywords (`if`, `end`, etc.).

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -87,7 +87,8 @@ module Solargraph
     def catalog bench
       old_api_hash = @source_map_hash&.values&.map(&:api_hash)
       need_to_uncache = (old_api_hash != bench.source_maps.map(&:api_hash))
-      @source_map_hash = bench.source_maps.to_h { |s| [s.filename, s] }
+      # @todo Work around #to_h problem in current Ruby head (3.5)
+      @source_map_hash = bench.source_maps.map { |s| [s.filename, s] }.to_h
       pins = bench.source_maps.flat_map(&:pins).flatten
       implicit.clear
       source_map_hash.each_value do |map|

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -13,14 +13,17 @@ module Solargraph
         @pins ||= []
       end
 
+      # @return [Hash{String => Array<Pin::Namespace>}]
       def namespace_hash
         @namespace_hash ||= Hash.new { |h, k| h[k] = [] }
       end
 
+      # @return [Hash{String => Array<Pin::Base>}]
       def pin_class_hash
         @pin_class_hash ||= Hash.new { |h, k| h[k] = [] }
       end
 
+      # @return [Hash{String => Array<Pin::Base>}]
       def path_pin_hash
         @path_pin_hash ||= Hash.new { |h, k| h[k] = [] }
       end
@@ -34,22 +37,27 @@ module Solargraph
         @pin_select_cache[klass] ||= pin_class_hash.each_with_object(s) { |(key, o), n| n.merge(o) if key <= klass }
       end
 
+      # @return [Hash{String => Array<Pin::Reference::Include>}]
       def include_references
         @include_references ||= Hash.new { |h, k| h[k] = [] }
       end
 
+      # @return [Hash{String => Array<Pin::Reference::Extend>}]
       def extend_references
         @extend_references ||= Hash.new { |h, k| h[k] = [] }
       end
 
+      # @return [Hash{String => Array<Pin::Reference::Prepend>}]
       def prepend_references
         @prepend_references ||= Hash.new { |h, k| h[k] = [] }
       end
 
+      # @return [Hash{String => Array<Pin::Reference::Superclass>}]
       def superclass_references
         @superclass_references ||= Hash.new { |h, k| h[k] = [] }
       end
 
+      # @param pins [Array<Pin::Base>]
       def merge pins
         deep_clone.catalog pins
       end

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+module Solargraph
+  class ApiMap
+    class Index
+      # @param pins [Array<Pin::Base>]
+      def initialize pins
+        catalog pins
+      end
+
+      # @return [Array<Pin::Base>]
+      def pins
+        @pins ||= []
+      end
+
+      def namespace_hash
+        @namespace_hash ||= Hash.new { |h, k| h[k] = [] }
+      end
+
+      def pin_class_hash
+        @pin_class_hash ||= Hash.new { |h, k| h[k] = [] }
+      end
+
+      def path_pin_hash
+        @path_pin_hash ||= Hash.new { |h, k| h[k] = [] }
+      end
+
+      # @generic T
+      # @param klass [Class<generic<T>>]
+      # @return [Set<generic<T>>]
+      def pins_by_class klass
+        # @type [Set<Solargraph::Pin::Base>]
+        s = Set.new
+        @pin_select_cache[klass] ||= pin_class_hash.each_with_object(s) { |(key, o), n| n.merge(o) if key <= klass }
+      end
+
+      def include_references
+        @include_references ||= Hash.new { |h, k| h[k] = [] }
+      end
+
+      def extend_references
+        @extend_references ||= Hash.new { |h, k| h[k] = [] }
+      end
+
+      def prepend_references
+        @prepend_references ||= Hash.new { |h, k| h[k] = [] }
+      end
+
+      def superclass_references
+        @superclass_references ||= Hash.new { |h, k| h[k] = [] }
+      end
+
+      def merge pins
+        deep_clone.catalog pins
+      end
+
+      protected
+
+      attr_writer :pins, :pin_select_cache, :namespace_hash, :pin_class_hash, :path_pin_hash, :include_references,
+                  :extend_references, :prepend_references, :superclass_references
+
+      def deep_clone
+        Index.allocate.tap do |copy|
+          copy.pin_select_cache = {}
+          copy.pins = pins.clone
+          %i[
+            namespace_hash pin_class_hash path_pin_hash include_references extend_references prepend_references
+            superclass_references
+          ].each do |sym|
+            copy.send("#{sym}=", send(sym).clone)
+            copy.send(sym)&.transform_values!(&:clone)
+          end
+        end
+      end
+
+      def catalog new_pins
+        @pin_select_cache = {}
+        pins.concat new_pins
+        set = new_pins.to_set
+        set.classify(&:class)
+           .map { |k, v| pin_class_hash[k].concat v.to_a }
+        set.classify(&:namespace)
+           .map { |k, v| namespace_hash[k].concat v.to_a }
+        set.classify(&:path)
+           .map { |k, v| path_pin_hash[k].concat v.to_a }
+        @namespaces = path_pin_hash.keys.compact.to_set
+        pins_by_class(Pin::Reference::Include).each do |pin|
+          store_parametric_reference(include_references, pin)
+        end
+        # @todo move the rest of these reference pins over to use
+        #   generic types, adding rbs_map/conversions.rb code to
+        #   populate type parameters and adding related specs ensuring
+        #   the generics get resolved, along with any api_map.rb
+        #   changes needed in
+        pins_by_class(Pin::Reference::Prepend).each do |pin|
+          prepend_references[pin.namespace].push pin.name
+        end
+        pins_by_class(Pin::Reference::Extend).each do |pin|
+          extend_references[pin.namespace].push pin.name
+        end
+        pins_by_class(Pin::Reference::Superclass).each do |pin|
+          superclass_references[pin.namespace].push pin.name
+        end
+        pins_by_class(Pin::Reference::Override).each do |ovr|
+          pin = path_pin_hash[ovr.name].first
+          next if pin.nil?
+          new_pin = if pin.path.end_with?('#initialize')
+            path_pin_hash[pin.path.sub(/#initialize/, '.new')].first
+          end
+          (ovr.tags.map(&:tag_name) + ovr.delete).uniq.each do |tag|
+            pin.docstring.delete_tags tag
+            new_pin.docstring.delete_tags tag if new_pin
+          end
+          ovr.tags.each do |tag|
+            pin.docstring.add_tag(tag)
+            redefine_return_type pin, tag
+            if new_pin
+              new_pin.docstring.add_tag(tag)
+              redefine_return_type new_pin, tag
+            end
+          end
+        end
+        self
+      end
+
+      # Add references to a map
+      #
+      # @param h [Hash{String => Pin:Base}]
+      # @param reference_pin [Pin::Reference]
+      #
+      # @return [void]
+      def store_parametric_reference(h, reference_pin)
+        referenced_ns = reference_pin.name
+        referenced_tag_params = reference_pin.generic_values
+        referenced_tag = referenced_ns +
+                         if referenced_tag_params && referenced_tag_params.length > 0
+                           "<" + referenced_tag_params.join(', ') + ">"
+                         else
+                           ''
+                         end
+        referencing_ns = reference_pin.namespace
+        h[referencing_ns].push referenced_tag
+      end
+
+      # @param pin [Pin::Method]
+      # @param tag [YARD::Tags::Tag]
+      # @return [void]
+      def redefine_return_type pin, tag
+        return unless pin && tag.tag_name == 'return'
+        pin.instance_variable_set(:@return_type, ComplexType.try_parse(tag.type))
+        pin.signatures.each do |sig|
+          sig.instance_variable_set(:@return_type, ComplexType.try_parse(tag.type))
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -7,13 +7,32 @@ module Solargraph
     # core.
     #
     class Store
-      # @return [Array<Solargraph::Pin::Base>]
-      attr_reader :pins
+      # @param static [Enumerable<Pin::Base>]
+      # @param dynamic [Enumerable<Pin::Base>]
+      def initialize static = [], dynamic = []
+        @static_index = Index.new(static)
+        @dynamic = dynamic
+        @index = @static_index.merge(dynamic)
+      end
 
-      # @param pins [Enumerable<Solargraph::Pin::Base>]
-      def initialize pins = []
-        @pins = pins
-        index
+      # @return [Array<Solargraph::Pin::Base>]
+      def pins
+        index.pins
+      end
+
+      # @param static [Enumerable<Pin::Base>]
+      # @param dynamic [Enumerable<Pin::Base>]
+      def update! static = [], dynamic = []
+        # @todo Fix this map
+        @fqns_pins_map = nil
+        if @static_index.pins == static
+          return self if @dynamic == dynamic
+        else
+          @static_index = Index.new(static)
+        end
+        @dynamic = dynamic
+        @index = @static_index.merge(dynamic)
+        self
       end
 
       def to_s
@@ -74,11 +93,7 @@ module Solargraph
       # @param path [String]
       # @return [Array<Solargraph::Pin::Base>]
       def get_path_pins path
-        path_pin_hash[path] || []
-      end
-
-      def cacheable_pins
-        @cacheable_pins ||= pins_by_class(Pin::Namespace) + pins_by_class(Pin::Constant) + pins_by_class(Pin::Method) + pins_by_class(Pin::Reference)
+        index.path_pin_hash[path]
       end
 
       # @param fqns [String]
@@ -109,7 +124,7 @@ module Solargraph
 
       # @return [Set<String>]
       def namespaces
-        @namespaces ||= Set.new
+        index.namespaces
       end
 
       # @return [Enumerable<Solargraph::Pin::Namespace>]
@@ -151,18 +166,11 @@ module Solargraph
         pins_by_class(Pin::Block)
       end
 
-      def inspect
-        # Avoid insane dumps in specs
-        to_s
-      end
-
       # @generic T
       # @param klass [Class<generic<T>>]
       # @return [Set<generic<T>>]
       def pins_by_class klass
-        # @type [Set<Solargraph::Pin::Base>]
-        s = Set.new
-        @pin_select_cache[klass] ||= @pin_class_hash.each_with_object(s) { |(key, o), n| n.merge(o) if key <= klass }
+        index.pins_by_class klass
       end
 
       # @param fqns [String]
@@ -182,6 +190,8 @@ module Solargraph
 
       private
 
+      attr_reader :index
+
       # @return [Hash{::Array(String, String) => ::Array<Pin::Namespace>}]
       def fqns_pins_map
         @fqns_pins_map ||= Hash.new do |h, (base, name)|
@@ -192,129 +202,39 @@ module Solargraph
 
       # @return [Enumerable<Solargraph::Pin::Symbol>]
       def symbols
-        pins_by_class(Pin::Symbol)
+        index.pins_by_class(Pin::Symbol)
       end
 
       # @return [Hash{String => Array<String>}]
       def superclass_references
-        @superclass_references ||= {}
+        index.superclass_references
       end
 
       # @return [Hash{String => Array<String>}]
       def include_references
-        @include_references ||= {}
+        index.include_references
       end
 
       # @return [Hash{String => Array<String>}]
       def prepend_references
-        @prepend_references ||= {}
+        index.prepend_references
       end
 
       # @return [Hash{String => Array<String>}]
       def extend_references
-        @extend_references ||= {}
+        index.extend_references
       end
 
       # @param name [String]
       # @return [Enumerable<Solargraph::Pin::Base>]
       def namespace_children name
-        namespace_map[name] || []
-      end
-
-      # @return [Hash{String => Enumerable<Pin::Base>}
-      def namespace_map
-        @namespace_map ||= {}
+        return [] unless index.namespace_hash.key?(name)
+        index.namespace_hash[name]
       end
 
       # @return [Enumerable<Pin::InstanceVariable>]
       def all_instance_variables
-        pins_by_class(Pin::InstanceVariable)
-      end
-
-      # @return [Hash{String => Array<Pin::Base>}]
-      def path_pin_hash
-        @path_pin_hash ||= {}
-      end
-
-      # Add references to a map
-      #
-      # @param h [Hash{String => Pin:Base}]
-      # @param reference_pin [Pin::Reference]
-      #
-      # @return [void]
-      def store_parametric_reference(h, reference_pin)
-        referenced_ns = reference_pin.name
-        referenced_tag_params = reference_pin.generic_values
-        referenced_tag = referenced_ns +
-                         if referenced_tag_params && referenced_tag_params.length > 0
-                           "<" + referenced_tag_params.join(', ') + ">"
-                         else
-                           ''
-                         end
-        referencing_ns = reference_pin.namespace
-        h[referencing_ns] ||= []
-        h[referencing_ns].push referenced_tag
-      end
-
-      # @return [void]
-      def index
-        set = pins.to_set
-        @pin_class_hash = set.classify(&:class).transform_values(&:to_a)
-        # @type [Hash{Class => ::Array<Solargraph::Pin::Base>}]
-        @pin_select_cache = {}
-        @namespace_map = set.classify(&:namespace)
-        @path_pin_hash = set.classify(&:path)
-        @namespaces = @path_pin_hash.keys.compact.to_set
-        pins_by_class(Pin::Reference::Include).each do |pin|
-          store_parametric_reference(include_references, pin)
-        end
-        # @todo move the rest of these reference pins over to use
-        #   generic types, adding rbs_map/conversions.rb code to
-        #   populate type parameters and adding related specs ensuring
-        #   the generics get resolved, along with any api_map.rb
-        #   changes needed in
-        pins_by_class(Pin::Reference::Prepend).each do |pin|
-          prepend_references[pin.namespace] ||= []
-          prepend_references[pin.namespace].push pin.name
-        end
-        pins_by_class(Pin::Reference::Extend).each do |pin|
-          extend_references[pin.namespace] ||= []
-          extend_references[pin.namespace].push pin.name
-        end
-        pins_by_class(Pin::Reference::Superclass).each do |pin|
-          superclass_references[pin.namespace] ||= []
-          superclass_references[pin.namespace].push pin.name
-        end
-        pins_by_class(Pin::Reference::Override).each do |ovr|
-          pin = get_path_pins(ovr.name).first
-          next if pin.nil?
-          new_pin = if pin.path.end_with?('#initialize')
-            get_path_pins(pin.path.sub(/#initialize/, '.new')).first
-          end
-          (ovr.tags.map(&:tag_name) + ovr.delete).uniq.each do |tag|
-            pin.docstring.delete_tags tag
-            new_pin.docstring.delete_tags tag if new_pin
-          end
-          ovr.tags.each do |tag|
-            pin.docstring.add_tag(tag)
-            redefine_return_type pin, tag
-            if new_pin
-              new_pin.docstring.add_tag(tag)
-              redefine_return_type new_pin, tag
-            end
-          end
-        end
-      end
-
-      # @param pin [Pin::Method]
-      # @param tag [YARD::Tags::Tag]
-      # @return [void]
-      def redefine_return_type pin, tag
-        return unless pin && tag.tag_name == 'return'
-        pin.instance_variable_set(:@return_type, ComplexType.try_parse(tag.type))
-        pin.signatures.each do |sig|
-          sig.instance_variable_set(:@return_type, ComplexType.try_parse(tag.type))
-        end
+        index.pins_by_class(Pin::InstanceVariable)
       end
     end
   end

--- a/lib/solargraph/equality.rb
+++ b/lib/solargraph/equality.rb
@@ -27,6 +27,7 @@ module Solargraph
 
     def freeze
       equality_fields.each(&:freeze)
+      super
     end
   end
 end

--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -94,11 +94,11 @@ module Solargraph
           elsif n.type == :lvar
             result.push Chain::Call.new(n.children[0].to_s)
           elsif n.type == :ivar
-             result.push Chain::InstanceVariable.new(n.children[0].to_s)
+            result.push Chain::InstanceVariable.new(n.children[0].to_s)
           elsif n.type == :cvar
-             result.push Chain::ClassVariable.new(n.children[0].to_s)
+            result.push Chain::ClassVariable.new(n.children[0].to_s)
           elsif n.type == :gvar
-             result.push Chain::GlobalVariable.new(n.children[0].to_s)
+            result.push Chain::GlobalVariable.new(n.children[0].to_s)
           elsif n.type == :or_asgn
             # @todo: Need a new Link class here that evaluates the
             #   existing variable type with the RHS, and generates a

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -134,11 +134,10 @@ module Solargraph
       # Pin equality is determined using the #nearly? method and also
       # requiring both pins to have the same location.
       #
-      def eql? other
+      def == other
         return false unless nearly? other
         comments == other.comments && location == other.location
       end
-      alias == eql?
 
       # The pin's return type.
       #

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -8,7 +8,6 @@ module Solargraph
       include Common
       include Conversions
       include Documenting
-      include Equality
 
       # @return [YARD::CodeObjects::Base]
       attr_reader :code_object
@@ -40,22 +39,6 @@ module Solargraph
         @name = name
         @comments = comments
       end
-
-      # @sg-ignore Fix "Not enough arguments to Module#protected"
-      protected def equality_fields
-        # 'source' not included so that top level namespaces are comparable, whether from RBS, code or a constant
-        [self.class, identity, code_object, location, type_location, name, path, comments, closure, return_type]
-      end
-
-      # specialize some things from Equality mix-in
-
-      def eql?(other)
-        self.class.eql?(other.class) &&
-          equality_fields.eql?(other.equality_fields) &&
-          nearly?(other)
-      end
-
-      alias == eql?
 
       # @return [String]
       def comments
@@ -147,6 +130,15 @@ module Solargraph
             compare_docstring_tags(docstring, other.docstring))
           )
       end
+
+      # Pin equality is determined using the #nearly? method and also
+      # requiring both pins to have the same location.
+      #
+      def eql? other
+        return false unless nearly? other
+        comments == other.comments && location == other.location
+      end
+      alias == eql?
 
       # The pin's return type.
       #

--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -21,11 +21,6 @@ module Solargraph
         @node = node
       end
 
-      # @sg-ignore Fix "Not enough arguments to Module#protected"
-      protected def equality_fields
-        super + [node, node&.location]
-      end
-
       # @param api_map [ApiMap]
       # @return [void]
       def rebind api_map

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -31,6 +31,10 @@ module Solargraph
         @anon_splat = anon_splat
       end
 
+      def == other
+        super && other.node == node
+      end
+
       def transform_types(&transform)
         # @todo 'super' alone should work here I think, but doesn't typecheck at level typed
         m = super(&transform)

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -116,20 +116,16 @@ module Solargraph
       # @sg-ignore
       def infer api_map, name_pin, locals
         cache_key = [node, node&.location, links, name_pin&.return_type, locals]
-        cache_key_hash = cache_key.hash
-        cached = @@inference_cache[cache_key] unless node.nil?
-        return cached if cached && @@inference_invalidation_key == api_map.hash
-        out = infer_uncached api_map, name_pin, locals
-        if @@inference_invalidation_key != api_map.hash
-          logger.debug { "Invalidating cache due to api_map change: #{api_map.hash}" }
-          @@inference_cache = {}
+        if @@inference_invalidation_key == api_map.hash
+          cached = @@inference_cache[cache_key]
+          return cached if cached
+        else
           @@inference_invalidation_key = api_map.hash
+          @@inference_cache = {}
         end
-        unless node.nil?
-          logger.debug { "Chain#infer() - caching result - cache_key_hash=#{cache_key_hash}, links.map(&:hash)=#{links.map(&:hash)}, links=#{links}, cache_key.map(&:hash) = #{cache_key.map(&:hash)}, cache_key=#{cache_key}" }
-          @@inference_cache[cache_key] = out
-        end
-        out
+        out = infer_uncached api_map, name_pin, locals
+        logger.debug { "Chain#infer() - caching result - cache_key_hash=#{cache_key.hash}, links.map(&:hash)=#{links.map(&:hash)}, links=#{links}, cache_key.map(&:hash) = #{cache_key.map(&:hash)}, cache_key=#{cache_key}" }
+        @@inference_cache[cache_key] = out
       end
 
       # @param api_map [ApiMap]

--- a/lib/solargraph/source/cursor.rb
+++ b/lib/solargraph/source/cursor.rb
@@ -112,7 +112,7 @@ module Solargraph
       #
       # @return [Boolean]
       def assign?
-        [:lvasgn, :ivasgn, :gvasgn, :cvasgn].include? chain&.node&.type
+        %i[lvasgn ivasgn gvasgn cvasgn].include? chain&.node&.type
       end
 
       # Get a cursor pointing to the method that receives the current statement


### PR DESCRIPTION
Update `ApiMap::Store` to track static pins in their own `Index`.

Static pins come from core/stdlib/gem documentation. Dynamic pins come from the workspace. When the store gets updated, it can reuse the existing static index if it hasn't changed.