### PR TITLE
Avoid overlapping chdir calls in multiple threads

### DIFF
--- a/lib/solargraph.rb
+++ b/lib/solargraph.rb
@@ -53,6 +53,8 @@ module Solargraph
   dir = File.dirname(__FILE__)
   VIEWS_PATH = File.join(dir, 'solargraph', 'views')
 
+  CHDIR_MUTEX = Mutex.new
+
   # @param type [Symbol] Type of assert.
   def self.asserts_on?(type)
     if ENV['SOLARGRAPH_ASSERTS'].nil? || ENV['SOLARGRAPH_ASSERTS'].empty?

--- a/lib/solargraph/language_server/message/text_document/formatting.rb
+++ b/lib/solargraph/language_server/message/text_document/formatting.rb
@@ -23,8 +23,7 @@ module Solargraph
             # Ensure only one instance of RuboCop::Runner is running at
             # a time - it uses 'chdir' to read config files with ERB,
             # which can conflict with other chdirs.
-            @@rubocop_mutex ||= Mutex.new
-            corrections = @@rubocop_mutex.synchronize do
+            corrections = Solargraph::CHDIR_MUTEX.synchronize do
               redirect_stdout do
                 ::RuboCop::Runner.new(options, ::RuboCop::ConfigStore.new).run(paths)
               end


### PR DESCRIPTION
I've been hitting flaky tests like this:

```
  1) Protocol can format file without file extension
     Failure/Error: expect(response['error']).to be_nil

       expected: nil
            got: {"code"=>-32603, "message"=>"[RuntimeError] conflicting chdir during another chdir block"}
     # ./spec/language_server/protocol_spec.rb:472:in `block (2 levels) in <top (required)>'
```

I monkeypatched Dir.chdir and found out that RuboCop is using chdir (which affects the whole process) in order to read config files.

We should probably consider forking before calling into RuboCop; just because two RuboCop chdirs don't overlap doesn't mean that having an unexpected cwd is safe for other code.