### PR TITLE
Speed-up LSP completion response times

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -77,7 +77,6 @@ Layout/ClosingHeredocIndentation:
 # Configuration parameters: AllowForAlignment.
 Layout/CommentIndentation:
   Exclude:
-    - 'lib/solargraph/api_map.rb'
     - 'lib/solargraph/language_server/host.rb'
     - 'lib/solargraph/parser/parser_gem/node_methods.rb'
     - 'lib/solargraph/source_map/mapper.rb'
@@ -2136,13 +2135,6 @@ Style/NegatedIfElseCondition:
     - 'lib/solargraph/type_checker.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: AllowedMethods.
-# AllowedMethods: be, be_a, be_an, be_between, be_falsey, be_kind_of, be_instance_of, be_truthy, be_within, eq, eql, end_with, include, match, raise_error, respond_to, start_with
-Style/NestedParenthesizedCalls:
-  Exclude:
-    - 'lib/solargraph/type_checker.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 Style/NestedTernaryOperator:
   Exclude:
     - 'lib/solargraph/pin/conversions.rb'
@@ -2237,7 +2229,6 @@ Style/RedundantBegin:
     - 'lib/solargraph/shell.rb'
     - 'lib/solargraph/source/cursor.rb'
     - 'lib/solargraph/source/encoding_fixes.rb'
-    - 'lib/solargraph/type_checker.rb'
     - 'lib/solargraph/workspace.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
@@ -2674,7 +2665,6 @@ YARD/MismatchName:
     - 'lib/solargraph/pin/until.rb'
     - 'lib/solargraph/pin/while.rb'
     - 'lib/solargraph/pin_cache.rb'
-    - 'lib/solargraph/source/chain.rb'
     - 'lib/solargraph/source/chain/call.rb'
     - 'lib/solargraph/source/chain/z_super.rb'
     - 'lib/solargraph/type_checker.rb'

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -62,6 +62,16 @@ module Solargraph
         @superclass_references ||= Hash.new { |h, k| h[k] = [] }
       end
 
+      # @return [Hash{String => Array<Pin::MethodAlias>}]
+      def method_alias_hash
+        @method_alias_hash ||= Hash.new { |h, k| h[k] = [] }
+      end
+
+      # @return [Hash{String => Array<Pin::Method>}]
+      def method_name_hash
+        @method_name_hash ||= Hash.new { |h, k| h[k] = [] }
+      end
+
       # @param pins [Array<Pin::Base>]
       # @return [self]
       def merge pins
@@ -71,7 +81,7 @@ module Solargraph
       protected
 
       attr_writer :pins, :pin_select_cache, :namespace_hash, :pin_class_hash, :path_pin_hash, :include_references,
-                  :extend_references, :prepend_references, :superclass_references
+                  :extend_references, :prepend_references, :superclass_references, :method_alias_hash, :method_name_hash
 
       # @return [self]
       def deep_clone
@@ -80,7 +90,7 @@ module Solargraph
           copy.pins = pins.clone
           %i[
             namespace_hash pin_class_hash path_pin_hash include_references extend_references prepend_references
-            superclass_references
+            superclass_references method_alias_hash method_name_hash
           ].each do |sym|
             copy.send("#{sym}=", send(sym).clone)
             copy.send(sym)&.transform_values!(&:clone)
@@ -105,6 +115,8 @@ module Solargraph
         map_references Pin::Reference::Prepend, prepend_references
         map_references Pin::Reference::Extend, extend_references
         map_references Pin::Reference::Superclass, superclass_references
+        map_method_aliases
+        map_methods_by_name
         map_overrides
         self
       end
@@ -135,6 +147,22 @@ module Solargraph
                          end
         referencing_ns = reference_pin.namespace
         hash[referencing_ns].push referenced_tag
+      end
+
+      # @return [void]
+      def map_method_aliases
+        pins_by_class(Pin::MethodAlias).each do |alias_pin|
+          method_name = alias_pin.name
+          method_alias_hash[method_name] << alias_pin
+        end
+      end
+
+      # @return [void]
+      def map_methods_by_name
+        pins_by_class(Pin::Method).each do |method_pin|
+          method_name = method_pin.name
+          method_name_hash[method_name] << method_pin
+        end
       end
 
       # @return [void]

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -62,16 +62,6 @@ module Solargraph
         @superclass_references ||= Hash.new { |h, k| h[k] = [] }
       end
 
-      # @return [Hash{String => Array<Pin::MethodAlias>}]
-      def method_alias_hash
-        @method_alias_hash ||= Hash.new { |h, k| h[k] = [] }
-      end
-
-      # @return [Hash{String => Array<Pin::Method>}]
-      def method_name_hash
-        @method_name_hash ||= Hash.new { |h, k| h[k] = [] }
-      end
-
       # @param pins [Array<Pin::Base>]
       # @return [self]
       def merge pins
@@ -81,7 +71,7 @@ module Solargraph
       protected
 
       attr_writer :pins, :pin_select_cache, :namespace_hash, :pin_class_hash, :path_pin_hash, :include_references,
-                  :extend_references, :prepend_references, :superclass_references, :method_alias_hash, :method_name_hash
+                  :extend_references, :prepend_references, :superclass_references
 
       # @return [self]
       def deep_clone
@@ -90,7 +80,7 @@ module Solargraph
           copy.pins = pins.clone
           %i[
             namespace_hash pin_class_hash path_pin_hash include_references extend_references prepend_references
-            superclass_references method_alias_hash method_name_hash
+            superclass_references
           ].each do |sym|
             copy.send("#{sym}=", send(sym).clone)
             copy.send(sym)&.transform_values!(&:clone)
@@ -115,8 +105,6 @@ module Solargraph
         map_references Pin::Reference::Prepend, prepend_references
         map_references Pin::Reference::Extend, extend_references
         map_references Pin::Reference::Superclass, superclass_references
-        map_method_aliases
-        map_methods_by_name
         map_overrides
         self
       end
@@ -147,22 +135,6 @@ module Solargraph
                          end
         referencing_ns = reference_pin.namespace
         hash[referencing_ns].push referenced_tag
-      end
-
-      # @return [void]
-      def map_method_aliases
-        pins_by_class(Pin::MethodAlias).each do |alias_pin|
-          method_name = alias_pin.name
-          method_alias_hash[method_name] << alias_pin
-        end
-      end
-
-      # @return [void]
-      def map_methods_by_name
-        pins_by_class(Pin::Method).each do |method_pin|
-          method_name = method_pin.name
-          method_name_hash[method_name] << method_pin
-        end
       end
 
       # @return [void]

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -199,13 +199,6 @@ module Solargraph
         fqns_pins_map[[base, name]]
       end
 
-      # Get methods by name for efficient lookup
-      # @param method_name [String] The method name to look up
-      # @return [Array<Pin::Method>] Array of methods with that name
-      def get_methods_by_name(method_name)
-        index.method_name_hash[method_name]
-      end
-
       # Get all ancestors (superclasses, includes, prepends, extends) for a namespace
       # @param fqns [String] The fully qualified namespace
       # @return [Array<String>] Array of ancestor namespaces including the original

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -209,19 +209,19 @@ describe Solargraph::ApiMap do
   it 'finds stacks of methods' do
     map = Solargraph::SourceMap.load_string(%(
       module Mixin
-        def meth; end
+        def select; end
       end
-      class Foo
+      class Foo < Array
         include Mixin
-        def meth; end
+        def select; end
       end
       class Bar < Foo
-        def meth; end
+        def select; end
       end
     ))
     @api_map.index map.pins
-    pins = @api_map.get_method_stack('Bar', 'meth')
-    expect(pins.map(&:path)).to eq(['Bar#meth', 'Foo#meth', 'Mixin#meth'])
+    pins = @api_map.get_method_stack('Bar', 'select')
+    expect(pins.map(&:path)).to eq(['Bar#select', 'Foo#select', 'Mixin#select', 'Array#select', 'Enumerable#select', 'Kernel#select'])
   end
 
   it 'finds symbols' do


### PR DESCRIPTION
> [!WARNING]
>  DISCLAIMER: @claude was used to generate the code of the new methods, but mostly because I knew what I was looking for, and I was too lazy to figure out the methods needed to be called to make it work.

### Problem

In my current work project (with 7,140 Ruby files with  109,664  total lines), I've noticed that initial or cold LSP completions were taking an extremely long time. By **initial or cold completions**, I mean:

1. First requests after LSP boot (> ~40s)
2. First requests after opening a new file (~10-20s)
3. First requests after editing an open file (~10-20s)

The subsequent completions were fine up until the next edit, I'm assuming due to the caching ( less than typically ~0.5-1s)

```yaml
# .solargraph.yml
---
include:
  - "**/*.rb"
exclude:
  - "**/spec/**/*"
  - test/**/*
  - vendor/**/*
  - ".bundle/**/*"
domains: []
plugins:
  - solargraph-rspec
  - solargraph-rails
rspec:
  let_methods:
    - let_it_be
reporters:
  - rubocop
  - require_not_found
formatter:
  rubocop:
    cops: all
max_files: 20000

```

Coming from the https://github.com/castwide/solargraph/pull/1028, I initially thought the issue might be related to the indexing store update. However after using the excellent profiler, [vernier](https://github.com/jhawthorn/vernier), I came to find that the bottleneck seemed to be the `Solargraph::ApiMap#resolve_method_aliases` particularly its recursive usage of `#get_method_stack` inside `Solargraph::ApiMap#resolve_method_alias`

https://github.com/castwide/solargraph/blob/91bdc3244c4ad8762a89b6b37d144b7fe7d2fa0b/lib/solargraph/api_map.rb#L970

<details><summary>Vernier screenshot</summary>
<img width="433" height="685" alt="image" src="https://github.com/user-attachments/assets/e4dc6ac6-95b7-47b7-85be-cef602a07720" />
</details> 

---------------

### Solution

Replace recursive `get_method_stack` and linear search with direct indexed method lookup via `Store` and `Index`.

- ~~Add indexed lookups for methods and aliases by name~~
	- 	~~Assume that the method names are relatively distinct enough to reduce the search space~~ -> [turned out redundant.](https://github.com/castwide/solargraph/pull/1035/commits/49fa70429048761a6a22aae341773c01af5f61d2)
- Reuse Cached ancestor traversal to avoid repeated computations via `get_method_stack`
- Add fast path for creating resolved alias pins without individual lookups

### Results 🚀

#### Before

[Vernier Profile](https://www.dropbox.com/scl/fi/hx7h4cl3z8huy476c2lsb/before_solargraph_verier_profile_20250821202548.json.gz?rlkey=oak0rdlxfzsyht4zb0oxgh6v5&st=a6mq9e37&dl=0)

<details><summary>Screenshots</summary>

#### First request after LSP boot

 - Total Go-to-definition completion time (~47s)

<img width="971" height="398" alt="image" src="https://github.com/user-attachments/assets/d39e0bf7-4238-4103-9eed-70550feea99c" />

- `Solargraph::Library#definitions_at` time (~4.3s)

<img width="782" height="405" alt="image" src="https://github.com/user-attachments/assets/693c3f3c-c9fc-465a-b87a-280ec44169ae" />


> [!NOTE]
> As we can see, most of the time is spent on cataloging initially, which makes sense. 

---------------

#### First request after opening a new file

- Total Go-to-definition completion time (~9.6s)

<img width="560" height="389" alt="image" src="https://github.com/user-attachments/assets/8afe32e6-4a8a-4ff3-9803-348f644b25ac" />


-  `Solargraph::Library#definitions_at` time (~7.9s)

<img width="414" height="379" alt="image" src="https://github.com/user-attachments/assets/df3c62de-1e53-4226-a10e-5f6d7bda8692" />



</details> 

#### After

[Vernier Profile](https://www.dropbox.com/scl/fi/fqiyclwnsgcxqvixmksoe/after_solargraph_verier_profile_20250821195536.json.gz?rlkey=ng4dcyu02h9f71qazpbl5xlac&st=f1l5pcqh&dl=0)

<details><summary>Screenshots</summary>

#### First request after LSP boot

 - Total Go-to-definition completion time (~13.8s)

<img width="647" height="372" alt="image" src="https://github.com/user-attachments/assets/ec9948b3-cfec-401a-b316-3d5473f9caa0" />


- `Solargraph::Library#definitions_at` time (0.92s)

<img width="633" height="370" alt="image" src="https://github.com/user-attachments/assets/6ff487c8-de92-45a2-bb9c-4c71baa7c43c" />

> [!NOTE]
> As we can see, most of the time is spent on cataloging initially, which makes sense. 

---------------

#### First request after opening a new file

- Total Go-to-definition completion time (4.6s)

<img width="566" height="379" alt="image" src="https://github.com/user-attachments/assets/4a39bc28-22f0-48bd-9f19-93986974bb25" />

-  `Solargraph::Library#definitions_at` time (0.6s)

<img width="410" height="376" alt="image" src="https://github.com/user-attachments/assets/f44b935b-6128-4a72-b4be-44c7c12db6e3" />

</details> 

------

### Summary

Performance improvements (measured on a large Ruby project with ~7,100 files):

- First request after LSP boot: ⏱️ 47s → 13.8s (~3.6x faster)

- First request after opening a new file: ⏱️ 9.6s → 4.6s (~2x faster)

- `Solargraph::Library#definitions_at` hot path: ⏱️ 4.3s → 0.9s (~4.6x faster)

Cached responses seem not to be impacted by this change, and they remain fast as before.


### Further potential Improvements

Example completion after file open: 

<img width="404" height="380" alt="image" src="https://github.com/user-attachments/assets/93a19da3-29e6-499c-868e-9a0629f207df" />


From the samples above (with the new implementation), cataloging accounts for roughly 75-85% of the total time in cold completion responses. There may be room for improvement here - for example, by making cataloging run asynchronously. I recall some recent changes in this area, so the implications aren’t entirely clear. That said, my hunch is that for code completion specifically, developer experience often benefits more from speed than from perfect accuracy (just my personal opinion).

### [Vernier](https://github.com/jhawthorn/vernier) quick how-tos

Assuming that you've already installed the gem locally, to run the solargraph with vernier use:

```
vernier run -- solargraph stdio
```

Use https://vernier.prof/ to upload the profiles above. 

If Vernier is a new tool for you, [this video stream](https://www.youtube.com/watch?v=9nvX3OHykGQ#t=27m40) from Aaron is highly recommended!