### PR TITLE
Require external bundle

### DIFF
--- a/lib/solargraph.rb
+++ b/lib/solargraph.rb
@@ -2,6 +2,7 @@
 
 Encoding.default_external = 'UTF-8'
 
+require 'bundler'
 require 'set'
 require 'yard-solargraph'
 require 'solargraph/yard_tags'

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -94,7 +94,7 @@ module Solargraph
       end
       unresolved_requires = (bench.external_requires + implicit.requires + bench.workspace.config.required).to_a.compact.uniq
       if @unresolved_requires != unresolved_requires || @doc_map&.uncached_gemspecs&.any?
-        @doc_map = DocMap.new(unresolved_requires, [], bench.workspace.rbs_collection_path) # @todo Implement gem preferences
+        @doc_map = DocMap.new(unresolved_requires, [], bench.workspace) # @todo Implement gem preferences
         @unresolved_requires = unresolved_requires
       end
       @cache.clear if store.update(@@core_map.pins, @doc_map.pins, implicit.pins, iced_pins, live_pins)

--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -152,7 +152,9 @@ module Solargraph
       # @param isa_node [Parser::AST::Node]
       # @return [Array(String, String)]
       def parse_isa(isa_node)
-        return unless isa_node.type == :send && isa_node.children[1] == :is_a?
+        # @todo A nil guard might be good enough here, but we might want to
+        #   see if the callers are checking for nils instead.
+        return unless isa_node&.type == :send && isa_node.children[1] == :is_a?
         # Check if conditional node follows this pattern:
         #   s(:send,
         #     s(:send, nil, :foo), :is_a?,

--- a/spec/doc_map_spec.rb
+++ b/spec/doc_map_spec.rb
@@ -30,9 +30,9 @@ describe Solargraph::DocMap do
   end
 
   it 'imports all gems when bundler/require used' do
-    plain_doc_map = Solargraph::DocMap.new([], [])
-
-    doc_map_with_bundler_require = Solargraph::DocMap.new(['bundler/require'], [])
+    workspace = Solargraph::Workspace.new(Dir.pwd)
+    plain_doc_map = Solargraph::DocMap.new([], [], workspace)
+    doc_map_with_bundler_require = Solargraph::DocMap.new(['bundler/require'], [], workspace)
 
     expect(doc_map_with_bundler_require.pins.length - plain_doc_map.pins.length).to be_positive
   end


### PR DESCRIPTION
ref https://github.com/castwide/vscode-solargraph/issues/280

`DocMap` needs to collect gem dependencies from the workspace when Solargraph is not running in the workspace's Bundler environment. A method that did it in an external process previously existed in `YardMap`. This PR adds the method back in `DocMap`. It only gets called when Solargraph is not running in a bundled environment or its environment is outside of the target workspace.
