### PR TITLE
Understand "Parser::AST::Node < AST::Node" in RBS

### DIFF
--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -163,9 +163,10 @@ module Solargraph
             generic_defaults[param.name.to_s] = ComplexType.parse(tag).force_rooted
           end
         end
+        class_name = decl.name.relative!.to_s
         class_pin = Solargraph::Pin::Namespace.new(
           type: :class,
-          name: decl.name.relative!.to_s,
+          name: class_name,
           closure: Solargraph::Pin::ROOT_PIN,
           comments: decl.comment&.string,
           type_location: location_decl_to_pin_location(decl.location),
@@ -180,11 +181,12 @@ module Solargraph
         if decl.super_class
           type = build_type(decl.super_class.name, decl.super_class.args)
           generic_values = type.all_params.map(&:to_s)
+          superclass_name = decl.super_class.name.to_s
           pins.push Solargraph::Pin::Reference::Superclass.new(
             type_location: location_decl_to_pin_location(decl.super_class.location),
             closure: class_pin,
             generic_values: generic_values,
-            name: decl.super_class.name.relative!.to_s,
+            name: superclass_name,
             source: :rbs
           )
         end

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -103,6 +103,7 @@ describe Solargraph::RbsMap::Conversions do
   if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('3.9.1')
     context 'with method pin for Open3.capture2e' do
       it 'accepts chdir kwarg' do
+        pending('https://github.com/castwide/solargraph/pull/1005')
         api_map = Solargraph::ApiMap.load_with_cache('.', $stdout)
 
         method_pin = api_map.pins.find do |pin|

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -1,81 +1,119 @@
 describe Solargraph::RbsMap::Conversions do
-  # create a temporary directory with the scope of the spec
-  around do |example|
-    require 'tmpdir'
-    Dir.mktmpdir("rspec-solargraph-") do |dir|
-      @temp_dir = dir
-      example.run
-    end
-  end
-
-  let(:conversions) do
-    loader = RBS::EnvironmentLoader.new(core_root: nil, repository: RBS::Repository.new(no_stdlib: false))
-    loader.add(path: Pathname(temp_dir))
-    Solargraph::RbsMap::Conversions.new(loader: loader)
-  end
-
-  before do
-    rbs_file = File.join(temp_dir, 'foo.rbs')
-    File.write(rbs_file, rbs)
-  end
-
-  attr_reader :temp_dir
-
-  context 'with untyped response' do
-    let(:rbs) do
-      <<~RBS
-          class Foo
-            def bar: () -> untyped
-          end
-        RBS
+  context 'with RBS to digest' do
+    # create a temporary directory with the scope of the spec
+    around do |example|
+      require 'tmpdir'
+      Dir.mktmpdir("rspec-solargraph-") do |dir|
+        @temp_dir = dir
+        example.run
+      end
     end
 
-    subject(:method_pin) { conversions.pins.find { |pin| pin.path == 'Foo#bar' } }
-
-    it { should_not be_nil }
-
-    it { should be_a(Solargraph::Pin::Method) }
-
-    it 'maps untyped in RBS to undefined in Solargraph 'do
-      expect(method_pin.return_type.tag).to eq('undefined')
-    end
-  end
-
-  # https://github.com/castwide/solargraph/issues/1042
-  context 'with Hash superclass with untyped value and alias' do
-    let(:rbs) do
-      <<~RBS
-          class Sub < Hash[Symbol, untyped]
-            alias meth_alias []
-          end
-        RBS
+    let(:conversions) do
+      loader = RBS::EnvironmentLoader.new(core_root: nil, repository: RBS::Repository.new(no_stdlib: false))
+      loader.add(path: Pathname(temp_dir))
+      Solargraph::RbsMap::Conversions.new(loader: loader)
     end
 
     let(:api_map) { Solargraph::ApiMap.new }
 
-    let(:sup_method_stack) { api_map.get_method_stack('Hash{Symbol => undefined}', '[]', scope: :instance) }
-
-    let(:sub_alias_stack) { api_map.get_method_stack('Sub', 'meth_alias', scope: :instance) }
-
     before do
+      rbs_file = File.join(temp_dir, 'foo.rbs')
+      File.write(rbs_file, rbs)
       api_map.index conversions.pins
     end
 
-    it 'does not crash looking at superclass method' do
-      expect { sup_method_stack }.not_to raise_error
+    attr_reader :temp_dir
+
+    context 'with untyped response' do
+      let(:rbs) do
+        <<~RBS
+          class Foo
+            def bar: () -> untyped
+          end
+        RBS
+      end
+
+      subject(:method_pin) { conversions.pins.find { |pin| pin.path == 'Foo#bar' } }
+
+      it { should_not be_nil }
+
+      it { should be_a(Solargraph::Pin::Method) }
+
+      it 'maps untyped in RBS to undefined in Solargraph 'do
+        expect(method_pin.return_type.tag).to eq('undefined')
+      end
     end
 
-    it 'does not crash looking at alias' do
-      expect { sub_alias_stack }.not_to raise_error
+    # https://github.com/castwide/solargraph/issues/1042
+    context 'with Hash superclass with untyped value and alias' do
+      let(:rbs) do
+        <<~RBS
+          class Sub < Hash[Symbol, untyped]
+            alias meth_alias []
+          end
+        RBS
+      end
+
+      let(:sup_method_stack) { api_map.get_method_stack('Hash{Symbol => undefined}', '[]', scope: :instance) }
+
+      let(:sub_alias_stack) { api_map.get_method_stack('Sub', 'meth_alias', scope: :instance) }
+
+      it 'does not crash looking at superclass method' do
+        expect { sup_method_stack }.not_to raise_error
+      end
+
+      it 'does not crash looking at alias' do
+        expect { sub_alias_stack }.not_to raise_error
+      end
+
+      it 'finds superclass method pin return type' do
+        expect(sup_method_stack.map(&:return_type).map(&:rooted_tags).uniq).to eq(['undefined'])
+      end
+
+      it 'finds superclass method pin parameter type' do
+        expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
+                 .uniq).to eq(['Symbol'])
+      end
     end
 
-    it 'finds superclass method pin return type' do
-      expect(sup_method_stack.map(&:return_type).map(&:rooted_tags).uniq).to eq(['undefined'])
-    end
+    context 'with overlapping module hierarchies and inheritance' do
+      let(:rbs) do
+        <<~RBS
+          module B
+            class C
+              def foo: () -> String
+            end
+          end
+          module A
+            module B
+              class C < ::B::C
+              end
+            end
+          end
+        RBS
+      end
 
-    it 'finds superclass method pin parameter type' do
-      expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
-               .uniq).to eq(['Symbol'])
+      subject(:method_pin) { api_map.get_method_stack('A::B::C', 'foo').first }
+
+      it { should be_a(Solargraph::Pin::Method) }
+    end
+  end
+
+  if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('3.9.1')
+    context 'with method pin for Open3.capture2e' do
+      it 'accepts chdir kwarg' do
+        api_map = Solargraph::ApiMap.load_with_cache('.', $stdout)
+
+        method_pin = api_map.pins.find do |pin|
+          pin.is_a?(Solargraph::Pin::Method) && pin.path == 'Open3.capture2e'
+        end
+
+        chdir_param = method_pin&.signatures&.flat_map(&:parameters)&.find do |param| # rubocop:disable Style/SafeNavigationChainLength
+          param.name == 'chdir'
+        end
+        expect(chdir_param).not_to be_nil, -> { "Found pin #{method_pin.to_rbs} from #{method_pin.type_location}" }
+      end
     end
   end
 end

--- a/spec/rbs_map/core_map_spec.rb
+++ b/spec/rbs_map/core_map_spec.rb
@@ -6,7 +6,7 @@ describe Solargraph::RbsMap::CoreMap do
       pin = store.get_path_pins("Errno::#{const}").first
       expect(pin).to be_a(Solargraph::Pin::Namespace)
       superclass = store.get_superclass(pin.path)
-      expect(superclass).to eq('SystemCallError')
+      expect(superclass).to eq('::SystemCallError')
     end
   end
 


### PR DESCRIPTION
Right now the parser gem RBS doesn't get handled correctly; it doesn't mark the AST::Node being inherited from as being rooted, meaning we end up resolving the superclass of Parser::AST::Node to be...Parser::AST::Node.