### PR TITLE
Fix Convention/Plugin pins not being updated on file change

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -102,7 +102,7 @@ module Solargraph
         @doc_map = DocMap.new(unresolved_requires, [], bench.workspace) # @todo Implement gem preferences
         @unresolved_requires = @doc_map.unresolved_requires
       end
-      @cache.clear if store.update(@@core_map.pins, @doc_map.pins, implicit.pins, iced_pins, live_pins)
+      @cache.clear if store.update(@@core_map.pins, @doc_map.pins, implicit.pins.dup, iced_pins, live_pins)
       @missing_docs = [] # @todo Implement missing docs
       self
     end

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -74,10 +74,11 @@ module Solargraph
     # Map a single source.
     #
     # @param source [Source]
+    # @param live [Boolean] True for live source map (active editor file)
     # @return [self]
-    def map source
+    def map source, live: false
       map = Solargraph::SourceMap.map(source)
-      catalog Bench.new(source_maps: [map])
+      catalog Bench.new(source_maps: [map], live_map: live ? map : nil)
       self
     end
 
@@ -88,7 +89,7 @@ module Solargraph
     def catalog bench
       @source_map_hash = bench.source_map_hash
       iced_pins = bench.icebox.flat_map(&:pins)
-      live_pins = bench.live_map&.pins || []
+      live_pins = bench.live_map&.all_pins || []
       conventions_environ.clear
       source_map_hash.each_value do |map|
         conventions_environ.merge map.conventions_environ
@@ -102,7 +103,7 @@ module Solargraph
         @doc_map = DocMap.new(unresolved_requires, [], bench.workspace) # @todo Implement gem preferences
         @unresolved_requires = @doc_map.unresolved_requires
       end
-      @cache.clear if store.update(@@core_map.pins, @doc_map.pins, conventions_environ.pins.dup, iced_pins, live_pins)
+      @cache.clear if store.update(@@core_map.pins, @doc_map.pins, conventions_environ.pins, iced_pins, live_pins)
       @missing_docs = [] # @todo Implement missing docs
       self
     end

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -65,7 +65,7 @@ module Solargraph
       # @todo This implementation is incomplete. It should probably create a
       #   Bench.
       @source_map_hash = {}
-      implicit.clear
+      conventions_environ.clear
       cache.clear
       store.update @@core_map.pins, pins
       self
@@ -89,11 +89,11 @@ module Solargraph
       @source_map_hash = bench.source_map_hash
       iced_pins = bench.icebox.flat_map(&:pins)
       live_pins = bench.live_map&.pins || []
-      implicit.clear
+      conventions_environ.clear
       source_map_hash.each_value do |map|
-        implicit.merge map.environ
+        conventions_environ.merge map.conventions_environ
       end
-      unresolved_requires = (bench.external_requires + implicit.requires + bench.workspace.config.required).to_a.compact.uniq
+      unresolved_requires = (bench.external_requires + conventions_environ.requires + bench.workspace.config.required).to_a.compact.uniq
       recreate_docmap = @unresolved_requires != unresolved_requires ||
                      @doc_map&.uncached_yard_gemspecs&.any? ||
                      @doc_map&.uncached_rbs_collection_gemspecs&.any? ||
@@ -102,7 +102,7 @@ module Solargraph
         @doc_map = DocMap.new(unresolved_requires, [], bench.workspace) # @todo Implement gem preferences
         @unresolved_requires = @doc_map.unresolved_requires
       end
-      @cache.clear if store.update(@@core_map.pins, @doc_map.pins, implicit.pins.dup, iced_pins, live_pins)
+      @cache.clear if store.update(@@core_map.pins, @doc_map.pins, conventions_environ.pins.dup, iced_pins, live_pins)
       @missing_docs = [] # @todo Implement missing docs
       self
     end
@@ -111,7 +111,7 @@ module Solargraph
     #   that this overload of 'protected' will typecheck @sg-ignore
     # @sg-ignore
     protected def equality_fields
-      [self.class, @source_map_hash, implicit, @doc_map, @unresolved_requires]
+      [self.class, @source_map_hash, conventions_environ, @doc_map, @unresolved_requires]
     end
 
     # @return [DocMap]
@@ -151,8 +151,8 @@ module Solargraph
     end
 
     # @return [Environ]
-    def implicit
-      @implicit ||= Environ.new
+    def conventions_environ
+      @conventions_environ ||= Environ.new
     end
 
     # @param filename [String]
@@ -421,7 +421,7 @@ module Solargraph
       skip = Set.new
       if rooted_tag == ''
         # @todo Implement domains
-        implicit.domains.each do |domain|
+        conventions_environ.domains.each do |domain|
           type = ComplexType.try_parse(domain)
           next if type.undefined?
           result.concat inner_get_methods(type.name, type.scope, visibility, deep, skip)

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -18,6 +18,11 @@ module Solargraph
       end
 
       # @param pinsets [Array<Enumerable<Pin::Base>>]
+      #   - pinsets[0] = core Ruby pins
+      #   - pinsets[1] = documentation/gem pins
+      #   - pinsets[2] = convention pins
+      #   - pinsets[3] = workspace source pins
+      #   - pinsets[4] = currently open file pins
       # @return [Boolean] True if the index was updated
       def update *pinsets
         return catalog(pinsets) if pinsets.length != @pinsets.length

--- a/lib/solargraph/convention.rb
+++ b/lib/solargraph/convention.rb
@@ -23,6 +23,7 @@ module Solargraph
     end
 
     # @param convention [Class<Convention::Base>]
+    # @return [void]
     def self.unregister convention
       @@conventions.delete_if { |c| c.is_a?(convention) }
     end

--- a/lib/solargraph/convention.rb
+++ b/lib/solargraph/convention.rb
@@ -23,9 +23,8 @@ module Solargraph
     end
 
     # @param convention [Class<Convention::Base>]
-    # @return [void]
-    def self.deregister convention
-      @@conventions.delete_if { |c| c.instance_of? convention }
+    def self.unregister convention
+      @@conventions.delete_if { |c| c.is_a?(convention) }
     end
 
     # @param source_map [SourceMap]

--- a/lib/solargraph/source_map.rb
+++ b/lib/solargraph/source_map.rb
@@ -30,9 +30,12 @@ module Solargraph
     def initialize source
       @source = source
 
-      environ.merge Convention.for_local(self) unless filename.nil?
-      self.convention_pins = environ.pins
-      # @type [Hash{Class<generic<T>> => Array<generic<T>>}]
+      conventions_environ.merge Convention.for_local(self) unless filename.nil?
+      # FIXME: unmemoizing the document_symbols in case it was called and memoized from any of conventions above
+      # this is to ensure that the convention_pins from all conventions are used in the document_symbols.
+      # solargraph-rails is known to use this method to get the document symbols. It should probably be removed.
+      @document_symbols = nil
+      self.convention_pins = conventions_environ.pins
       @pin_select_cache = {}
     end
 
@@ -69,8 +72,8 @@ module Solargraph
     end
 
     # @return [Environ]
-    def environ
-      @environ ||= Environ.new
+    def conventions_environ
+      @conventions_environ ||= Environ.new
     end
 
     # all pins except Solargraph::Pin::Reference::Reference
@@ -178,8 +181,6 @@ module Solargraph
     # @param pins [Array<Pin::Base>]
     # @return [Array<Pin::Base>]
     def convention_pins=(pins)
-      # unmemoizing the document_symbols in case it was called from any of conventions
-      @document_symbols = nil
       @convention_pins = pins
     end
 

--- a/lib/solargraph/source_map.rb
+++ b/lib/solargraph/source_map.rb
@@ -21,6 +21,11 @@ module Solargraph
       data.pins
     end
 
+    # @return [Array<Pin::Base>]
+    def all_pins
+      pins + convention_pins
+    end
+
     # @return [Array<Pin::LocalVariable>]
     def locals
       data.locals

--- a/lib/solargraph/source_map.rb
+++ b/lib/solargraph/source_map.rb
@@ -169,6 +169,9 @@ module Solargraph
     private
 
     # @return [Hash{Class => Array<Pin::Base>}]
+    # @return [Array<Pin::Base>]
+    attr_writer :convention_pins
+
     def pin_class_hash
       @pin_class_hash ||= pins.to_set.classify(&:class).transform_values(&:to_a)
     end
@@ -181,12 +184,6 @@ module Solargraph
     # @return [Array<Pin::Base>]
     def convention_pins
       @convention_pins || []
-    end
-
-    # @param pins [Array<Pin::Base>]
-    # @return [Array<Pin::Base>]
-    def convention_pins=(pins)
-      @convention_pins = pins
     end
 
     # @param line [Integer]

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -791,7 +791,9 @@ describe Solargraph::ApiMap do
 
   it 'ignores malformed mixins' do
     closure = Solargraph::Pin::Namespace.new(name: 'Foo', closure: Solargraph::Pin::ROOT_PIN, type: :class)
-    mixin = Solargraph::Pin::Reference::Include.new(name: 'defined?(DidYouMean::SpellChecker) && defined?(DidYouMean::Correctable)', closure: closure)
+    mixin = Solargraph::Pin::Reference::Include.new(
+      name: 'defined?(DidYouMean::SpellChecker) && defined?(DidYouMean::Correctable)', closure: closure
+    )
     api_map = Solargraph::ApiMap.new(pins: [closure, mixin])
     expect(api_map.get_method_stack('Foo', 'foo')).to be_empty
   end

--- a/spec/convention_spec.rb
+++ b/spec/convention_spec.rb
@@ -89,8 +89,8 @@ describe Solargraph::Convention do
 
     # Update the source
     updated_source = source.synchronize(updater)
-    # Re-map the updated source to refresh the API map - this tests the fix from 4d091c5c
-    api_map.map(updated_source)
+    # Re-map the updated live source to refresh the API map - this tests the fix from 4d091c5c
+    api_map.map(updated_source, live: true)
 
     # Now check that both methods are available
     pins = api_map.get_path_pins('MyModel#existing_field')

--- a/spec/convention_spec.rb
+++ b/spec/convention_spec.rb
@@ -1,4 +1,5 @@
 describe Solargraph::Convention do
+  # rubocop:disable RSpec/ExampleLength, RSpec/MultipleExpectations
   it 'newly defined pins are resolved by ApiMap after file changes' do
     filename = 'test.rb'
 
@@ -11,7 +12,7 @@ describe Solargraph::Convention do
 
     # Create a dummy convention that statically provides one method
     dummy_convention = Class.new(Solargraph::Convention::Base) do
-      def local(_source_map)
+      def local _source_map
         Solargraph::Environ.new(
           pins: [
             Solargraph::Pin::Method.new(
@@ -26,7 +27,7 @@ describe Solargraph::Convention do
       end
     end
 
-    Solargraph::Convention.register dummy_convention
+    described_class.register dummy_convention
 
     source = Solargraph::Source.load_string(initial_code, filename)
     api_map = Solargraph::ApiMap.new
@@ -47,10 +48,10 @@ describe Solargraph::Convention do
     RUBY
 
     # Unregister the old convention and register a new one with two methods
-    Solargraph::Convention.unregister dummy_convention
+    described_class.unregister dummy_convention
 
     updated_dummy_convention = Class.new(Solargraph::Convention::Base) do
-      def local(_source_map)
+      def local _source_map
         Solargraph::Environ.new(
           pins: [
             Solargraph::Pin::Method.new(
@@ -72,7 +73,7 @@ describe Solargraph::Convention do
       end
     end
 
-    Solargraph::Convention.register updated_dummy_convention
+    described_class.register updated_dummy_convention
 
     # Create an updater that represents the file being saved with new content
     updater = Solargraph::Source::Updater.new(
@@ -103,6 +104,7 @@ describe Solargraph::Convention do
     expect(method_pin).not_to be_nil
     expect(method_pin.name).to eq('newly_defined_field')
 
-    Solargraph::Convention.unregister updated_dummy_convention
+    described_class.unregister updated_dummy_convention
   end
+  # rubocop:enable RSpec/ExampleLength, RSpec/MultipleExpectations
 end

--- a/spec/convention_spec.rb
+++ b/spec/convention_spec.rb
@@ -1,3 +1,108 @@
 describe Solargraph::Convention do
-  
+  it 'newly defined pins are resolved by ApiMap after file changes' do
+    filename = 'test.rb'
+
+    # Initial code with one DSL call
+    initial_code = <<~RUBY
+      class MyModel
+        dummy_dsl :existing_field
+      end
+    RUBY
+
+    # Create a dummy convention that statically provides one method
+    dummy_convention = Class.new(Solargraph::Convention::Base) do
+      def local(_source_map)
+        Solargraph::Environ.new(
+          pins: [
+            Solargraph::Pin::Method.new(
+              name: 'existing_field',
+              closure: Solargraph::Pin::Namespace.new(name: 'MyModel'),
+              scope: :instance,
+              location: Solargraph::Location.new('test.rb', Solargraph::Range.from_to(1, 2, 1, 27)),
+              return_type: Solargraph::ComplexType.parse('String')
+            )
+          ]
+        )
+      end
+    end
+
+    Solargraph::Convention.register dummy_convention
+
+    source = Solargraph::Source.load_string(initial_code, filename)
+    api_map = Solargraph::ApiMap.new
+    api_map.map(source)
+
+    # Verify that the existing method works
+    pins = api_map.get_path_pins('MyModel#existing_field')
+    method_pin = pins.first
+    expect(method_pin).not_to be_nil
+    expect(method_pin.name).to eq('existing_field')
+
+    # Now simulate adding a new DSL call by updating the source
+    updated_code = <<~RUBY
+      class MyModel
+        dummy_dsl :existing_field
+        dummy_dsl :newly_defined_field
+      end
+    RUBY
+
+    # Unregister the old convention and register a new one with two methods
+    Solargraph::Convention.unregister dummy_convention
+
+    updated_dummy_convention = Class.new(Solargraph::Convention::Base) do
+      def local(_source_map)
+        Solargraph::Environ.new(
+          pins: [
+            Solargraph::Pin::Method.new(
+              name: 'existing_field',
+              closure: Solargraph::Pin::Namespace.new(name: 'MyModel'),
+              scope: :instance,
+              location: Solargraph::Location.new('test.rb', Solargraph::Range.from_to(1, 2, 1, 27)),
+              return_type: Solargraph::ComplexType.parse('String')
+            ),
+            Solargraph::Pin::Method.new(
+              name: 'newly_defined_field',
+              closure: Solargraph::Pin::Namespace.new(name: 'MyModel'),
+              scope: :instance,
+              location: Solargraph::Location.new('test.rb', Solargraph::Range.from_to(2, 2, 2, 31)),
+              return_type: Solargraph::ComplexType.parse('String')
+            )
+          ]
+        )
+      end
+    end
+
+    Solargraph::Convention.register updated_dummy_convention
+
+    # Create an updater that represents the file being saved with new content
+    updater = Solargraph::Source::Updater.new(
+      filename,
+      2, # version
+      [
+        # Replace the entire content
+        Solargraph::Source::Change.new(
+          Solargraph::Range.from_to(0, 0, source.code.lines.length - 1, source.code.lines.last.length),
+          updated_code
+        )
+      ]
+    )
+
+    # Update the source
+    updated_source = source.synchronize(updater)
+    # Re-map the updated source to refresh the API map - this tests the fix from 4d091c5c
+    api_map.map(updated_source)
+
+    # Now check that both methods are available
+    pins = api_map.get_path_pins('MyModel#existing_field')
+    method_pin = pins.first
+    expect(method_pin).not_to be_nil
+    expect(method_pin.name).to eq('existing_field')
+
+    pins = api_map.get_path_pins('MyModel#newly_defined_field')
+    method_pin = pins.first
+    expect(method_pin).not_to be_nil
+    expect(method_pin.name).to eq('newly_defined_field')
+
+    Solargraph::Convention.unregister updated_dummy_convention
+  end
 end

--- a/spec/doc_map_spec.rb
+++ b/spec/doc_map_spec.rb
@@ -75,6 +75,6 @@ describe Solargraph::DocMap do
     expect(doc_map.requires).to include('original_gem', 'convention_gem1', 'convention_gem2')
 
     # Clean up the registered convention
-    Solargraph::Convention.deregister dummy_convention
+    Solargraph::Convention.unregister dummy_convention
   end
 end

--- a/spec/source_map_spec.rb
+++ b/spec/source_map_spec.rb
@@ -62,7 +62,7 @@ describe Solargraph::SourceMap do
 
     expect(map.document_symbols.map(&:path)).to include('FooBar#baz_convention')
 
-    Solargraph::Convention.deregister dummy_convention
+    Solargraph::Convention.unregister dummy_convention
   end
 
   it "locates block pins" do


### PR DESCRIPTION
 This PR fixes an issue where [RSpec plugin](https://github.com/lekemula/solargraph-rspec) (or any plugin for that matter) pins weren't being updated after file saves/changes due to a subtle reference sharing bug in index store.

### Problem:
  ~~The implicit.pins array was being shared between `ApiMap` and `Index` objects. Since `implicit` environ (now named `conventions_environ`) is memoized, when `Store#update(*pinsets)` compared pin sets to detect changes, were using the same `implicit.pins` array, thus changes were not detected, since those arrays are always identical:~~
  https://github.com/castwide/solargraph/blob/2bf80f04f53f40a5e818640c0e95eb6e7fe7fc50/lib/solargraph/api_map/store.rb#L29

UPDATE: The above is true; however, solving it by updating all convention pins every time we change turned out to be a bad idea in terms of performance time (obviously).

### Solution:
  
~~Added .dup to ensure each object gets its own copy of the pins array, allowing the change detection to work correctly.~~

~~I have to give credit to @claude, coz this was taking me forever to figure out why the two arrays were always the same! 🤯~~

Include the convention pins in `live_pins` when updating the store.

PS. I hope you don't mind the `implicit` to `conventions` rename. That was adding cognitive load to reason about those pins, and I hope this makes it more explicit that these are pins related to plugins/conventions.

### Testing:
  - [RSpec plugin](https://github.com/lekemula/solargraph-rspec) pins (ie. spec file changes) now properly update after file modifications
  - No regression in existing functionality
