### PR TITLE
Map RBS 'untyped' type (RBS::Types::Bases::Any) to 'undefined'

### DIFF
--- a/lib/solargraph/rbs_map.rb
+++ b/lib/solargraph/rbs_map.rb
@@ -10,7 +10,7 @@ module Solargraph
     autoload :CoreFills,   'solargraph/rbs_map/core_fills'
     autoload :StdlibMap,   'solargraph/rbs_map/stdlib_map'
 
-    include Conversions
+    include Logging
 
     # @type [Hash{String => RbsMap}]
     @@rbs_maps_hash = {}
@@ -25,10 +25,12 @@ module Solargraph
       @version = version
       @collection = nil
       @directories = directories
-      loader = RBS::EnvironmentLoader.new(core_root: nil, repository: repository)
       add_library loader, library, version
       return unless resolved?
-      load_environment_to_pins(loader)
+    end
+
+    def pins
+      @pins ||= resolved? ? conversions.pins : []
     end
 
     # @generic T
@@ -70,6 +72,14 @@ module Solargraph
     end
 
     private
+
+    def loader
+      @loader ||= RBS::EnvironmentLoader.new(core_root: nil, repository: repository)
+    end
+
+    def conversions
+      @conversions ||= Conversions.new(loader: loader)
+    end
 
     # @param loader [RBS::EnvironmentLoader]
     # @param library [String]

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -6,7 +6,7 @@ module Solargraph
   class RbsMap
     # Functions for converting RBS declarations to Solargraph pins
     #
-    module Conversions
+    class Conversions
       include Logging
 
       # A container for tracking the current context of the RBS conversion
@@ -22,10 +22,16 @@ module Solargraph
         end
       end
 
-      # @return [Array<Pin::Base>]
-      def pins
-        @pins ||= []
+      def initialize(loader:)
+        @loader = loader
+        @pins = []
+        load_environment_to_pins(loader)
       end
+
+      attr_reader :loader
+
+      # @return [Array<Pin::Base>]
+      attr_reader :pins
 
       private
 
@@ -683,8 +689,7 @@ module Solargraph
         if type.is_a?(RBS::Types::Optional)
           "#{other_type_to_tag(type.type)}, nil"
         elsif type.is_a?(RBS::Types::Bases::Any)
-          # @todo Not sure what to do with Any yet
-          'BasicObject'
+          'undefined'
         elsif type.is_a?(RBS::Types::Bases::Bool)
           'Boolean'
         elsif type.is_a?(RBS::Types::Tuple)

--- a/lib/solargraph/rbs_map/core_map.rb
+++ b/lib/solargraph/rbs_map/core_map.rb
@@ -5,7 +5,6 @@ module Solargraph
     # Ruby core pins
     #
     class CoreMap
-      include Conversions
 
       FILLS_DIRECTORY = File.join(File.dirname(__FILE__), '..', '..', '..', 'rbs', 'fills')
 
@@ -14,15 +13,28 @@ module Solargraph
         if cache
           pins.replace cache
         else
-          loader = RBS::EnvironmentLoader.new(repository: RBS::Repository.new(no_stdlib: false))
           loader.add(path: Pathname(FILLS_DIRECTORY))
-          load_environment_to_pins(loader)
           pins.concat RbsMap::CoreFills::ALL
+          @pins = conversions.pins
           processed = ApiMap::Store.new(pins).pins.reject { |p| p.is_a?(Solargraph::Pin::Reference::Override) }
           pins.replace processed
 
           Cache.save('core.ser', pins)
         end
+      end
+
+      def pins
+        @pins ||= []
+      end
+
+      private
+
+      def loader
+        @loader ||= RBS::EnvironmentLoader.new(repository: RBS::Repository.new(no_stdlib: false))
+      end
+
+      def conversions
+        @conversions ||= Conversions.new(loader: loader)
       end
     end
   end

--- a/lib/solargraph/rbs_map/core_map.rb
+++ b/lib/solargraph/rbs_map/core_map.rb
@@ -14,8 +14,8 @@ module Solargraph
           pins.replace cache
         else
           loader.add(path: Pathname(FILLS_DIRECTORY))
-          pins.concat RbsMap::CoreFills::ALL
           @pins = conversions.pins
+          @pins.concat RbsMap::CoreFills::ALL
           processed = ApiMap::Store.new(pins).pins.reject { |p| p.is_a?(Solargraph::Pin::Reference::Override) }
           pins.replace processed
 

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -1,0 +1,54 @@
+describe Solargraph::RbsMap::Conversions do
+  # create a temporary directory with the scope of the spec
+  around do |example|
+    require 'tmpdir'
+    Dir.mktmpdir("rspec-solargraph-") do |dir|
+      @temp_dir = dir
+      example.run
+    end
+  end
+
+  let(:rbs_repo) do
+    RBS::Repository.new(no_stdlib: false)
+  end
+
+  let(:loader) do
+    RBS::EnvironmentLoader.new(core_root: nil, repository: rbs_repo)
+  end
+
+  let(:conversions) do
+    Solargraph::RbsMap::Conversions.new(loader: loader)
+  end
+
+  let(:pins) do
+    conversions.pins
+  end
+
+  before do
+    rbs_file = File.join(temp_dir, 'foo.rbs')
+    File.write(rbs_file, rbs)
+    loader.add(path: Pathname(temp_dir))
+  end
+
+  attr_reader :temp_dir
+
+  context 'with untyped response' do
+    let(:rbs) do
+      <<~RBS
+          class Foo
+            def bar: () -> untyped
+          end
+        RBS
+    end
+
+    subject(:method_pin) { pins.find { |pin| pin.path == 'Foo#bar' } }
+
+    it { should_not be_nil }
+
+    it { should be_a(Solargraph::Pin::Method) }
+
+    it 'maps untyped in RBS to undefined in Solargraph 'do
+      expect(method_pin.return_type.tag).to eq('undefined')
+    end
+  end
+end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -746,7 +746,7 @@ describe Solargraph::SourceMap::Clip do
     expect(clip.infer.tag).to eq('Class')
   end
 
-  it 'infers BasicObject from Class#new' do
+  it 'infers undefined from Class#new' do
     source = Solargraph::Source.load_string(%(
       cls = Class.new
       cls.new
@@ -754,17 +754,17 @@ describe Solargraph::SourceMap::Clip do
     api_map = Solargraph::ApiMap.new
     api_map.map source
     clip = api_map.clip_at('test.rb', [2, 11])
-    expect(clip.infer.tag).to eq('BasicObject')
+    expect(clip.infer.tag).to eq('undefined')
   end
 
-  it 'infers BasicObject from Class.new.new' do
+  it 'infers undefined from Class.new.new' do
     source = Solargraph::Source.load_string(%(
       Class.new.new
     ), 'test.rb')
     api_map = Solargraph::ApiMap.new
     api_map.map source
     clip = api_map.clip_at('test.rb', [1, 17])
-    expect(clip.infer.tag).to eq('BasicObject')
+    expect(clip.infer.tag).to eq('undefined')
   end
 
   it 'completes class instance variables in the namespace' do


### PR DESCRIPTION
This seems to be the most clear mapping - viewing these three names as all meaning 'I am making no promises on what type this can be'.

https://github.com/ruby/rbs/blob/master/docs/syntax.md#base-types

'untyped' is used in RBS as the initial type inserted for all arguments and return values when stubs are generated

Also:
* Refactor RbsMap::Conversions into a standalone class for testing   purposes