### PR TITLE
Make typechecker errors vim quickfix friendly

### DIFF
--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -259,7 +259,7 @@ module Solargraph
           next if problems.empty?
           problems.sort! { |a, b| a.location.range.start.line <=> b.location.range.start.line }
           puts problems.map { |prob|
-            "#{prob.location.filename}:#{prob.location.range.start.line + 1} - #{prob.message}"
+            "#{prob.location.filename}:#{prob.location.range.start.line + 1}: #{prob.message}"
           }.join("\n")
           filecount += 1
           probcount += problems.length


### PR DESCRIPTION
A minor change to the typechecker output, but a life-changing one for Vim/Emacs users.
(I mention only Vim in the title, because that's what we vim-ers do :) )

This is similar to: https://docs.rubocop.org/rubocop/formatters.html#emacs-style-formatter

Everything in Vim revolves around something called [quickfix](https://medium.com/@EduardoRodriguesF/vim-start-using-quickfix-lists-e43a7a29ba52). It's essentially a list of "things needed to be fixed" where you can easily navigate between next/prev/first/last, and do a lot more around them. 

Among other things, one can run a terminal command and have this list populated; for example:

`cexpr system("bundle exec solargraph typecheck --level strict")`, and have this convenient list populated:

<img width="936" height="237" alt="image" src="https://github.com/user-attachments/assets/e5f93e7e-1796-4f83-b99c-644eb048c92a" />



