### PR TITLE
Create MethodAlias pins from YARD

### DIFF
--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -36,11 +36,12 @@ module Solargraph
       # @param closure [Solargraph::Pin::Closure, nil]
       # @param name [String]
       # @param comments [String]
-      def initialize location: nil, type_location: nil, closure: nil, name: '', comments: ''
+      def initialize location: nil, type_location: nil, closure: nil, source: nil, name: '', comments: ''
         @location = location
         @type_location = type_location
         @closure = closure
         @name = name
+        @source = source
         @comments = comments
       end
 

--- a/lib/solargraph/yard_map/mapper/to_method.rb
+++ b/lib/solargraph/yard_map/mapper/to_method.rb
@@ -16,29 +16,55 @@ module Solargraph
         def self.make code_object, name = nil, scope = nil, visibility = nil, closure = nil, spec = nil
           closure ||= Solargraph::Pin::Namespace.new(
             name: code_object.namespace.to_s,
-            gates: [code_object.namespace.to_s]
+            gates: [code_object.namespace.to_s],
+            type: code_object.namespace.is_a?(YARD::CodeObjects::ClassObject) ? :class : :module,
+            source: :yardoc,
           )
           location = object_location(code_object, spec)
           name ||= code_object.name.to_s
           return_type = ComplexType::SELF if name == 'new'
           comments = code_object.docstring ? code_object.docstring.all.to_s : ''
-          pin = Pin::Method.new(
-            location: location,
-            closure: closure,
-            name: name,
-            comments: comments,
-            scope: scope || code_object.scope,
-            visibility: visibility || code_object.visibility,
-            # @todo Might need to convert overloads to signatures
-            parameters: [],
-            explicit: code_object.is_explicit?,
-            return_type: return_type
-          )
-          pin.parameters.concat get_parameters(code_object, location, comments, pin)
+          final_scope = scope || code_object.scope
+          final_visibility = visibility || code_object.visibility
+          if code_object.is_alias?
+            origin_code_object = code_object.namespace.aliases[code_object]
+            pin = Pin::MethodAlias.new(
+              name: name,
+              location: location,
+              original: origin_code_object.name.to_s,
+              closure: closure,
+              comments: comments,
+              scope: final_scope,
+              visibility: final_visibility,
+              explicit: code_object.is_explicit?,
+              return_type: return_type,
+              parameters: [],
+              source: :yardoc,
+            )
+          else
+            pin = Pin::Method.new(
+              location: location,
+              closure: closure,
+              name: name,
+              comments: comments,
+              scope: final_scope,
+              visibility: final_visibility,
+              # @todo Might need to convert overloads to signatures
+              explicit: code_object.is_explicit?,
+              return_type: return_type,
+              attribute: code_object.is_attribute?,
+              parameters: [],
+              source: :yardoc,
+            )
+            pin.parameters.concat get_parameters(code_object, location, comments, pin)
+          end
+          logger.debug { "ToMethod.make: Just created method pin: #{pin.inspect}" }
           pin
         end
 
         class << self
+          include Logging
+
           private
 
           # @param code_object [YARD::CodeObjects::Base]
@@ -59,7 +85,8 @@ module Solargraph
                 name: arg_name(a),
                 presence: nil,
                 decl: arg_type(a),
-                asgn_code: a[1]
+                asgn_code: a[1],
+                source: :yardoc,
               )
             end
           end


### PR DESCRIPTION
While chasing down some unexpectedly untyped methods in solargraph-rails, I found that we're not processing method aliases correctly in YARD - this resolved the issue and enabled more method pins to be typed correctly and have the correct set of signatures / parameters.