### PR TITLE
[Bug fix] Fixed an error in rbs/fills/tuple.rbs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,6 @@ source 'https://rubygems.org'
 
 gemspec name: 'solargraph'
 
-gem 'rbs', '>= 3.9.4'
-
 # Local gemfile for development tools, etc.
 local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile

--- a/Gemfile
+++ b/Gemfile
@@ -2,6 +2,8 @@ source 'https://rubygems.org'
 
 gemspec name: 'solargraph'
 
+gem 'rbs', '>= 3.9.4'
+
 # Local gemfile for development tools, etc.
 local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ostruct', '~> 0.6'
   s.add_runtime_dependency 'parser', '~> 3.0'
   s.add_runtime_dependency 'prism', '~> 1.4'
-  s.add_runtime_dependency 'rbs', '~> 3.3'
+  s.add_runtime_dependency 'rbs', '~> 3.9'
   s.add_runtime_dependency 'reverse_markdown', '~> 3.0'
   s.add_runtime_dependency 'rubocop', '~> 1.38'
   s.add_runtime_dependency 'thor', '~> 1.0'

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ostruct', '~> 0.6'
   s.add_runtime_dependency 'parser', '~> 3.0'
   s.add_runtime_dependency 'prism', '~> 1.4'
-  s.add_runtime_dependency 'rbs', '~> 3.9'
+  s.add_runtime_dependency 'rbs', '~> 3.6.1'
   s.add_runtime_dependency 'reverse_markdown', '~> 3.0'
   s.add_runtime_dependency 'rubocop', '~> 1.38'
   s.add_runtime_dependency 'thor', '~> 1.0'


### PR DESCRIPTION
When using Solargraph version 0.55.4 or later with vscode on Windows, I get the following error:

![error](https://github.com/user-attachments/assets/64e5829e-1f72-43e6-a56a-498e0b42e8a9)

If this error occurs, various functions of solargraph will not work.

The cause of the error is that when the rbs gem is a relatively old version (for example, 3.4.0), an error occurs in the syntax of `rbs/fills/tuple.rbs`.

To avoid this, we have made it mandatory to also install the rbs gem of version 3.6.1 or higher when installing the solargraph gem.

The value 3.6.1 is the version in which the error no longer occurred in my environment.