### PR TITLE
Index arbitrary pinsets

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -66,7 +66,7 @@ module Solargraph
       @source_map_hash = {}
       implicit.clear
       cache.clear
-      store.update! @@core_map.pins, pins
+      store.update @@core_map.pins, pins
       self
     end
 
@@ -85,11 +85,9 @@ module Solargraph
     # @param bench [Bench]
     # @return [self]
     def catalog bench
-      old_api_hash = @source_map_hash&.values&.map(&:api_hash)
-      need_to_uncache = (old_api_hash != bench.source_maps.map(&:api_hash))
-      # @todo Work around #to_h problem in current Ruby head (3.5)
-      @source_map_hash = bench.source_maps.map { |s| [s.filename, s] }.to_h
-      pins = bench.source_maps.flat_map(&:pins).flatten
+      @source_map_hash = bench.source_map_hash
+      iced_pins = bench.icebox.flat_map(&:pins)
+      live_pins = bench.live_map&.pins || []
       implicit.clear
       source_map_hash.each_value do |map|
         implicit.merge map.environ
@@ -98,11 +96,8 @@ module Solargraph
       if @unresolved_requires != unresolved_requires || @doc_map&.uncached_gemspecs&.any?
         @doc_map = DocMap.new(unresolved_requires, [], bench.workspace.rbs_collection_path) # @todo Implement gem preferences
         @unresolved_requires = unresolved_requires
-        need_to_uncache = true
       end
-      store.update! @@core_map.pins + @doc_map.pins, implicit.pins + pins
-      @cache.clear if need_to_uncache
-
+      @cache.clear if store.update(@@core_map.pins + @doc_map.pins, implicit.pins + iced_pins, live_pins)
       @missing_docs = [] # @todo Implement missing docs
       self
     end
@@ -111,7 +106,7 @@ module Solargraph
     #   that this overload of 'protected' will typecheck @sg-ignore
     # @sg-ignore
     protected def equality_fields
-      [self.class, @source_map_hash, implicit, @doc_map, @unresolved_requires, @missing_docs]
+      [self.class, @source_map_hash, implicit, @doc_map, @unresolved_requires]
     end
 
     # @return [::Array<Gem::Specification>]

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -97,7 +97,7 @@ module Solargraph
         @doc_map = DocMap.new(unresolved_requires, [], bench.workspace.rbs_collection_path) # @todo Implement gem preferences
         @unresolved_requires = unresolved_requires
       end
-      @cache.clear if store.update(@@core_map.pins + @doc_map.pins, implicit.pins + iced_pins, live_pins)
+      @cache.clear if store.update(@@core_map.pins, @doc_map.pins, implicit.pins, iced_pins, live_pins)
       @missing_docs = [] # @todo Implement missing docs
       self
     end

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -4,7 +4,7 @@ module Solargraph
   class ApiMap
     class Index
       # @param pins [Array<Pin::Base>]
-      def initialize pins
+      def initialize pins = []
         catalog pins
       end
 

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -31,7 +31,11 @@ module Solargraph
 
         pinsets[changed..].each_with_index do |pins, idx|
           @pinsets[changed + idx] = pins
-          @indexes[changed + idx] = @indexes[changed + idx - 1].merge(pins)
+          @indexes[changed + idx] = if pins.empty?
+            @indexes[changed + idx - 1]
+          else
+            @indexes[changed + idx - 1].merge(pins)
+          end
         end
         true
       end

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -9,10 +9,13 @@ module Solargraph
     class Store
       # @param static [Enumerable<Pin::Base>]
       # @param dynamic [Enumerable<Pin::Base>]
-      def initialize static = [], dynamic = []
+      # @param live [Enumerable<Pin::Base>]
+      def initialize static = [], dynamic = [], live = []
         @static_index = Index.new(static)
         @dynamic = dynamic
-        @index = @static_index.merge(dynamic)
+        @dynamic_index = @static_index.merge(dynamic)
+        @live = live
+        @index = @dynamic_index.merge(live)
       end
 
       # @return [Array<Solargraph::Pin::Base>]
@@ -22,17 +25,24 @@ module Solargraph
 
       # @param static [Enumerable<Pin::Base>]
       # @param dynamic [Enumerable<Pin::Base>]
-      def update! static = [], dynamic = []
+      # @return [Boolean] True if the index was updated
+      def update static = [], dynamic = [], live = []
         # @todo Fix this map
         @fqns_pins_map = nil
         if @static_index.pins == static
-          return self if @dynamic == dynamic
+          if @dynamic == dynamic
+            return false if @live == live
+          else
+            @dynamic_index = @static_index.merge(dynamic)
+          end
         else
           @static_index = Index.new(static)
+          @dynamic_index = @static_index.merge(dynamic)
         end
         @dynamic = dynamic
-        @index = @static_index.merge(dynamic)
-        self
+        @live = live
+        @index = @dynamic_index.merge(live)
+        true
       end
 
       def to_s

--- a/lib/solargraph/bench.rb
+++ b/lib/solargraph/bench.rb
@@ -11,18 +11,34 @@ module Solargraph
     # @return [Workspace]
     attr_reader :workspace
 
+    # @return [SourceMap]
+    attr_reader :live_map
+
     # @return [Set<String>]
     attr_reader :external_requires
 
     # @param source_maps [Array<SourceMap>, Set<SourceMap>]
     # @param workspace [Workspace]
+    # @param live_map [SourceMap, nil]
     # @param external_requires [Array<String>, Set<String>]
-    def initialize source_maps: [], workspace: Workspace.new, external_requires: []
+    def initialize source_maps: [], workspace: Workspace.new, live_map: nil, external_requires: []
       @source_maps = source_maps.to_set
       @workspace = workspace
+      @live_map = live_map
       @external_requires = external_requires.reject { |path| workspace.would_require?(path) }
                                             .compact
                                             .to_set
+    end
+
+    # @return [Hash{String => SourceMap}]
+    def source_map_hash
+      # @todo Work around #to_h bug in current Ruby head (3.5) with #map#to_h
+      @source_map_hash ||= source_maps.map { |s| [s.filename, s] }
+                                      .to_h
+    end
+
+    def icebox
+      @icebox ||= (source_maps - [live_map])
     end
   end
 end

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -430,7 +430,8 @@ module Solargraph
       Bench.new(
         source_maps: source_map_hash.values,
         workspace: workspace,
-        external_requires: external_requires
+        external_requires: external_requires,
+        live_map: @current ? source_map_hash[@current.filename] : nil
       )
     end
 

--- a/spec/api_map/store_spec.rb
+++ b/spec/api_map/store_spec.rb
@@ -1,2 +1,51 @@
+# frozen_string_literal: true
+
 describe Solargraph::ApiMap::Store do
+  it 'indexes multiple pinsets' do
+    foo_pin = Solargraph::Pin::Namespace.new(name: 'Foo')
+    bar_pin = Solargraph::Pin::Namespace.new(name: 'Bar')
+    store = Solargraph::ApiMap::Store.new([foo_pin], [bar_pin])
+
+    expect(store.get_path_pins('Foo')).to eq([foo_pin])
+    expect(store.get_path_pins('Bar')).to eq([bar_pin])
+  end
+
+  it 'indexes empty pinsets' do
+    foo_pin = Solargraph::Pin::Namespace.new(name: 'Foo')
+
+    store = Solargraph::ApiMap::Store.new([], [foo_pin])
+    expect(store.get_path_pins('Foo')).to eq([foo_pin])
+  end
+
+  it 'updates existing pinsets' do
+    foo_pin = Solargraph::Pin::Namespace.new(name: 'Foo')
+    bar_pin = Solargraph::Pin::Namespace.new(name: 'Bar')
+    baz_pin = Solargraph::Pin::Namespace.new(name: 'Baz')
+    store = Solargraph::ApiMap::Store.new([foo_pin], [bar_pin])
+    store.update([foo_pin], [baz_pin])
+
+    expect(store.get_path_pins('Foo')).to eq([foo_pin])
+    expect(store.get_path_pins('Baz')).to eq([baz_pin])
+    expect(store.get_path_pins('Bar')).to be_empty
+  end
+
+  it 'updates new pinsets' do
+    foo_pin = Solargraph::Pin::Namespace.new(name: 'Foo')
+    bar_pin = Solargraph::Pin::Namespace.new(name: 'Bar')
+    store = Solargraph::ApiMap::Store.new([foo_pin])
+    store.update([foo_pin], [bar_pin])
+
+    expect(store.get_path_pins('Foo')).to eq([foo_pin])
+    expect(store.get_path_pins('Bar')).to eq([bar_pin])
+  end
+
+  it 'updates empty stores' do
+    foo_pin = Solargraph::Pin::Namespace.new(name: 'Foo')
+    bar_pin = Solargraph::Pin::Namespace.new(name: 'Bar')
+    store = Solargraph::ApiMap::Store.new
+    store.update([foo_pin, bar_pin])
+
+    expect(store.get_path_pins('Foo')).to eq([foo_pin])
+    expect(store.get_path_pins('Bar')).to eq([bar_pin])
+  end
 end


### PR DESCRIPTION
* `Bench` tracks the file currently being edited to avoid unnecessary reindexing of other files in the workspace.
* `ApiMap::Store` indexes arbitrary pinsets for more granular control over when index merges occur.
