### PR TITLE
Plugin Util: Add Combination Priority

### DIFF
--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -76,6 +76,9 @@ module Solargraph
       end
 
       def combine_with(other, attrs = {})
+        priority_choice = choose_priority(other)
+        return priority_choice unless priority_choice.nil?
+
         sigs = combine_signatures(other)
         parameters = if sigs.length > 0
           [].freeze


### PR DESCRIPTION
While working on adding factory bot support into the rspec plugin, I noticed that I couldn't override existing documentation within factory bot itself. There is the override ref pin, but that doesn't quite let you override an entire method. This would allow it to

This is backwards compatible & only affects plugins, as I cannot see why this would be useful from a writing code/docs perspective 