### PR TITLE
Combine global pins from plugins

### DIFF
--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -53,7 +53,6 @@ module Solargraph
       @rbs_collection_config_path = workspace&.rbs_collection_config_path
       @environ = Convention.for_global(self)
       load_serialized_gem_pins
-      pins.concat @environ.pins
     end
 
     def cache_all!(out)
@@ -163,6 +162,10 @@ module Solargraph
           pins = deserialize_combined_pin_cache gemspec
           @pins.concat pins if pins
         end
+      end
+      environ_pins = @environ.pins
+      unless environ_pins.empty?
+        @pins = GemPins.combine_method_pins_by_path(@pins + environ_pins)
       end
       logger.info { "DocMap#load_serialized_gem_pins: Loaded and processed serialized pins together in #{time.real} seconds" }
       @uncached_yard_gemspecs.uniq!

--- a/lib/solargraph/gem_pins.rb
+++ b/lib/solargraph/gem_pins.rb
@@ -21,7 +21,6 @@ module Solargraph
 
     # @param pins [Array<Pin::Base>]
     def self.combine_method_pins_by_path(pins)
-      # bad_pins = pins.select { |pin| pin.is_a?(Pin::Method) && pin.path == 'StringIO.open' && pin.source == :rbs }; raise "wtf: #{bad_pins}" if bad_pins.length > 1
       method_pins, alias_pins = pins.partition { |pin| pin.class == Pin::Method }
       by_path = method_pins.group_by(&:path)
       by_path.transform_values! do |pins|
@@ -33,7 +32,7 @@ module Solargraph
     def self.combine_method_pins(*pins)
       out = pins.reduce(nil) do |memo, pin|
         next pin if memo.nil?
-        if memo == pin && memo.source != :combined
+        if memo == pin && memo.source != :combined && memo.source == pin.source
           # @todo we should track down situations where we are handled
           #   the same pin from the same source here and eliminate them -
           #   this is an efficiency workaround for now

--- a/spec/doc_map_spec.rb
+++ b/spec/doc_map_spec.rb
@@ -74,7 +74,7 @@ describe Solargraph::DocMap do
       # we know this is included in our bundle
       doc_map = Solargraph::DocMap.new([], [])
 
-      expect(doc_map.pins).to include(new_pin)
+      expect(doc_map.pins).to include(environ_pin)
     end
 
     let(:cache_pin) { Solargraph::Pin::Method.new(name: 'my_method', source: :cache) }


### PR DESCRIPTION
Plugin pins aren't always respected - they don't get run through GemPins for combination, leading to the pin pulled not necessarily being from the plugin if there is a pin from another source.