### PR TITLE
Remove yard reference from gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,6 @@ source 'https://rubygems.org'
 
 gemspec name: 'solargraph'
 
-# allow rubocop-yard to understand literal symbols in type annotations
-gem 'yard', github: 'apiology/yard', branch: 'literal_symbols', require: false
-
 # Local gemfile for development tools, etc.
 local_gemfile = File.expand_path(".Gemfile", __dir__)
 instance_eval File.read local_gemfile if File.exist? local_gemfile


### PR DESCRIPTION
@apiology If you need to use your fork of the yard gem for development, you can create a `.Gemfile` (note the dot) in the project root. Bundler will load it and Git will ignore it.