### PR TITLE
Include Rakefile, Gemfile, and gemspec files in config by default

### DIFF
--- a/lib/solargraph/convention/gemspec.rb
+++ b/lib/solargraph/convention/gemspec.rb
@@ -12,7 +12,8 @@ module Solargraph
               'Gem::Specification.new',
               %(
 @yieldparam [self]
-              )
+              ),
+              source: :gemspec
             )
           ]
         )

--- a/lib/solargraph/workspace/config.rb
+++ b/lib/solargraph/workspace/config.rb
@@ -151,7 +151,7 @@ module Solargraph
       # @return [Hash{String => Array, Hash, Integer}]
       def default_config
         {
-          'include' => ['**/*.rb'],
+          'include' => ['Rakefile', 'Gemfile', '*.gemspec', '**/*.rb'],
           'exclude' => ['spec/**/*', 'test/**/*', 'vendor/**/*', '.bundle/**/*'],
           'require' => [],
           'domains' => [],


### PR DESCRIPTION
We package conventions for these, but unless the user remembers to configure them, they don't take advantage of Solargraph