### PR TITLE
Improve typechecking error message

### DIFF
--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -272,7 +272,11 @@ module Solargraph
           # @todo remove the internal_or_core? check at a higher-than-strict level
           if !found || found.is_a?(Pin::BaseVariable) || (closest.defined? && internal_or_core?(found))
             unless closest.generic? || ignored_pins.include?(found)
-              result.push Problem.new(location, "Unresolved call to #{missing.links.last.word}")
+              if closest.defined?
+                result.push Problem.new(location, "Unresolved call to #{missing.links.last.word} on #{closest}")
+              else
+                result.push Problem.new(location, "Unresolved call to #{missing.links.last.word}")
+              end
               @marked_ranges.push rng
             end
           end

--- a/spec/type_checker/levels/strict_spec.rb
+++ b/spec/type_checker/levels/strict_spec.rb
@@ -40,6 +40,7 @@ describe Solargraph::TypeChecker do
       ))
       expect(checker.problems).to be_one
       expect(checker.problems.first.message).to include('Unresolved call')
+      expect(checker.problems.first.message).not_to include('undefined')
     end
 
     it 'reports undefined method calls with defined roots' do
@@ -48,6 +49,7 @@ describe Solargraph::TypeChecker do
       ))
       expect(checker.problems).to be_one
       expect(checker.problems.first.message).to include('Unresolved call')
+      expect(checker.problems.first.message).to include('String')
       expect(checker.problems.first.message).to include('not_a_method')
     end
 


### PR DESCRIPTION
If we know the target of an unresolved method call, include it in the error message.