### PR TITLE
Drop broken 'namespaces' method

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -236,13 +236,6 @@ module Solargraph
       store.pins_by_class(Pin::Keyword)
     end
 
-    # An array of namespace names defined in the ApiMap.
-    #
-    # @return [Set<String>]
-    def namespaces
-      store.namespaces
-    end
-
     # True if the namespace exists.
     #
     # @param name [String] The namespace to match

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -142,11 +142,6 @@ module Solargraph
         fqns_pins(fqns).any?
       end
 
-      # @return [Set<String>]
-      def namespaces
-        index.namespaces
-      end
-
       # @return [Enumerable<Solargraph::Pin::Namespace>]
       def namespace_pins
         pins_by_class(Solargraph::Pin::Namespace)


### PR DESCRIPTION
These unused methods call into ApiMap::Index#namespaces, which does not exist.