### PR TITLE
Resolve class aliases via Constant pins

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -933,6 +933,7 @@ RSpec/DescribeClass:
     - '**/spec/views/**/*'
     - 'spec/complex_type_spec.rb'
     - 'spec/source_map/node_processor_spec.rb'
+    - 'spec/api_map_method_spec.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).
 # Configuration parameters: SkipBlocks, EnforcedStyle, OnlyStaticConstants.

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -752,6 +752,7 @@ module Solargraph
     # @param skip [Set<String>]
     # @param no_core [Boolean] Skip core classes if true
     # @return [Array<Pin::Base>]
+    # rubocop:disable Metrics/CyclomaticComplexity
     def inner_get_methods rooted_tag, scope, visibility, deep, skip, no_core = false
       rooted_type = ComplexType.parse(rooted_tag).force_rooted
       fqns = rooted_type.namespace
@@ -816,6 +817,7 @@ module Solargraph
       end
       result
     end
+    # rubocop:enable Metrics/CyclomaticComplexity
 
     # @param fqns [String]
     # @param visibility [Array<Symbol>]

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -781,13 +781,15 @@ module Solargraph
         if scope == :instance
           store.get_include_pins(fqns).reverse.each do |ref|
             const = get_constants('', *ref.closure.gates).find { |pin| pin.path.end_with? ref.name }
-            if const.is_a?(Pin::Namespace) || const.nil?
-              referenced_tag = ref.parametrized_tag
-              next unless referenced_tag.defined?
-              result.concat inner_get_methods_from_reference(referenced_tag.to_s, namespace_pin, rooted_type, scope, visibility, deep, skip, true)
+            if const.is_a?(Pin::Namespace)
+              result.concat inner_get_methods(const.path, scope, visibility, deep, skip, true)
             elsif const.is_a?(Pin::Constant)
               type = const.infer(self)
               result.concat inner_get_methods(type.namespace, scope, visibility, deep, skip, true) if type.defined?
+            else
+              referenced_tag = ref.parametrized_tag
+              next unless referenced_tag.defined?
+              result.concat inner_get_methods_from_reference(referenced_tag.to_s, namespace_pin, rooted_type, scope, visibility, deep, skip, true)
             end
           end
           rooted_sc_tag = qualify_superclass(rooted_tag)

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -539,16 +539,16 @@ module Solargraph
       fqns = rooted_type.namespace
       namespace_pin = store.get_path_pins(fqns).first
       methods = if namespace_pin.is_a?(Pin::Constant)
-        type = namespace_pin.infer(self)
-        if type.defined?
-          namespace_pin = store.get_path_pins(type.namespace).first
-          get_methods(type.namespace, scope: scope, visibility: visibility).select { |p| p.name == name }
-        else
-          []
-        end
-      else
-        get_methods(rooted_tag, scope: scope, visibility: visibility).select { |p| p.name == name }
-      end
+                  type = namespace_pin.infer(self)
+                  if type.defined?
+                    namespace_pin = store.get_path_pins(type.namespace).first
+                    get_methods(type.namespace, scope: scope, visibility: visibility).select { |p| p.name == name }
+                  else
+                    []
+                  end
+                else
+                  get_methods(rooted_tag, scope: scope, visibility: visibility).select { |p| p.name == name }
+                end
       methods = erase_generics(namespace_pin, rooted_type, methods) unless preserve_generics
       methods
     end

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -47,6 +47,7 @@ module Solargraph
         @include_references ||= Hash.new { |h, k| h[k] = [] }
       end
 
+      # @return [Hash{String => Array<Pin::Reference::Include>}]
       def include_reference_pins
         @include_reference_pins ||= Hash.new { |h, k| h[k] = [] }
       end
@@ -123,6 +124,7 @@ module Solargraph
         end
       end
 
+      # @return [void]
       def map_include_pins
         pins_by_class(Solargraph::Pin::Reference::Include).each do |pin|
           include_reference_pins[pin.namespace].push pin

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -47,6 +47,10 @@ module Solargraph
         @include_references ||= Hash.new { |h, k| h[k] = [] }
       end
 
+      def include_reference_pins
+        @include_reference_pins ||= Hash.new { |h, k| h[k] = [] }
+      end
+
       # @return [Hash{String => Array<String>}]
       def extend_references
         @extend_references ||= Hash.new { |h, k| h[k] = [] }
@@ -105,6 +109,7 @@ module Solargraph
         map_references Pin::Reference::Prepend, prepend_references
         map_references Pin::Reference::Extend, extend_references
         map_references Pin::Reference::Superclass, superclass_references
+        map_include_pins
         map_overrides
         self
       end
@@ -115,6 +120,12 @@ module Solargraph
       def map_references klass, hash
         pins_by_class(klass).each do |pin|
           store_parametric_reference(hash, pin)
+        end
+      end
+
+      def map_include_pins
+        pins_by_class(Solargraph::Pin::Reference::Include).each do |pin|
+          include_reference_pins[pin.namespace].push pin
         end
       end
 

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -89,6 +89,7 @@ module Solargraph
         include_references[fqns] || []
       end
 
+      # @return [Array<Pin::Reference::Include>]
       def get_include_pins fqns
         include_reference_pins[fqns] || []
       end

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -89,6 +89,10 @@ module Solargraph
         include_references[fqns] || []
       end
 
+      def get_include_pins fqns
+        include_reference_pins[fqns] || []
+      end
+
       # @param fqns [String]
       # @return [Array<String>]
       def get_prepends fqns
@@ -281,6 +285,10 @@ module Solargraph
       # @return [Hash{String => Array<Pin::Reference::Include>}]
       def include_references
         index.include_references
+      end
+
+      def include_reference_pins
+        index.include_reference_pins
       end
 
       # @return [Hash{String => Array<Pin::Reference::Prepend>}]

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -89,6 +89,7 @@ module Solargraph
         include_references[fqns] || []
       end
 
+      # @param fqns [String]
       # @return [Array<Pin::Reference::Include>]
       def get_include_pins fqns
         include_reference_pins[fqns] || []
@@ -288,6 +289,7 @@ module Solargraph
         index.include_references
       end
 
+      # @return [Array<Pin::Reference::Include>]
       def include_reference_pins
         index.include_reference_pins
       end

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -289,7 +289,7 @@ module Solargraph
         index.include_references
       end
 
-      # @return [Array<Pin::Reference::Include>]
+      # @return [Hash{String => Array<Solargraph::Pin::Reference::Include>}]
       def include_reference_pins
         index.include_reference_pins
       end

--- a/lib/solargraph/pin/reference.rb
+++ b/lib/solargraph/pin/reference.rb
@@ -21,16 +21,12 @@ module Solargraph
       def parametrized_tag
         @parametrized_tag ||= ComplexType.try_parse(
           name +
-          if generic_values&.length > 0
-            "<" + generic_values.join(', ') + ">"
+          if generic_values&.length&.> 0
+            '<' + generic_values.join(', ') + '>'
           else
             ''
           end
         )
-      end
-
-      def parametrized?
-        generic_values&.any?
       end
     end
   end

--- a/lib/solargraph/pin/reference.rb
+++ b/lib/solargraph/pin/reference.rb
@@ -22,7 +22,7 @@ module Solargraph
         @parametrized_tag ||= ComplexType.try_parse(
           name +
           if generic_values&.length&.> 0
-            '<' + generic_values.join(', ') + '>'
+            "<#{generic_values.join(', ')}>"
           else
             ''
           end

--- a/lib/solargraph/pin/reference.rb
+++ b/lib/solargraph/pin/reference.rb
@@ -17,6 +17,21 @@ module Solargraph
         super(**splat)
         @generic_values = generic_values
       end
+
+      def parametrized_tag
+        @parametrized_tag ||= ComplexType.try_parse(
+          name +
+          if generic_values&.length > 0
+            "<" + generic_values.join(', ') + ">"
+          else
+            ''
+          end
+        )
+      end
+
+      def parametrized?
+        generic_values&.any?
+      end
     end
   end
 end

--- a/lib/solargraph/pin/reference.rb
+++ b/lib/solargraph/pin/reference.rb
@@ -18,6 +18,7 @@ module Solargraph
         @generic_values = generic_values
       end
 
+      # @return [ComplexType]
       def parametrized_tag
         @parametrized_tag ||= ComplexType.try_parse(
           name +

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -14,28 +14,6 @@ describe Solargraph::ApiMap do
   describe '#qualify' do
     let(:external_requires) { ['yaml'] }
 
-    # it 'resolves YAML to Psych' do
-    #   pin = api_map.get_path_pins('YAML').first
-    #   puts pin.inspect
-    #   puts pin.return_type
-    #   expect(api_map.qualify('YAML', '')).to eq('Psych')
-    # end
-
-    # it 'resolves constants used to alias namespaces' do
-    #   map = Solargraph::SourceMap.load_string(%(
-    #     class Foo
-    #       def bing; end
-    #     end
-
-    #     module Bar
-    #       Baz = ::Foo
-    #     end
-    # ))
-    #   api_map.index map.pins
-    #   fqns = api_map.qualify('Bar::Baz')
-    #   expect(fqns).to eq('Foo')
-    # end
-
     it 'understands alias namespaces resolving types' do
       source = Solargraph::Source.load_string(%(
         class Foo

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+describe Solargraph::ApiMap do
+  let(:api_map) { described_class.new }
+  let(:bench) do
+    Solargraph::Bench.new(external_requires: external_requires, workspace: Solargraph::Workspace.new('.'))
+  end
+  let(:external_requires) { [] }
+
+  before do
+    api_map.catalog bench
+  end
+
+  describe '#qualify' do
+    let(:external_requires) { ['yaml'] }
+
+    # it 'resolves YAML to Psych' do
+    #   pin = api_map.get_path_pins('YAML').first
+    #   puts pin.inspect
+    #   puts pin.return_type
+    #   expect(api_map.qualify('YAML', '')).to eq('Psych')
+    # end
+
+    # it 'resolves constants used to alias namespaces' do
+    #   map = Solargraph::SourceMap.load_string(%(
+    #     class Foo
+    #       def bing; end
+    #     end
+
+    #     module Bar
+    #       Baz = ::Foo
+    #     end
+    # ))
+    #   api_map.index map.pins
+    #   fqns = api_map.qualify('Bar::Baz')
+    #   expect(fqns).to eq('Foo')
+    # end
+
+    it 'understands alias namespaces resolving types' do
+      source = Solargraph::Source.load_string(%(
+        class Foo
+          # @return [Symbol]
+          def bing; end
+        end
+
+        module Bar
+          Baz = ::Foo
+        end
+
+        a = Bar::Baz.new.bing
+        a
+        Bar::Baz
+      ), 'test.rb')
+
+      api_map = described_class.new.map(source)
+
+      clip = api_map.clip_at('test.rb', [11, 8])
+      expect(clip.infer.to_s).to eq('Symbol')
+    end
+
+    it 'understands nested alias namespaces to nested classes resolving types' do
+      source = Solargraph::Source.load_string(%(
+        module A
+          class Foo
+            # @return [Symbol]
+            def bing; end
+          end
+        end
+
+        module Bar
+          Baz = A::Foo
+        end
+
+        a = Bar::Baz.new.bing
+        a
+      ), 'test.rb')
+
+      api_map = described_class.new.map(source)
+
+      clip = api_map.clip_at('test.rb', [13, 8])
+      expect(clip.infer.to_s).to eq('Symbol')
+    end
+
+    it 'understands nested alias namespaces resolving types' do
+      source = Solargraph::Source.load_string(%(
+        module Bar
+          module A
+            class Foo
+              # @return [Symbol]
+              def bing; :bingo; end
+            end
+          end
+        end
+
+        module Bar
+          Foo = A::Foo
+        end
+
+        a = Bar::Foo.new.bing
+        a
+      ), 'test.rb')
+
+      api_map = described_class.new.map(source)
+
+      clip = api_map.clip_at('test.rb', [15, 8])
+      expect(clip.infer.to_s).to eq('Symbol')
+    end
+
+    it 'understands includes using nested alias namespaces resolving types' do
+      source = Solargraph::Source.load_string(%(
+        module Foo
+          # @return [Symbol]
+          def bing; :yay; end
+        end
+
+        module Bar
+          Baz = Foo
+        end
+
+        class B
+          include Foo
+        end
+
+        a = B.new.bing
+        a
+      ), 'test.rb')
+
+      api_map = described_class.new.map(source)
+
+      clip = api_map.clip_at('test.rb', [15, 8])
+      expect(clip.infer.to_s).to eq('Symbol')
+    end
+  end
+
+  describe '#get_method_stack' do
+    let(:out) { StringIO.new }
+    let(:api_map) { described_class.load_with_cache(Dir.pwd, out) }
+
+    context 'with stdlib that has vital dependencies' do
+      let(:external_requires) { ['yaml'] }
+      let(:method_stack) { api_map.get_method_stack('YAML', 'safe_load', scope: :class) }
+
+      it 'handles the YAML gem aliased to Psych' do
+        expect(method_stack).not_to be_empty
+      end
+    end
+
+    context 'with thor' do
+      let(:external_requires) { ['thor'] }
+      let(:method_stack) { api_map.get_method_stack('Thor', 'desc', scope: :class) }
+
+      it 'handles finding Thor.desc' do
+        expect(method_stack).not_to be_empty
+      end
+    end
+  end
+end

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe Solargraph::ApiMap do
+describe 'Solargraph::ApiMap methods' do
   let(:api_map) { described_class.new }
   let(:bench) do
     Solargraph::Bench.new(external_requires: external_requires, workspace: Solargraph::Workspace.new('.'))

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
-describe Solargraph::ApiMap do
-  let(:api_map) { described_class.new }
+describe 'Solargraph::ApiMap methods' do
+  let(:api_map) { Solargraph::ApiMap.new }
   let(:bench) do
     Solargraph::Bench.new(external_requires: external_requires, workspace: Solargraph::Workspace.new('.'))
   end

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -30,7 +30,7 @@ describe 'Solargraph::ApiMap methods' do
         Bar::Baz
       ), 'test.rb')
 
-      api_map = described_class.new.map(source)
+      api_map = Solargraph::ApiMap.new.map(source)
 
       clip = api_map.clip_at('test.rb', [11, 8])
       expect(clip.infer.to_s).to eq('Symbol')
@@ -53,7 +53,7 @@ describe 'Solargraph::ApiMap methods' do
         a
       ), 'test.rb')
 
-      api_map = described_class.new.map(source)
+      api_map = Solargraph::ApiMap.new.map(source)
 
       clip = api_map.clip_at('test.rb', [13, 8])
       expect(clip.infer.to_s).to eq('Symbol')
@@ -78,7 +78,7 @@ describe 'Solargraph::ApiMap methods' do
         a
       ), 'test.rb')
 
-      api_map = described_class.new.map(source)
+      api_map = Solargraph::ApiMap.new.map(source)
 
       clip = api_map.clip_at('test.rb', [15, 8])
       expect(clip.infer.to_s).to eq('Symbol')
@@ -103,7 +103,7 @@ describe 'Solargraph::ApiMap methods' do
         a
       ), 'test.rb')
 
-      api_map = described_class.new.map(source)
+      api_map = Solargraph::ApiMap.new.map(source)
 
       clip = api_map.clip_at('test.rb', [15, 8])
       expect(clip.infer.to_s).to eq('Symbol')
@@ -112,7 +112,7 @@ describe 'Solargraph::ApiMap methods' do
 
   describe '#get_method_stack' do
     let(:out) { StringIO.new }
-    let(:api_map) { described_class.load_with_cache(Dir.pwd, out) }
+    let(:api_map) { Solargraph::ApiMap.load_with_cache(Dir.pwd, out) }
 
     context 'with stdlib that has vital dependencies' do
       let(:external_requires) { ['yaml'] }

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-describe 'Solargraph::ApiMap methods' do
+describe Solargraph::ApiMap do
   let(:api_map) { described_class.new }
   let(:bench) do
     Solargraph::Bench.new(external_requires: external_requires, workspace: Solargraph::Workspace.new('.'))

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -132,4 +132,25 @@ describe 'Solargraph::ApiMap methods' do
       end
     end
   end
+
+  describe '#get_methods' do
+    it 'recognizes mixin references from context' do
+      source = Solargraph::Source.load_string(%(
+        module Foo
+          module Bar
+            def baz; end
+          end
+
+          class Includer
+            include Bar
+          end
+        end
+      ), 'test.rb')
+
+      api_map = Solargraph::ApiMap.new
+      api_map.map source
+      pins = api_map.get_methods('Foo::Includer')
+      expect(pins.map(&:path)).to include('Foo::Bar#baz')
+    end
+  end
 end

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -1,6 +1,7 @@
 require 'tmpdir'
 
 describe Solargraph::ApiMap do
+  # rubocop:disable RSpec/InstanceVariable
   before :all do
     @api_map = Solargraph::ApiMap.new
   end
@@ -209,19 +210,19 @@ describe Solargraph::ApiMap do
   it 'finds stacks of methods' do
     map = Solargraph::SourceMap.load_string(%(
       module Mixin
-        def select; end
+        def meth; end
       end
-      class Foo < Array
+      class Foo
         include Mixin
-        def select; end
+        def meth; end
       end
       class Bar < Foo
-        def select; end
+        def meth; end
       end
     ))
     @api_map.index map.pins
-    pins = @api_map.get_method_stack('Bar', 'select')
-    expect(pins.map(&:path)).to eq(['Bar#select', 'Foo#select', 'Mixin#select', 'Array#select', 'Enumerable#select', 'Kernel#select'])
+    pins = @api_map.get_method_stack('Bar', 'meth')
+    expect(pins.map(&:path)).to eq(['Bar#meth', 'Foo#meth', 'Mixin#meth'])
   end
 
   it 'finds symbols' do
@@ -817,4 +818,61 @@ describe Solargraph::ApiMap do
     clip = api_map.clip_at('test.rb', [11, 10])
     expect(clip.infer.to_s).to eq('Symbol')
   end
+
+  it 'resolves aliases in identically named deeply nested classes' do
+    source = Solargraph::Source.load_string(%(
+      module A
+        module Bar
+          # @return [Integer]
+          def quux; 123; end
+        end
+
+        Baz = Bar
+
+        class Foo
+          include Baz
+        end
+      end
+
+      def c
+        b = A::Foo.new.quux
+        b
+      end
+    ), 'test.rb')
+
+    api_map = described_class.new.map(source)
+    clip = api_map.clip_at('test.rb', [16, 8])
+    expect(clip.infer.to_s).to eq('Integer')
+  end
+
+  it 'resolves aliases in nested classes' do
+    source = Solargraph::Source.load_string(%(
+      module A
+        module Bar
+          class Baz
+            # @return [Integer]
+            def quux; 123; end
+          end
+        end
+
+        Baz = Bar::Baz
+
+        class Foo
+          include Baz
+        end
+      end
+
+      def c
+        b = A::Foo.new.quux
+        b
+      end
+    ), 'test.rb')
+
+    api_map = described_class.new.map(source)
+
+    clip = api_map.clip_at('test.rb', [18, 4])
+    expect(clip.infer.to_s).to eq('Integer')
+  end
+
+  # rubocop:enable RSpec/InstanceVariable
 end

--- a/spec/convention/struct_definition_spec.rb
+++ b/spec/convention/struct_definition_spec.rb
@@ -21,7 +21,7 @@ describe Solargraph::Convention::StructDefinition do
       expect(param_baz.return_type.tag).to eql('Integer')
     end
 
-    it 'should set closure to method on assignment operator parameters' do
+    it 'sets closure to method on assignment operator parameters' do
       source = Solargraph::SourceMap.load_string(%(
         # @param bar [String]
         # @param baz [Integer]
@@ -140,7 +140,7 @@ describe Solargraph::Convention::StructDefinition do
       Solargraph::TypeChecker.load_string(code, 'test.rb', :strong)
     end
 
-    it 'should not crash' do
+    it "doesn't crash" do
       checker = type_checker(%(
         Foo = Struct.new(:bar, :baz)
       ))


### PR DESCRIPTION
This is a refactor of #1029 to avoid performance degradation. I started with the original specs and tried to make the minimum possible changes that would make them pass.

There was already a mechanism for resolving namespaces from constants, but there were a few gaps in its usage, e.g., aliases referenced in mixins.

Resolution is generally handled through inference. Given `class Foo; end; Bar = Foo`, the `Bar` pin would infer a return type of `Class<Foo>`.

Further refinements will be handled in a followup PR. Among other changes, I expect to start passing the reference pins directly through `ApiMap::Store` instead of reducing them to string representations of type tags. This should ensure that the `ApiMap` has access to important details like the stack of open gates in the reference's closure.