### PR TITLE
[breaking] Comply with YARD documentation on Hash tag format

### DIFF
--- a/lib/solargraph/complex_type/type_methods.rb
+++ b/lib/solargraph/complex_type/type_methods.rb
@@ -171,7 +171,11 @@ module Solargraph
         elsif fixed_parameters?
           "(#{subtypes_str})"
         else
-          "<#{subtypes_str}>"
+          if name == 'Hash'
+            "<#{key_types_str}, #{subtypes_str}>"
+          else
+            "<#{key_types_str}#{subtypes_str}>"
+          end
         end
       end
 

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -55,6 +55,13 @@ module Solargraph
             key_types.concat(subs[0].map { |u| ComplexType.new([u]) })
             # @sg-ignore
             subtypes.concat(subs[1].map { |u| ComplexType.new([u]) })
+          elsif parameters_type == :list && name == 'Hash'
+            # Treat Hash<A, B> as Hash{A => B}
+            if subs.length != 2
+              raise ComplexTypeError, "Bad hash type: name=#{name}, substring=#{substring} - must have exactly two parameters"
+            end
+            key_types.concat(subs[0].map { |u| ComplexType.new([u]) })
+            subtypes.concat(subs[1].map { |u| ComplexType.new([u]) })
           else
             subtypes.concat subs
           end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -35,7 +35,7 @@ describe Solargraph::ComplexType do
   end
 
   it "parses multiple subtypes" do
-    types = Solargraph::ComplexType.parse 'Hash<Symbol, String>'
+    types = Solargraph::ComplexType.parse 'Array<Symbol, String>'
     expect(types.length).to eq(1)
     expect(types.first.tag).to eq('Hash<Symbol, String>')
     expect(types.first.name).to eq('Hash')
@@ -104,6 +104,18 @@ describe Solargraph::ComplexType do
       expect(types.first.nil_type?).to be(true)
       expect(types.to_rbs).to eq('nil')
     end
+  end
+
+  it "parses Hash using <> notation" do
+    types = Solargraph::ComplexType.parse 'Hash<Symbol, String>'
+    expect(types.length).to eq(1)
+    expect(types.first.tag).to eq('Hash<Symbol, String>')
+    expect(types.first.name).to eq('Hash')
+    expect(types.first.key_types.length).to eq(1)
+    expect(types.first.key_types[0].name).to eq('Symbol')
+    expect(types.first.subtypes.length).to eq(1)
+    expect(types.first.subtypes[0].name).to eq('String')
+    expect(types.to_rbs).to eq('Hash[Symbol, String]')
   end
 
   it "identifies parametrized types" do

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -37,12 +37,12 @@ describe Solargraph::ComplexType do
   it "parses multiple subtypes" do
     types = Solargraph::ComplexType.parse 'Array<Symbol, String>'
     expect(types.length).to eq(1)
-    expect(types.first.tag).to eq('Hash<Symbol, String>')
-    expect(types.first.name).to eq('Hash')
+    expect(types.first.tag).to eq('Array<Symbol, String>')
+    expect(types.first.name).to eq('Array')
     expect(types.first.subtypes.length).to eq(2)
     expect(types.first.subtypes[0].name).to eq('Symbol')
     expect(types.first.subtypes[1].name).to eq('String')
-    expect(types.to_rbs).to eq('Hash[Symbol, String]')
+    expect(types.to_rbs).to eq('Array[Symbol, String]')
   end
 
   it "detects namespace and scope for simple types" do


### PR DESCRIPTION
Fixes #961

This is technically a breaking change, but should be pretty safe - doesn't look like we ever parsed key types out of Hash<A, B>.  Here's the spec as of 2018: https://github.com/castwide/solargraph/commit/5209b491a4be5ab5a8d48eaec66d397fd41fc527

See https://www.rubydoc.info/gems/yard/file/docs/Tags.md#hashes