### PR TITLE
Fix inline Struct definition

### DIFF
--- a/lib/solargraph/convention/struct_definition/struct_assignment_node.rb
+++ b/lib/solargraph/convention/struct_definition/struct_assignment_node.rb
@@ -25,7 +25,12 @@ module Solargraph
           def valid?(node)
             return false unless node&.type == :casgn
             return false if node.children[2].nil?
-            struct_node = node.children[2].children[0]
+
+            struct_node = if node.children[2].type == :block
+                            node.children[2].children[0]
+                          else
+                            node.children[2]
+                          end
 
             struct_definition_node?(struct_node)
           end
@@ -43,7 +48,11 @@ module Solargraph
 
         # @return [Parser::AST::Node]
         def struct_node
-          node.children[2].children[0]
+          if node.children[2].type == :block
+            node.children[2].children[0]
+          else
+            node.children[2]
+          end
         end
       end
     end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -3135,6 +3135,8 @@ describe Solargraph::SourceMap::Clip do
     pin = api_map.get_path_pins('Foo#bar=').first
     expect(pin).not_to be_nil
     expect(pin.return_type.to_s).to eq('String')
+    pin = api_map.get_path_pins('Foo#foo').first
+    expect(pin).not_to be_nil
 
     clip = api_map.clip_at('test.rb', [9, 15])
     names = clip.complete.pins.map(&:name)
@@ -3217,8 +3219,37 @@ describe Solargraph::SourceMap::Clip do
     pin = api_map.get_path_pins('Foo#bar=').first
     expect(pin).not_to be_nil
     expect(pin.return_type.to_s).to eq('String')
+    pin = api_map.get_path_pins('Foo#foo').first
+    expect(pin).not_to be_nil
 
     clip = api_map.clip_at('test.rb', [9, 15])
+    names = clip.complete.pins.map(&:name)
+    expect(names).to include('bar', 'bar=', 'baz', 'baz=')
+  end
+
+  it 'completes Struct methods via const assignment without a block' do
+    source = Solargraph::Source.load_string(%(
+      # @param bar [String]
+      # @param baz [Integer]
+      Foo = Struct.new(:bar, :baz)
+
+      Foo.new.ba
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    pin = api_map.get_path_pins('Foo#baz').first
+    expect(pin).not_to be_nil
+    expect(pin.return_type.to_s).to eq('Integer')
+    pin = api_map.get_path_pins('Foo#baz=').first
+    expect(pin).not_to be_nil
+    expect(pin.return_type.to_s).to eq('Integer')
+    pin = api_map.get_path_pins('Foo#bar').first
+    expect(pin).not_to be_nil
+    expect(pin.return_type.to_s).to eq('String')
+    pin = api_map.get_path_pins('Foo#bar=').first
+    expect(pin).not_to be_nil
+    expect(pin.return_type.to_s).to eq('String')
+
+    clip = api_map.clip_at('test.rb', [5, 15])
     names = clip.complete.pins.map(&:name)
     expect(names).to include('bar', 'bar=', 'baz', 'baz=')
   end


### PR DESCRIPTION
Fixes inline struct definition without `do..end` block:

```ruby
# @param bar [String]
# @param baz [Integer]
Foo = Struct.new(:bar, :baz)
```