### PR TITLE
[regression] Add back bundler/require support for solargraph-rails

### DIFF
--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -177,12 +177,13 @@ module Solargraph
     # @param gemspec [Gem::Specification]
     # @return [Array<Gem::Specification>]
     def fetch_dependencies gemspec
+      # @param spec [Gem::Dependency]
       only_runtime_dependencies(gemspec).each_with_object(Set.new) do |spec, deps|
         Solargraph.logger.info "Adding #{spec.name} dependency for #{gemspec.name}"
         dep = Gem::Specification.find_by_name(spec.name, spec.requirement)
         deps.merge fetch_dependencies(dep) if deps.add?(dep)
       rescue Gem::MissingSpecError
-        Solargraph.logger.warn "Gem dependency #{spec.name} #{spec.requirements} for #{gemspec.name} not found."
+        Solargraph.logger.warn "Gem dependency #{spec.name} #{spec.requirement} for #{gemspec.name} not found."
       end.to_a
     end
 

--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -180,7 +180,9 @@ module Solargraph
       # @param spec [Gem::Dependency]
       only_runtime_dependencies(gemspec).each_with_object(Set.new) do |spec, deps|
         Solargraph.logger.info "Adding #{spec.name} dependency for #{gemspec.name}"
-        dep = Gem::Specification.find_by_name(spec.name, spec.requirement)
+        dep = Gem.loaded_specs[gemspec.name]
+        # @todo is next line necessary?
+        dep ||= Gem::Specification.find_by_name(spec.name, spec.requirement)
         deps.merge fetch_dependencies(dep) if deps.add?(dep)
       rescue Gem::MissingSpecError
         Solargraph.logger.warn "Gem dependency #{spec.name} #{spec.requirement} for #{gemspec.name} not found."

--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -180,7 +180,7 @@ module Solargraph
       # @param spec [Gem::Dependency]
       only_runtime_dependencies(gemspec).each_with_object(Set.new) do |spec, deps|
         Solargraph.logger.info "Adding #{spec.name} dependency for #{gemspec.name}"
-        dep = Gem.loaded_specs[gemspec.name]
+        dep = Gem.loaded_specs[spec.name]
         # @todo is next line necessary?
         dep ||= Gem::Specification.find_by_name(spec.name, spec.requirement)
         deps.merge fetch_dependencies(dep) if deps.add?(dep)

--- a/spec/doc_map_spec.rb
+++ b/spec/doc_map_spec.rb
@@ -29,6 +29,21 @@ describe Solargraph::DocMap do
     expect(doc_map.uncached_gemspecs).to eq([gemspec])
   end
 
+  it 'imports all gems when bundler/require used' do
+    gemspec_a = Gem::Specification.new do |spec|
+      spec.name = 'not_a_gem'
+      spec.version = '1.0.0'
+    end
+    gemspec_b = Gem::Specification.new do |spec|
+      spec.name = 'also_not_a_gem'
+      spec.version = '1.0.0'
+    end
+    allow(Gem).to receive(:loaded_specs).with(no_args).and_return({ 'a' => gemspec_a, 'b' => gemspec_b })
+
+    doc_map = Solargraph::DocMap.new(['bundler/require'], [])
+    expect(doc_map.uncached_gemspecs).to eq([gemspec_a, gemspec_b])
+  end
+
   it 'does not warn for redundant requires' do
     # Requiring 'set' is unnecessary because it's already included in core. It
     # might make sense to log redundant requires, but a warning is overkill.

--- a/spec/doc_map_spec.rb
+++ b/spec/doc_map_spec.rb
@@ -30,18 +30,11 @@ describe Solargraph::DocMap do
   end
 
   it 'imports all gems when bundler/require used' do
-    gemspec_a = Gem::Specification.new do |spec|
-      spec.name = 'not_a_gem'
-      spec.version = '1.0.0'
-    end
-    gemspec_b = Gem::Specification.new do |spec|
-      spec.name = 'also_not_a_gem'
-      spec.version = '1.0.0'
-    end
-    allow(Gem).to receive(:loaded_specs).with(no_args).and_return({ 'a' => gemspec_a, 'b' => gemspec_b })
+    plain_doc_map = Solargraph::DocMap.new([], [])
 
-    doc_map = Solargraph::DocMap.new(['bundler/require'], [])
-    expect(doc_map.uncached_gemspecs).to eq([gemspec_a, gemspec_b])
+    doc_map_with_bundler_require = Solargraph::DocMap.new(['bundler/require'], [])
+
+    expect(doc_map_with_bundler_require.pins.length - plain_doc_map.pins.length).to be_positive
   end
 
   it 'does not warn for redundant requires' do

--- a/spec/source_map/mapper_spec.rb
+++ b/spec/source_map/mapper_spec.rb
@@ -1195,7 +1195,7 @@ describe Solargraph::SourceMap::Mapper do
           # @!method bar
           # @!method baz
         end
-      end  
+      end
     ), 'test.rb')
     api_map = Solargraph::ApiMap.new
     api_map.map source
@@ -1212,7 +1212,7 @@ describe Solargraph::SourceMap::Mapper do
         class << self
           # @!method baz
         end
-      end  
+      end
     ), 'test.rb')
     api_map = Solargraph::ApiMap.new
     api_map.map source
@@ -1391,6 +1391,15 @@ describe Solargraph::SourceMap::Mapper do
       Bundler.require
     ))
     pin = map.pins.select { |pin| pin.is_a?(Solargraph::Pin::Reference::Require) }.first
+    expect(pin.name).to eq('bundler/require')
+  end
+
+  it 'maps Bundler.require in Rails context to require "bundler/require"' do
+    map = Solargraph::SourceMap.load_string(%(
+      Bundler.require(*Rails.groups)
+    ))
+    pin = map.pins.select { |pin| pin.is_a?(Solargraph::Pin::Reference::Require) }.first
+    # not perfect - would be best if we did something with the argument to limit pins gathered
     expect(pin.name).to eq('bundler/require')
   end
 


### PR DESCRIPTION
This fix is needed for solargraph-rails; see https://github.com/iftheshoefritz/solargraph-rails/actions/runs/15252590965/job/42892684049 for what happens without it.  Specifically, look at how active_storage support is broken - any active_storage fields on models won't be able to be qualified, as the classes they reference are not in our api_map.

Background:

Rails includes `Bundler.require(*Rails.groups)` and `require 'rails/all'`, which both auto-requires paths from a number of gems.

Currently, we don't properly handle `rails/all`, as it includes gem dependencies that look like `activestorage` (gem name), whereas our current code won't find the dependency unless it's spelled `active_storage` (require name).

We also dropped support for bundler/require at some point, so that doesn't catch it either, as well as breaking some expected behavior around other gems which are not specifically brought in by 'rails/all'.