### PR TITLE
Look for external requires before cataloging bench

### DIFF
--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -677,8 +677,8 @@ module Solargraph
 
       mutex.synchronize do
         logger.info "Cataloging #{workspace.directory.empty? ? 'generic workspace' : workspace.directory}"
-        api_map.catalog bench
         source_map_hash.values.each { |map| find_external_requires(map) }
+        api_map.catalog bench
         logger.info "Catalog complete (#{api_map.source_maps.length} files, #{api_map.pins.length} pins)"
         logger.info "#{api_map.uncached_yard_gemspecs.length} uncached YARD gemspecs"
         logger.info "#{api_map.uncached_rbs_collection_gemspecs.length} uncached RBS collection gemspecs"

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -26,6 +26,22 @@ describe Solargraph::Library do
     expect(completion.pins.map(&:name)).to include('x')
   end
 
+  it "returns a Completion from a gem" do
+    library = Solargraph::Library.new(Solargraph::Workspace.new(Dir.pwd,
+                                                                Solargraph::Workspace::Config.new))
+    library.attach Solargraph::Source.load_string(%(
+      require 'backport'
+
+      # @param adapter [Backport::Adapter]
+      def foo(adapter)
+        adapter.remo
+      end
+    ), 'file.rb', 0)
+    completion = library.completions_at('file.rb', 5, 19)
+    expect(completion).to be_a(Solargraph::SourceMap::Completion)
+    expect(completion.pins.map(&:name)).to include('remote')
+  end
+
   it "gets definitions from a file" do
     library = Solargraph::Library.new
     src = Solargraph::Source.load_string %(


### PR DESCRIPTION
It seems like sync_catalog will go through the motions but not actually load pins from gems here due to passing an empty requires array to ApiMap.

I'm sure those requires get pulled in eventually, but we go through at least one catalog cycle without it happening.

Found while trying to test a different issue but not being able to get completions from a gem in a spec.