### PR TITLE
Document pages

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -527,13 +527,8 @@ module Solargraph
           .select { |path| path.downcase.include?(query.downcase) }
     end
 
-    # Get YARD documentation for the specified path.
-    #
-    # @example
-    #   api_map.document('String#split')
-    #
-    # @todo This method is likely superfluous. Calling get_path_pins directly
-    #   should be sufficient.
+    # @deprecated This method is likely superfluous. Calling #get_path_pins
+    #   directly should be sufficient.
     #
     # @param path [String] The path to find
     # @return [Enumerable<Pin::Base>]

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -602,7 +602,11 @@ module Solargraph
       # @return [Array]
       def document query
         result = []
-        libraries.each { |lib| result.concat lib.document(query) }
+        if libraries.empty?
+          result.concat generic_library.document(query)
+        else
+          libraries.each { |lib| result.concat lib.document(query) }
+        end
         result
       end
 

--- a/lib/solargraph/language_server/host.rb
+++ b/lib/solargraph/language_server/host.rb
@@ -299,6 +299,10 @@ module Solargraph
         end
       end
 
+      def command_path
+        options['commandPath'] || 'solargraph'
+      end
+
       # Prepare multiple folders.
       #
       # @param array [Array<Hash{String => String}>]

--- a/lib/solargraph/language_server/message/extended/document.rb
+++ b/lib/solargraph/language_server/message/extended/document.rb
@@ -6,12 +6,15 @@ module Solargraph
       module Extended
         class Document < Base
           def process
-            objects = host.document(params['query'])
+            api_map, pins = host.document(params['query'])
             page = Solargraph::Page.new(host.options['viewsPath'])
-            content = page.render('document', layout: true, locals: {objects: objects})
+            content = page.render('document', layout: true, locals: { api_map: api_map, pins: pins })
             set_result(
               content: content
             )
+          rescue StandardError => e
+            Solargraph.logger.warn "Error processing document: [#{e.class}] #{e.message}"
+            Solargraph.logger.debug e.backtrace.join("\n")
           end
         end
       end

--- a/lib/solargraph/language_server/message/extended/document_gems.rb
+++ b/lib/solargraph/language_server/message/extended/document_gems.rb
@@ -11,9 +11,9 @@ module Solargraph
         #
         class DocumentGems < Base
           def process
-            cmd = "yard gems"
-            cmd += " --rebuild" if params['rebuild']
-            o, s = Open3.capture2(cmd)
+            cmd = [host.command_path, 'gems']
+            cmd.push '--rebuild' if params['rebuild']
+            o, s = Open3.capture2(*cmd)
             if s != 0
               host.show_message "An error occurred while building gem documentation.", LanguageServer::MessageTypes::ERROR
               set_result({

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -327,9 +327,10 @@ module Solargraph
 
     # @param query [String]
     # @return [Enumerable<YARD::CodeObjects::Base>]
+    # @return [Array(ApiMap, Enumerable<Pin::Base>)]
     def document query
       sync_catalog
-      mutex.synchronize { api_map.document query }
+      mutex.synchronize { [api_map, api_map.get_path_pins(query)] }
     end
 
     # @param query [String]

--- a/lib/solargraph/views/_method.erb
+++ b/lib/solargraph/views/_method.erb
@@ -2,33 +2,33 @@
     Namespace:
 </h2>
 <p>
-    <a href="solargraph:/document?query=<%= CGI.escape object.namespace.path %>"><%= object.namespace %></a>
+    <a href="solargraph:/document?query=<%= CGI.escape pin.namespace.path %>"><%= pin.namespace %></a>
 </p>
 <h2>
     Overview:
 </h2>
-<%= htmlify object.docstring %>
+<%= htmlify pin.docstring %>
 <p class="document-section">
-    <big><strong>Visibility:</strong></big> <%= object.visibility %>
+    <big><strong>Visibility:</strong></big> <%= pin.visibility %>
 </p>
-<% unless object.tags(:param).empty? %>
+<% unless pin.docstring.tags(:param).empty? %>
     <h2>
         Parameters:
     </h2>
     <ul>
-        <% object.tags(:param).each do |tag| %>
+        <% pin.docstring.tags(:param).each do |tag| %>
             <li>
                 <%= erb :_name_type_tag, layout: false, locals: {tag: tag} %>
             </li>
         <% end %>
     </ul>
 <% end %>
-<% unless object.tags(:raise).empty? %>
+<% unless pin.docstring.tags(:raise).empty? %>
 <h2>
     Raises:
 </h2>
 <ul>
-    <% object.tags(:raise).each do |tag| %>
+    <% pin.docstring.tags(:raise).each do |tag| %>
         <li>
             <%= erb :_name_type_tag, layout: false, locals: {tag: tag} %>
         </li>
@@ -38,20 +38,20 @@
 <h2>
     Returns:
 </h2>
-<% if object.tag(:return).nil? %>
+<% if pin.docstring.tag(:return).nil? %>
     <p>
         Undefined/unknown
     </p>
 <% else %>
     <ul>
-        <% object.tags(:return).each do |tag| %>
+        <% pin.tags(:return).each do |tag| %>
             <li>
                 <%= erb :_name_type_tag, layout: false, locals: {tag: tag} %>
             </li>
         <% end %>
     </ul>
 <% end %>
-<% examples = object.tags(:example) %>
+<% examples = pin.docstring.tags(:example) %>
 <% unless examples.nil? %>
     <% examples.each do |example| %>
         <h2>

--- a/lib/solargraph/views/_namespace.erb
+++ b/lib/solargraph/views/_namespace.erb
@@ -1,12 +1,12 @@
 <h2>
     Overview:
 </h2>
-<%= htmlify object.docstring %>
+<%= htmlify pin.docstring %>
 <h2>
     Class Methods
 </h2>
 <ul class="doc-list">
-    <% object.meths(scope: :class).sort{|a, b| a.name <=> b.name}.each do |meth| %>
+    <% api_map.get_methods(pin.path, scope: :class, deep: false).sort{|a, b| a.name <=> b.name}.each do |meth| %>
         <li>
             <a href="solargraph:/document?query=<%= CGI.escape(meth.path) %>"><%= meth.name %></a>
         </li>
@@ -16,7 +16,7 @@
     Instance Methods
 </h2>
 <ul class="doc-list">
-    <% object.meths(scope: :instance).sort{|a, b| a.name <=> b.name}.each do |meth| %>
+    <% api_map.get_methods(pin.path, scope: :instance, deep: false).sort{|a, b| a.name <=> b.name}.each do |meth| %>
         <li>
             <a href="solargraph:/document?query=<%= CGI.escape(meth.path) %>"><%= meth.name %></a>
         </li>

--- a/lib/solargraph/views/document.erb
+++ b/lib/solargraph/views/document.erb
@@ -1,23 +1,23 @@
-<% objects.reverse.each do |object| %>
+<% pins.each do |pin| %>
     <h1>
-        <%= object.name %>
-        <% if object.is_a?(YARD::CodeObjects::MethodObject) and !object.parameters.empty? %>
-            <small>(<%= object.parameters.map {|p| "#{p[0]}#{p[1] and p[0].end_with?(':') ? ' ' : (p[1] ? ' = ' : '')}#{p[1]}"}.join(', ') %>)</small>
+        <%= pin.name %>
+        <% if pin.is_a?(Solargraph::Pin::Method) && !pin.parameters.empty? %>
+            <small>(<%= pin.parameters.map {|p| "#{p[0]}#{p[1] and p[0].end_with?(':') ? ' ' : (p[1] ? ' = ' : '')}#{p[1]}"}.join(', ') %>)</small>
         <% end %>
     </h1>
-    <% unless object.files.empty? %>
+    <% unless pins.map(&:location).compact.empty? %>
         <h2>
             Defined in:
         </h2>
         <ul>
-            <% object.files.each do |f| %>
+            <% pins.map(&:location).compact.map(&:filename).each do |f| %>
                 <li><%= f %></li>
             <% end %>
         </ul>
     <% end %>
-    <% if object.is_a?(YARD::CodeObjects::NamespaceObject) %>
-        <%= erb :_namespace, layout: false, locals: {object: object} %>
-    <% elsif object.is_a?(YARD::CodeObjects::MethodObject) %>
-        <%= erb :_method, layout: false, locals: {object: object} %>
+    <% if pin.is_a?(Solargraph::Pin::Namespace) %>
+        <%= erb :_namespace, layout: false, locals: {api_map: api_map, pin: pin} %>
+    <% elsif pin.is_a?(Solargraph::Pin::Method) %>
+        <%= erb :_method, layout: false, locals: {api_map: api_map, pin: pin} %>
     <% end %>
 <% end %>

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -243,7 +243,7 @@ describe Solargraph::Library do
 
   it "returns YARD documentation from the core" do
     library = Solargraph::Library.new
-    result = library.document('String')
+    api_map, result = library.document('String')
     expect(result).not_to be_empty
     expect(result.first).to be_a(Solargraph::Pin::Base)
   end
@@ -257,7 +257,7 @@ describe Solargraph::Library do
       end
     ), 'test.rb', 0)
     library.attach src
-    result = library.document('Foo#bar')
+    api_map, result = library.document('Foo#bar')
     expect(result).not_to be_empty
     expect(result.first).to be_a(Solargraph::Pin::Base)
   end


### PR DESCRIPTION
Re-enable the document page feature, e.g., the custom `$/solargraph/search` and `$/solargraph/document` messages.