### PR TITLE
Allow newer RBS gem versions

### DIFF
--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ostruct', '~> 0.6'
   s.add_runtime_dependency 'parser', '~> 3.0'
   s.add_runtime_dependency 'prism', '~> 1.4'
-  s.add_runtime_dependency 'rbs', '~> 3.3'
+  s.add_runtime_dependency 'rbs', ['>= 3.3', '<= 4.0.0.dev.4']
   s.add_runtime_dependency 'reverse_markdown', '~> 3.0'
   s.add_runtime_dependency 'rubocop', '~> 1.38'
   s.add_runtime_dependency 'thor', '~> 1.0'


### PR DESCRIPTION
This allow users to upgrade to recent Tapioca versions.

Tapioca now requires newish versions of the spoom gem, which depends on 4.x pre-releases of the rbs gem.