### PR TITLE
Allow solargraph version to be overidden for test purposes

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,3 @@
+# current git branch
+SOLARGRAPH_FORCE_VERSION=0.0.0.dev-$(git rev-parse --abbrev-ref HEAD | tr -d '\n' | tr '/' '-' | tr '_' '-')
+export SOLARGRAPH_FORCE_VERSION

--- a/lib/solargraph/version.rb
+++ b/lib/solargraph/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Solargraph
-  VERSION = '0.56.2'
+  VERSION = ENV.fetch('SOLARGRAPH_FORCE_VERSION', '0.56.2')
 end


### PR DESCRIPTION
Useful for:
1. Maintaining a separate pin cache per branch to avoid contamination and get more accurate spec results locally
2. Testing solargraph-rails against branches consolidating multiple open PRs (e.g., the dated ones at https://github.com/apiology/solargraph/pulls)

Includes a direnv implementation for #1