### PR TITLE
Eager load node processors

### DIFF
--- a/lib/solargraph.rb
+++ b/lib/solargraph.rb
@@ -97,3 +97,5 @@ module Solargraph
     Bundler.send meth, &block
   end
 end
+
+require 'solargraph/parser/parser_gem/node_processors'


### PR DESCRIPTION
As noted in #970, there's a circular dependency between `Convention` and `Parser` that can cause errors in constant initialization. Specifically, it appears to be a conflict while lazy-loading and registering node processors. The quick workaround is to eager-load the node processors after defining the root `Solargraph` module.