### PR TITLE
Separate YARD cache from doc map cache

### DIFF
--- a/lib/solargraph/yardoc.rb
+++ b/lib/solargraph/yardoc.rb
@@ -35,7 +35,7 @@ module Solargraph
     # @param gemspec [Gem::Specification]
     # @return [String]
     def path_for(gemspec)
-      File.join(Solargraph::Cache.work_dir, 'gems', "#{gemspec.name}-#{gemspec.version}.yardoc")
+      File.join(Solargraph::Cache.base_dir, "yard-#{YARD::VERSION}", "#{gemspec.name}-#{gemspec.version}.yardoc")
     end
 
     # Load a gem's yardoc and return its code objects.


### PR DESCRIPTION
Use a separate cache directory for yardocs so they're not dependent on the ruby/rbs/solargraph version. The doc map caches can share yardocs across versions as long as the YARD version is the same.