### PR TITLE
Flow sensitive typing handles x.is_a? without an argument

### DIFF
--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -230,7 +230,7 @@ module Solargraph
       def type_name(node)
         # e.g.,
         #  s(:const, nil, :Baz)
-        return unless node.type == :const
+        return unless node&.type == :const
         module_node = node.children[0]
         class_node = node.children[1]
 

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -241,4 +241,16 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     clip = api_map.clip_at('test.rb', [2, 6])
     expect { clip.infer.to_s }.not_to raise_error
   end
+
+  it 'handles is_a? with a receiver and no argument' do
+    source = Solargraph::Source.load_string(%(
+    r = '1'
+    if r.is_a?
+      x
+    end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [3, 6])
+    expect { clip.infer.to_s }.not_to raise_error
+  end
 end


### PR DESCRIPTION
Small bug I noticed while working on #1058. Flow sensitive typing can throw an `undefined method` error when it tries to infer a type name from an `is_a?` call without an argument.