### PR TITLE
Improve struct support

### DIFF
--- a/lib/solargraph/convention/struct_definition.rb
+++ b/lib/solargraph/convention/struct_definition.rb
@@ -17,7 +17,7 @@ module Solargraph
               location: loc,
               closure: region.closure,
               name: struct_definition_node.class_name,
-              comments: comments_for(node),
+              docstring: docstring,
               visibility: :public,
               gates: region.closure.gates.freeze
             )
@@ -31,7 +31,7 @@ module Solargraph
               location: get_node_location(node),
               closure: nspin,
               visibility: :private,
-              comments: comments_for(node)
+              docstring: docstring
             )
 
             pins.push initialize_method_pin
@@ -50,23 +50,34 @@ module Solargraph
             # define attribute accessors and instance variables
             struct_definition_node.attributes.each do |attribute_node, attribute_name|
               [attribute_name, "#{attribute_name}="].each do |name|
+                docs = docstring.tags.find { |t| t.tag_name == 'param' && t.name == attribute_name }
+
                 method_pin = Pin::Method.new(
                   name: name,
                   parameters: [],
                   scope: :instance,
                   location: get_node_location(attribute_node),
                   closure: nspin,
-                  comments: attribute_comments(attribute_node, attribute_name),
+                  # even assignments return the value
+                  comments: attribute_comment(docs, false),
                   visibility: :public
                 )
 
-                pins.push method_pin
+                if name.end_with?('=')
+                  method_pin.parameters << Pin::Parameter.new(
+                    name: attribute_name,
+                    location: get_node_location(attribute_node),
+                    closure: nspin,
+                    comments: attribute_comment(docs, true)
+                  )
 
-                next unless name.include?('=') # setter
-                pins.push Pin::InstanceVariable.new(name: "@#{attribute_name}",
-                                                    closure: method_pin,
-                                                    location: get_node_location(attribute_node),
-                                                    comments: attribute_comments(attribute_node, attribute_name))
+                  pins.push Pin::InstanceVariable.new(name: "@#{attribute_name}",
+                                    closure: method_pin,
+                                    location: get_node_location(attribute_node),
+                                    comments: attribute_comment(docs, false))
+                end
+
+                pins.push method_pin
               end
             end
 
@@ -84,15 +95,42 @@ module Solargraph
                                         end
           end
 
-          # @param attribute_node [Parser::AST::Node]
-          # @return [String, nil]
-          def attribute_comments(attribute_node, attribute_name)
-            struct_comments = comments_for(attribute_node)
-            return if struct_comments.nil? || struct_comments.empty?
+          # Gets/generates the relevant docstring for this struct & it's attributes
+          # @return [YARD::Docstring]
+          def docstring
+            @docstring ||= parse_comments
+          end
 
-            struct_comments.split("\n").find do |row|
-              row.include?(attribute_name)
-            end&.gsub('@param', '@return')&.gsub(attribute_name, '')
+          # Parses any relevant comments for a struct int a yard docstring
+          # @return [YARD::Docstring]
+          def parse_comments
+            struct_comments = comments_for(node) || ''
+            struct_definition_node.attributes.each do |attr_node, attr_name|
+              comment = comments_for(attr_node)
+              next if comment.nil?
+
+              # We should support specific comments for an attribute, and that can be either a @return on an @param
+              # But since we merge into the struct_comments, then we should interpret either as a param
+              comment = '@param ' + attr_name + comment[7..] if comment.start_with?('@return')
+
+              struct_comments += "\n#{comment}"
+            end
+
+            Solargraph::Source.parse_docstring(struct_comments).to_docstring
+          end
+
+          # @param tag [YARD::Tags::Tag, nil] The param tag for this attribute. If nil, this method is a no-op
+          # @param for_setter [Boolean] If true, will return a @param tag instead of a @return tag
+          def attribute_comment(tag, for_setter)
+            return "" if tag.nil?
+
+            suffix = "[#{tag.types&.join(',') || 'undefined'}] #{tag.text}"
+
+            if for_setter
+              "@param #{tag.name} #{suffix}"
+            else
+              "@return #{suffix}"
+            end
           end
         end
       end

--- a/spec/convention/struct_definition_spec.rb
+++ b/spec/convention/struct_definition_spec.rb
@@ -1,0 +1,117 @@
+describe Solargraph::Convention::StructDefinition do
+  describe 'parsing docs' do
+    it 'should support keyword args' do
+      source = Solargraph::SourceMap.load_string(%(
+        # @param bar [String]
+        # @param baz [Integer]
+        Foo = Struct.new(:bar, :baz, keyword_init: true)
+      ), 'test.rb')
+
+      # @type [Array<Solargraph::Pin::Parameter>]
+      params = source.pins.find { |p| p.path == 'Foo#initialize' }.parameters
+
+      param_bar = params.find { |p| p.name == 'bar' }
+      expect(param_bar).not_to be_nil
+      expect(param_bar.keyword?).to be(true)
+      expect(param_bar.return_type.tag).to eql('String')
+
+      param_baz = params.find { |p| p.name == 'baz' }
+      expect(param_baz).not_to be_nil
+      expect(param_baz.keyword?).to be(true)
+      expect(param_baz.return_type.tag).to eql('Integer')
+    end
+
+    it 'should support positional args' do
+      source = Solargraph::SourceMap.load_string(%(
+        # @param bar [String]
+        # @param baz [Integer]
+        Foo = Struct.new(:bar, :baz)
+      ), 'test.rb')
+
+      # @type [Array<Solargraph::Pin::Parameter>]
+      params = source.pins.find { |p| p.path == 'Foo#initialize' }.parameters
+
+      expect(params.map(&:name)).to eql(%w[bar baz])
+      expect(params.map(&:arg?)).to eql([true, true])
+      expect(params.map(&:return_type).map(&:tag)).to eql(%w[String Integer])
+    end
+
+
+    it 'should support positional args if keyword_init: false' do
+      source = Solargraph::SourceMap.load_string(%(
+        # @param bar [String]
+        # @param baz [Integer]
+        Foo = Struct.new(:bar, :baz, keyword_init: false)
+      ), 'test.rb')
+
+      # @type [Array<Solargraph::Pin::Parameter>]
+      params = source.pins.find { |p| p.path == 'Foo#initialize' }.parameters
+
+      expect(params.map(&:name)).to eql(%w[bar baz])
+      expect(params.map(&:arg?)).to eql([true, true])
+      expect(params.map(&:return_type).map(&:tag)).to eql(%w[String Integer])
+    end
+
+    it 'should support comments on args' do
+      source = Solargraph::SourceMap.load_string(%(
+        Foo = Struct.new(
+          # @return [String]
+          :bar,
+          # @param baz [Integer] Some text (also with arg name: baz)
+          #   Extra indented text :3
+          :baz
+        )
+      ), 'test.rb')
+
+      # @type [Array<Solargraph::Pin::Parameter>]~
+      params = source.pins.find { |p| p.path == 'Foo#initialize' }.parameters
+
+      expect(params.map(&:name)).to eql(%w[bar baz])
+      expect(params.map(&:return_type).map(&:tag)).to eql(%w[String Integer])
+      expect(params[1].documentation).to eql("Some text (also with arg name: baz)\nExtra indented text :3")
+    end
+
+    it 'should merge struct level comments and attribute level comments' do
+      # Note on repetitions: Imo this should stay undefined
+      # So if there'd be a @return statement on the bar attribute, I'd not sweat it
+
+      source = Solargraph::SourceMap.load_string(%(
+        # @param baz [String] Some text
+        Foo = Struct.new(
+          # @return [Integer]
+          :bar,
+          :baz
+        )
+      ), 'test.rb')
+
+      # @type [Array<Solargraph::Pin::Parameter>]
+      params = source.pins.find { |p| p.path == 'Foo#initialize' }.parameters
+
+      expect(params.map(&:name)).to eql(%w[bar baz])
+      expect(params.map(&:return_type).map(&:tag)).to eql(%w[Integer String])
+      expect(params[1].documentation).to eql("Some text")
+    end
+
+    [true, false].each do |kw_args|
+      it "should properly support assignment with #{kw_args ? 'keyword' : 'positional'} arg mode" do
+        # Both positional & kwargs init mode should act the same for assignment
+
+        source = Solargraph::SourceMap.load_string(%(
+          # @param bar [String]
+          # @param baz [Integer]
+          Foo = Struct.new(:bar, :baz, keyword_init: #{kw_args})
+        ), 'test.rb')
+  
+        params_bar = source.pins.find { |p| p.path == "Foo#bar=" }.parameters
+        expect(params_bar.length).to eql(1)
+        expect(params_bar.first.return_type.tag).to eql("String")
+        expect(params_bar.first.arg?).to be(true)
+  
+        params_baz = source.pins.find { |p| p.path == "Foo#baz=" }.parameters
+        expect(params_baz.length).to eql(1)
+        expect(params_baz.first.return_type.tag).to eql("Integer")
+        expect(params_baz.first.arg?).to be(true)
+      end
+    end
+  end
+end


### PR DESCRIPTION
Please let me know if there are issues!

- Preserve multi-line descriptions of params
- If the param description has the attribute name in it, it used to get removed
- Better support for all the different variations in documenting the struct params - `@return` on the param line, `@param` on the struct line `@param` above the param line, etc
