### PR TITLE
Ignore directory paths in Workspace#would_require?

### DIFF
--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -106,7 +106,7 @@ module Solargraph
     def would_require? path
       require_paths.each do |rp|
         full = File.join rp, path
-        return true if File.exist?(full) or File.exist?(full << ".rb")
+        return true if File.file?(full) || File.file?(full << ".rb")
       end
       false
     end
@@ -223,7 +223,7 @@ module Solargraph
     def configured_require_paths
       return ['lib'] if directory.empty?
       return [File.join(directory, 'lib')] if config.require_paths.empty?
-      config.require_paths.map{|p| File.join(directory, p)}
+      config.require_paths.map { |p| File.join(directory, p) }
     end
 
     # @return [void]

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -117,6 +117,11 @@ describe Solargraph::Workspace do
     expect(workspace.would_require?('not_there')).to be(false)
   end
 
+  it 'would not require directory paths' do
+    FileUtils.mkdir_p(File.join(dir_path, 'lib', 'emptydir'))
+    expect(workspace.would_require?('emptydir')).to be(false)
+  end
+
   it "uses configured require paths" do
     workspace = Solargraph::Workspace.new('spec/fixtures/workspace')
     expect(workspace.require_paths).to eq(['spec/fixtures/workspace/lib', 'spec/fixtures/workspace/ext'])


### PR DESCRIPTION
Bench uses Workspace#would_require? to determine if a require path is local. Ensure that the #would_require? method ignores directory paths.