### PR TITLE
Clip#define returns variable pins

### DIFF
--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -192,11 +192,7 @@ module Solargraph
       else
         mutex.synchronize do
           clip = api_map.clip(cursor)
-          if cursor.assign?
-            [Pin::ProxyType.new(name: cursor.word, return_type: clip.infer)]
-          else
-            clip.define.map { |pin| pin.realize(api_map) }
-          end
+          clip.define.map { |pin| pin.realize(api_map) }
         end
       end
     rescue FileNotFoundError => e

--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -89,21 +89,15 @@ module Solargraph
           elsif n.type == :const
             const = unpack_name(n)
             result.push Chain::Constant.new(const)
-          elsif [:lvasgn, :ivasgn, :gvasgn, :cvasgn].include?(n.type)
-            result.concat generate_links(n.children[1])
-          elsif n.type == :lvar
+          elsif [:lvar, :lvasgn].include?(n.type)
             result.push Chain::Call.new(n.children[0].to_s)
-          elsif n.type == :ivar
+          elsif [:ivar, :ivasgn].include?(n.type)
             result.push Chain::InstanceVariable.new(n.children[0].to_s)
-          elsif n.type == :cvar
+          elsif [:cvar, :cvasgn].include?(n.type)
             result.push Chain::ClassVariable.new(n.children[0].to_s)
-          elsif n.type == :gvar
+          elsif [:gvar, :gvasgn].include?(n.type)
             result.push Chain::GlobalVariable.new(n.children[0].to_s)
           elsif n.type == :or_asgn
-            # @todo: Need a new Link class here that evaluates the
-            #   existing variable type with the RHS, and generates a
-            #   union type of the LHS alone if never nil, or minus nil +
-            #   RHS if it is nilable.
             result.concat generate_links n.children[1]
           elsif [:class, :module, :def, :defs].include?(n.type)
             # @todo Undefined or what?

--- a/lib/solargraph/parser/parser_gem/node_processors/lvasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/lvasgn_node.rb
@@ -8,8 +8,8 @@ module Solargraph
           include ParserGem::NodeMethods
 
           def process
-            # variable not visible until next statement
-            presence = Range.new(get_node_end_position(node), region.closure.location.range.ending)
+            here = get_node_start_position(node)
+            presence = Range.new(here, region.closure.location.range.ending)
             loc = get_node_location(node)
             locals.push Solargraph::Pin::LocalVariable.new(
               location: loc,

--- a/lib/solargraph/source/cursor.rb
+++ b/lib/solargraph/source/cursor.rb
@@ -104,17 +104,6 @@ module Solargraph
         @string ||= source.string_at?(position)
       end
 
-
-      # True if the cursor's chain is an assignment to a variable.
-      #
-      # When the chain is an assignment, `Cursor#word` will contain the
-      # variable name.
-      #
-      # @return [Boolean]
-      def assign?
-        %i[lvasgn ivasgn gvasgn cvasgn].include? chain&.node&.type
-      end
-
       # Get a cursor pointing to the method that receives the current statement
       # as an argument.
       #

--- a/spec/language_server/message/text_document/hover_spec.rb
+++ b/spec/language_server/message/text_document/hover_spec.rb
@@ -41,6 +41,6 @@ describe Solargraph::LanguageServer::Message::TextDocument::Hover do
       }
     })
     message.process
-    expect(message.result[:contents][:value]).to eq("x\n\n`=> String`")
+    expect(message.result[:contents][:value]).to eq("x\n\n`=~ String`")
   end
 end

--- a/spec/parser/node_chainer_spec.rb
+++ b/spec/parser/node_chainer_spec.rb
@@ -111,9 +111,10 @@ describe 'NodeChainer' do
       foo = [1, 2]
     ))
     chain = Solargraph::Parser.chain(source.node)
-    expect(chain.links.map(&:word)).to eq(['<::Array>'])
+    expect(chain.links.map(&:word)).to eq(['foo'])
     foo_link = chain.links.first
-    expect(foo_link.class).to eq(Solargraph::Source::Chain::Array)
+    expect(foo_link.class).to eq(Solargraph::Source::Chain::Call)
+    expect(foo_link.arguments).to eq([])
   end
 
   it 'tracks complex lhs' do

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -365,7 +365,7 @@ describe Solargraph::SourceMap::Clip do
     ), 'test.rb')
     map = Solargraph::ApiMap.new
     map.map source
-    clip = map.clip_at('test.rb', Solargraph::Position.new(4, 6))
+    clip = map.clip_at('test.rb', Solargraph::Position.new(3, 7))
     type = clip.infer
     expect(type.to_s).to eq('String, Array')
   end
@@ -735,7 +735,7 @@ describe Solargraph::SourceMap::Clip do
     ), 'test.rb')
     api_map = Solargraph::ApiMap.new
     api_map.map source
-    clip = api_map.clip_at('test.rb', [7, 11])
+    clip = api_map.clip_at('test.rb', [6, 11])
     expect(clip.infer.tag).to eq('Class')
   end
 
@@ -1254,7 +1254,6 @@ describe Solargraph::SourceMap::Clip do
       class Mod
         def meth
           arr = []
-          arr
           1.times do
             arr
           end
@@ -1264,11 +1263,11 @@ describe Solargraph::SourceMap::Clip do
     ), 'test.rb')
     api_map = Solargraph::ApiMap.new
     api_map.map source
-    clip = api_map.clip_at('test.rb', [4, 11])
+    clip = api_map.clip_at('test.rb', [3, 11])
     expect(clip.infer.tag).to eq('Array')
-    clip = api_map.clip_at('test.rb', [6, 12])
+    clip = api_map.clip_at('test.rb', [5, 12])
     expect(clip.infer.tag).to eq('Array')
-    clip = api_map.clip_at('test.rb', [8, 10])
+    clip = api_map.clip_at('test.rb', [7, 10])
     expect(clip.infer.tag).to eq('Array')
   end
 


### PR DESCRIPTION
ref #933 

#864 modified Clip#define to return pins for local variable assignments instead of the variable pins themselves. While this makes sense in terms of how Ruby evaluates the code, it causes problems in pin maps. Given `a = example()`, the definition found by clips pointing at `a` is the `example()` method pin instead of the `a` variable pin, effectively making the variable invisible to code intelligence.

I tried merging this PR with #864, and merge conflicts aside, it seems to work. I'll push a branch to demonstrate. If it still causes problems in flow-sensitive typing, the solution might be to modify inference instead of definition, so a local variable reference inside its own assignment knows to jump out of the assignment node and infer from a previous definition.