### PR TITLE
Define closure for Pin::Symbol, for completeness

### DIFF
--- a/lib/solargraph/pin/symbol.rb
+++ b/lib/solargraph/pin/symbol.rb
@@ -20,6 +20,10 @@ module Solargraph
         ''
       end
 
+      def closure
+        @closure ||= Pin::ROOT_PIN
+      end
+
       def completion_item_kind
         Solargraph::LanguageServer::CompletionItemKinds::KEYWORD
       end

--- a/spec/pin/symbol_spec.rb
+++ b/spec/pin/symbol_spec.rb
@@ -1,8 +1,13 @@
 describe Solargraph::Pin::Symbol do
   context "as an unquoted literal" do
-    it "is a kind of keyword" do
+    it "is a kind of keyword to the LSP" do
       pin = Solargraph::Pin::Symbol.new(nil, ':symbol')
       expect(pin.completion_item_kind).to eq(Solargraph::LanguageServer::CompletionItemKinds::KEYWORD)
+    end
+
+    it "has global closure" do
+      pin = Solargraph::Pin::Symbol.new(nil, ':symbol')
+      expect(pin.closure).to eq(Solargraph::Pin::ROOT_PIN)
     end
 
     it "has a Symbol return type" do


### PR DESCRIPTION
This isn't used anywhere to my knowledge, but it makes sense to think of symbols as being in the global namespace, helps guarantee that closure is always available on a pin, and of course keeps the assert happy ;)