### PR TITLE
[regression] Gem caching perf and logging fixes

### DIFF
--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -90,9 +90,16 @@ module Solargraph
 
     # @param gemspec [Gem::Specification]
     def cache(gemspec, rebuild: false, out: nil)
-      out.puts("Caching pins for gem #{gemspec.name}:#{gemspec.version}") if out
-      cache_yard_pins(gemspec, out) if uncached_yard_gemspecs.include?(gemspec) || rebuild
-      cache_rbs_collection_pins(gemspec, out) if uncached_rbs_collection_gemspecs.include?(gemspec) || rebuild
+      build_yard = uncached_yard_gemspecs.include?(gemspec) || rebuild
+      build_rbs_collection = uncached_rbs_collection_gemspecs.include?(gemspec) || rebuild
+      if build_yard || build_rbs_collection
+        type = []
+        type << 'YARD' if build_yard
+        type << 'RBS collection' if build_rbs_collection
+        out.puts("Caching #{type.join(' and ')} pins for gem #{gemspec.name}:#{gemspec.version}") if out
+      end
+      cache_yard_pins(gemspec, out) if build_yard
+      cache_rbs_collection_pins(gemspec, out) if build_rbs_collection
     end
 
     # @return [Array<Gem::Specification>]
@@ -121,8 +128,12 @@ module Solargraph
       self.class.all_rbs_collection_gems_in_memory[rbs_collection_path] ||= {}
     end
 
-    def combined_pins_in_memory
+    def self.all_combined_pins_in_memory
       @combined_pins_in_memory ||= {}
+    end
+
+    def combined_pins_in_memory
+      self.class.all_combined_pins_in_memory
     end
 
     # @return [Set<Gem::Specification>]

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -587,7 +587,7 @@ module Solargraph
 
     # @return [void]
     def cache_next_gemspec
-      return if @cache_progres
+      return if @cache_progress
       spec = (api_map.uncached_yard_gemspecs + api_map.uncached_rbs_collection_gemspecs).
                find { |spec| !cache_errors.include?(spec) }
       return end_cache_progress unless spec

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -137,15 +137,18 @@ module Solargraph
     # @param names [Array<String>]
     # @return [void]
     def gems *names
+      api_map = ApiMap.load('.')
       if names.empty?
-        Gem::Specification.to_a.each { |spec| do_cache spec }
+        Gem::Specification.to_a.each { |spec| do_cache spec, api_map }
+        STDERR.puts "Documentation cached for all #{Gem::Specification.count} gems."
       else
         names.each do |name|
           spec = Gem::Specification.find_by_name(*name.split('='))
-          do_cache spec
+          do_cache spec, api_map
         rescue Gem::MissingSpecError
           warn "Gem '#{name}' not found"
         end
+        STDERR.puts "Documentation cached for #{names.count} gems."
       end
     end
 
@@ -256,8 +259,7 @@ module Solargraph
 
     # @param gemspec [Gem::Specification]
     # @return [void]
-    def do_cache gemspec
-      api_map = ApiMap.load('.')
+    def do_cache gemspec, api_map
       # @todo if the rebuild: option is passed as a positional arg,
       #   typecheck doesn't complain on the below line
       api_map.cache_gem(gemspec, rebuild: options.rebuild, out: $stdout)


### PR DESCRIPTION
* [regression] Only log when we are actually doing work caching pins
* [regression] Fix misspelled mutex-y variable name in gem caching - probably fixes #976
* [regression] Speed up 'solargraph gems' caching by only loading api_map once, avoiding extra loading of files from disk
* [regression] Use existing pattern to keep only one cache of combined pins in memory, instead of one per DocMap (~0.25s speed-up in solargraph project per docmap on my computer, ymmv)