### PR TITLE
Fix kwarg generation in ApiMap::SourceToYard

### DIFF
--- a/lib/solargraph/api_map/source_to_yard.rb
+++ b/lib/solargraph/api_map/source_to_yard.rb
@@ -67,7 +67,7 @@ module Solargraph
           method_object.docstring = pin.docstring
           method_object.visibility = pin.visibility || :public
           method_object.parameters = pin.parameters.map do |p|
-            [p.name, p.asgn_code]
+            [p.full_name, p.asgn_code]
           end
         end
       end

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -105,15 +105,11 @@ module Solargraph
         end
       end
 
-      # @return [String]
-      def full
+      def full_name
         case decl
-        when :optarg
-          "#{name} = #{asgn_code || '?'}"
-        when :kwarg
+        when :kwarg, :kwoptarg
           "#{name}:"
-        when :kwoptarg
-          "#{name}: #{asgn_code || '?'}"
+          "#{name}:"
         when :restarg
           "*#{name}"
         when :kwrestarg
@@ -123,6 +119,18 @@ module Solargraph
         else
           name
         end
+      end
+
+      # @return [String]
+      def full
+        full_name + case decl
+                    when :optarg
+                      "= #{asgn_code || '?'}"
+                    when :kwoptarg
+                      " #{asgn_code || '?'}"
+                    else
+                      ''
+                    end
       end
 
       # @return [ComplexType]

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -105,10 +105,12 @@ module Solargraph
         end
       end
 
+      # @return [String] the full name of the parameter, including any
+      #   declarative symbols such as `*` or `:` indicating type of
+      #   parameter. This is used in method signatures.
       def full_name
         case decl
         when :kwarg, :kwoptarg
-          "#{name}:"
           "#{name}:"
         when :restarg
           "*#{name}"

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -125,7 +125,7 @@ module Solargraph
       def full
         full_name + case decl
                     when :optarg
-                      "= #{asgn_code || '?'}"
+                      " = #{asgn_code || '?'}"
                     when :kwoptarg
                       " #{asgn_code || '?'}"
                     else

--- a/spec/api_map/source_to_yard_spec.rb
+++ b/spec/api_map/source_to_yard_spec.rb
@@ -108,5 +108,4 @@ describe Solargraph::ApiMap::SourceToYard do
     expect(method_object.parameters[0]).to eq(['baz', nil])
     expect(method_object.parameters[1]).to eq(['boo:', "'boo'"])
   end
-
 end

--- a/spec/api_map/source_to_yard_spec.rb
+++ b/spec/api_map/source_to_yard_spec.rb
@@ -92,4 +92,21 @@ describe Solargraph::ApiMap::SourceToYard do
     expect(method_object.parameters[0]).to eq(['baz', nil])
     expect(method_object.parameters[1]).to eq(['boo', "'boo'"])
   end
+
+  it "generates method keyword parameters" do
+    source = Solargraph::SourceMap.load_string(%(
+      class Foo
+        def bar baz, boo: 'boo'
+        end
+      end
+    ))
+    object = Object.new
+    object.extend Solargraph::ApiMap::SourceToYard
+    object.rake_yard Solargraph::ApiMap::Store.new(source.pins)
+    method_object = object.code_object_at('Foo#bar')
+    expect(method_object.parameters.length).to eq(2)
+    expect(method_object.parameters[0]).to eq(['baz', nil])
+    expect(method_object.parameters[1]).to eq(['boo:', "'boo'"])
+  end
+
 end


### PR DESCRIPTION
kwargs are currently generated as regular args in SourceToYard, which results in inaccurate RBS from sord, e.g. in the proposed 'solargraph rbs' command