### PR TITLE
DocMap checks for default Gemfile

### DIFF
--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -355,7 +355,10 @@ module Solargraph
     end
 
     def gemspecs_required_from_bundler
-      if workspace&.directory && Bundler.definition&.lockfile&.to_s&.start_with?(workspace.directory)
+      # @todo Handle projects with custom Bundler/Gemfile setups
+      return unless workspace.gemfile?
+
+      if workspace.gemfile? && Bundler.definition&.lockfile&.to_s&.start_with?(workspace.directory)
         # Find only the gems bundler is now using
         Bundler.definition.locked_gems.specs.flat_map do |lazy_spec|
           logger.info "Handling #{lazy_spec.name}:#{lazy_spec.version}"
@@ -396,8 +399,7 @@ module Solargraph
             next specs
           end.compact
         else
-          Solargraph.logger.warn e
-          raise BundleNotFoundError, "Failed to load gems from bundle at #{workspace&.directory}"
+          Solargraph.logger.warn "Failed to load gems from bundle at #{workspace&.directory}: #{e}"
         end
       end
     end

--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -155,6 +155,14 @@ module Solargraph
       server['commandPath'] || 'solargraph'
     end
 
+    # True if the workspace has a root Gemfile.
+    #
+    # @todo Handle projects with custom Bundler/Gemfile setups (see DocMap#gemspecs_required_from_bundler)
+    #
+    def gemfile?
+      directory && File.file?(File.join(directory, 'Gemfile'))
+    end
+
     private
 
     # The language server configuration (or an empty hash if the workspace was


### PR DESCRIPTION
ref https://github.com/castwide/vscode-solargraph/issues/282

When `DocMap` checks for required bundle dependencies, it needs to check for the existence of a default Gemfile to avoid raising an error.