### PR TITLE
[regression] Fix interface change breaking solargraph-rails

### DIFF
--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -27,7 +27,7 @@ module Solargraph
         # @param location [Location, nil]
         # @param arguments [::Array<Chain>]
         # @param block [Chain, nil]
-        def initialize word, location, arguments = [], block = nil
+        def initialize word, location = nil, arguments = [], block = nil
           @word = word
           @location = location
           @arguments = arguments


### PR DESCRIPTION
This will break solargraph-rails running against future releases, and there's no elegant way for solargraph-rails to work around it alone.