### PR TITLE
Faster constant resolution

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -856,7 +856,6 @@ module Solargraph
 
       # Search each ancestor for the original method
       ancestors.each do |ancestor_fqns|
-        ancestor_fqns = ComplexType.try_parse(ancestor_fqns).force_rooted.namespace
         next if ancestor_fqns.nil?
         ancestor_method_path = "#{ancestor_fqns}#{alias_pin.scope == :instance ? '#' : '.'}#{alias_pin.original}"
 

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -289,12 +289,12 @@ module Solargraph
     # @param tag [String, nil] The namespace to
     #   match, complete with generic parameters set to appropriate
     #   values if available
-    # @param context_tag [String] The fully qualified context in which
+    # @param gates [Array<String>] The fully qualified context in which
     #   the tag was referenced; start from here to resolve the name.
     #   Should not be prefixed with '::'.
     # @return [String, nil] fully qualified tag
-    def qualify tag, context_tag = ''
-      store.constants.qualify(tag, context_tag)
+    def qualify tag, *gates
+      store.constants.qualify(tag, *gates)
     end
 
     # Get a fully qualified namespace from a reference pin.

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -297,6 +297,13 @@ module Solargraph
       store.constants.qualify(tag, *gates)
     end
 
+    # @param name [String]
+    # @param gates [Array<String, Array<String>>]
+    # @return [String, nil]
+    def resolve name, *gates
+      store.constants.resolve(name, *gates)
+    end
+
     # Get a fully qualified namespace from a reference pin.
     #
     # @param pin [Pin::Reference]

--- a/lib/solargraph/api_map/constants.rb
+++ b/lib/solargraph/api_map/constants.rb
@@ -64,8 +64,6 @@ module Solargraph
           return resolved if resolved
           Solargraph.logger.debug "resolve failed. #{tag.inspect} #{gates.inspect} #{caller_locations[0, 2]}"
           return nil
-        else
-          raise "not shortable!"
         end
 
         context_tag = gates.first

--- a/lib/solargraph/api_map/constants.rb
+++ b/lib/solargraph/api_map/constants.rb
@@ -101,10 +101,17 @@ module Solargraph
 
       # @param name [String]
       # @param gate [String]
-      # @return [String, nil]
+      # @return [Pin::Constant, Pin::Namespace, nil]
       def simple_resolve name, gate
         here = "#{gate}::#{name}".sub(/^::/, '').sub(/::$/, '')
-        here if store.constant_names.include?(here)
+        pin = store.get_path_pins(here).first
+        if pin.is_a?(Pin::Constant)
+          const = Solargraph::Parser::NodeMethods.unpack_name(pin.assignment)
+          return unless const
+          resolve(const, pin.gates)
+        else
+          pin&.path
+        end
       end
 
       # @param gates [Array<String>]

--- a/lib/solargraph/api_map/constants.rb
+++ b/lib/solargraph/api_map/constants.rb
@@ -103,18 +103,11 @@ module Solargraph
       # @param gates [Array<String>]
       # @return [String, nil]
       def resolve_uncached name, gates
-        # parts = name.split('::')
-        # here = parts.shift
-        # resolved = simple_resolve(here, gates)
-        # return resolved if parts.empty? || resolved.nil?
-
-        # final = "#{resolved}::#{parts.join('::')}".sub(/^::/, '')
-        # final if store.namespace_exists?(final)
         resolved = nil
         base = gates
         name.split('::').each do |nam|
           resolved = complex_resolve(nam, base)
-          return unless resolved
+          break unless resolved
           base = [resolved]
         end
         resolved
@@ -125,7 +118,7 @@ module Solargraph
         gates.each do |gate|
           resolved = simple_resolve(name, gate)
           return resolved if resolved
-          store.get_includes(gate).each do |ref|
+          store.get_ancestor_references(gate).each do |ref|
             mixin = resolve(ref.name, ref.reference_gates - [gate])
             resolved = simple_resolve(name, mixin)
             return resolved if resolved
@@ -139,7 +132,7 @@ module Solargraph
       # @return [String, nil]
       def simple_resolve name, gate
         here = "#{gate}::#{name}".sub(/^::/, '').sub(/::$/, '')
-        here if store.namespace_exists?(here)
+        here if store.constant_names.include?(here)
       end
 
       # @param gates [Array<String>]

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -16,7 +16,9 @@ module Solargraph
       end
 
       # @return [Set<String>]
-      attr_reader :namespaces
+      def constant_names
+        @constant_names ||= (pins_by_class(Pin::Namespace) + pins_by_class(Pin::Constant)).to_set(&:path)
+      end
 
       # @return [Hash{String => Array<Pin::Namespace>}]
       def namespace_hash

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -15,11 +15,6 @@ module Solargraph
         @pins ||= []
       end
 
-      # @return [Set<String>]
-      def constant_names
-        @constant_names ||= (pins_by_class(Pin::Namespace) + pins_by_class(Pin::Constant)).to_set(&:path)
-      end
-
       # @return [Hash{String => Array<Pin::Namespace>}]
       def namespace_hash
         @namespace_hash ||= Hash.new { |h, k| h[k] = [] }

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -160,6 +160,10 @@ module Solargraph
         pins_by_class(Solargraph::Pin::Namespace)
       end
 
+      def constant_names
+        index.constant_names
+      end
+
       # @return [Enumerable<Solargraph::Pin::Method>]
       def method_pins
         pins_by_class(Solargraph::Pin::Method)
@@ -253,6 +257,10 @@ module Solargraph
         end
 
         ancestors.compact.uniq
+      end
+
+      def get_ancestor_references(fqns)
+        (get_prepends(fqns) + get_includes(fqns) + [get_superclass(fqns)]).compact
       end
 
       # @return [Constants]

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -160,10 +160,6 @@ module Solargraph
         pins_by_class(Solargraph::Pin::Namespace)
       end
 
-      def constant_names
-        index.constant_names
-      end
-
       # @return [Enumerable<Solargraph::Pin::Method>]
       def method_pins
         pins_by_class(Solargraph::Pin::Method)

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -33,12 +33,12 @@ module Solargraph
     # @param api_map [ApiMap]
     # @param context [String]
     # @return [ComplexType]
-    def qualify api_map, context = ''
+    def qualify api_map, *gates
       red = reduce_object
       types = red.items.map do |t|
         next t if ['nil', 'void', 'undefined'].include?(t.name)
         next t if ['::Boolean'].include?(t.rooted_name)
-        t.qualify api_map, context
+        t.qualify api_map, *gates
       end
       ComplexType.new(types).reduce_object
     end

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -409,12 +409,12 @@ module Solargraph
       # @param api_map [ApiMap] The ApiMap that performs qualification
       # @param context [String] The namespace from which to resolve names
       # @return [self, ComplexType, UniqueType] The generated ComplexType
-      def qualify api_map, context = ''
+      def qualify api_map, *gates
         transform do |t|
           next t if t.name == GENERIC_TAG_NAME
-          next t if t.duck_type? || t.void? || t.undefined?
-          recon = (t.rooted? ? '' : context)
-          fqns = api_map.qualify(t.name, recon)
+          next t if t.duck_type? || t.void? || t.undefined? || t.literal?
+          open = t.rooted? ? [''] : gates
+          fqns = api_map.qualify(t.non_literal_name, *open)
           if fqns.nil?
             next UniqueType::BOOLEAN if t.tag == 'Boolean'
             next UniqueType::UNDEFINED

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -513,7 +513,7 @@ module Solargraph
       # @param api_map [ApiMap]
       # @return [ComplexType]
       def typify api_map
-        return_type.qualify(api_map, namespace)
+        return_type.qualify(api_map, *(closure&.gates || ['']))
       end
 
       # Infer the pin's return type via static code analysis.

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -574,6 +574,18 @@ module Solargraph
         @identity ||= "#{closure&.path}|#{name}|#{location}"
       end
 
+      # The namespaces available for resolving the current namespace. Each gate
+      # should be a fully qualified namespace or the root namespace (i.e., an
+      # empty string.)
+      #
+      # Example: Given the name 'Bar' and the gates ['Foo', ''],
+      # the fully qualified namespace should be 'Foo::Bar' or 'Bar'.
+      #
+      # @return [Array<string>]
+      def gates
+        @gates ||= closure&.gates || ['']
+      end
+
       # @return [String, nil]
       def to_rbs
         return_type.to_rbs

--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -69,7 +69,7 @@ module Solargraph
                 namespace_pin = api_map.get_namespace_pins(meth.namespace, closure.namespace).first
                 arg_type.resolve_generics(namespace_pin, param_type)
               else
-                arg_type.self_to_type(chain.base.infer(api_map, self, locals)).qualify(api_map, meth.context.namespace)
+                arg_type.self_to_type(chain.base.infer(api_map, self, locals)).qualify(api_map, *meth.gates)
               end
             end
           end
@@ -96,7 +96,7 @@ module Solargraph
         target = chain.base.infer(api_map, receiver_pin, locals)
         target = full_context unless target.defined?
 
-        ComplexType.try_parse(*types).qualify(api_map, receiver_pin.context.namespace).self_to_type(target)
+        ComplexType.try_parse(*types).qualify(api_map, *receiver_pin.gates).self_to_type(target)
       end
     end
   end

--- a/lib/solargraph/pin/closure.rb
+++ b/lib/solargraph/pin/closure.rb
@@ -49,13 +49,6 @@ module Solargraph
       end
 
       # @return [::Array<String>]
-      def gates
-        # @todo This check might not be necessary. There should always be a
-        #   root pin
-        closure ? closure.gates : ['']
-      end
-
-      # @return [::Array<String>]
       def generics
         @generics ||= docstring.tags(:generic).map(&:name)
       end

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -298,7 +298,7 @@ module Solargraph
         type = see_reference(api_map) || typify_from_super(api_map)
         logger.debug { "Method#typify(self=#{self}) - type=#{type&.rooted_tags.inspect}" }
         unless type.nil?
-          qualified = type.qualify(api_map, namespace)
+          qualified = type.qualify(api_map, *closure.gates)
           logger.debug { "Method#typify(self=#{self}) => #{qualified.rooted_tags.inspect}" }
           return qualified
         end
@@ -556,7 +556,7 @@ module Solargraph
         if parts.first.empty? || parts.one?
           path = "#{namespace}#{ref}"
         else
-          fqns = api_map.qualify(parts.first, namespace)
+          fqns = api_map.qualify(parts.first, *gates)
           return ComplexType::UNDEFINED if fqns.nil?
           path = fqns + ref[parts.first.length] + parts.last
         end

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -556,7 +556,7 @@ module Solargraph
         if parts.first.empty? || parts.one?
           path = "#{namespace}#{ref}"
         else
-          fqns = api_map.qualify(parts.first, *gates)
+          fqns = api_map.resolve(parts.first, *gates)
           return ComplexType::UNDEFINED if fqns.nil?
           path = fqns + ref[parts.first.length] + parts.last
         end

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -166,7 +166,7 @@ module Solargraph
 
       # @param api_map [ApiMap]
       def typify api_map
-        return return_type.qualify(api_map, closure.context.namespace) unless return_type.undefined?
+        return return_type.qualify(api_map, *closure.gates) unless return_type.undefined?
         closure.is_a?(Pin::Block) ? typify_block_param(api_map) : typify_method_param(api_map)
       end
 
@@ -222,7 +222,7 @@ module Solargraph
           if found.nil? and !index.nil?
             found = params[index] if params[index] && (params[index].name.nil? || params[index].name.empty?)
           end
-          return ComplexType.try_parse(*found.types).qualify(api_map, meth.context.namespace) unless found.nil? || found.types.nil?
+          return ComplexType.try_parse(*found.types).qualify(api_map, *meth.closure.gates) unless found.nil? || found.types.nil?
         end
         ComplexType::UNDEFINED
       end

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -251,7 +251,7 @@ module Solargraph
         if parts.first.empty?
           path = "#{namespace}#{ref}"
         else
-          fqns = api_map.qualify(parts.first, namespace)
+          fqns = api_map.resolve(parts.first, namespace)
           return nil if fqns.nil?
           path = fqns + ref[parts.first.length] + parts.last
         end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -137,7 +137,7 @@ module Solargraph
                 #
                 # qualify(), however, happens in the namespace where
                 # the docs were written - from the method pin.
-                type = with_params(new_return_type.self_to_type(self_type), self_type).qualify(api_map, p.namespace) if new_return_type.defined?
+                type = with_params(new_return_type.self_to_type(self_type), self_type).qualify(api_map, *p.gates) if new_return_type.defined?
                 type ||= ComplexType::UNDEFINED
               end
               break if type.defined?
@@ -267,7 +267,7 @@ module Solargraph
           return [] unless method_pin
 
           method_pin.signatures.map(&:block).compact.map do |signature_pin|
-            return_type = signature_pin.return_type.qualify(api_map, name_pin.namespace)
+            return_type = signature_pin.return_type.qualify(api_map, *name_pin.gates)
             signature_pin.proxy(return_type)
           end
         end

--- a/lib/solargraph/source/chain/constant.rb
+++ b/lib/solargraph/source/chain/constant.rb
@@ -17,6 +17,9 @@ module Solargraph
             base = word
             gates = name_pin.gates
           end
+          fqns = api_map.send(:store).constants.resolve(base, gates)
+          return api_map.get_path_pins(fqns) if fqns
+
           parts = base.split('::')
           gates.each do |gate|
             # @todo 'Wrong argument type for

--- a/lib/solargraph/source/chain/constant.rb
+++ b/lib/solargraph/source/chain/constant.rb
@@ -15,7 +15,7 @@ module Solargraph
             gates = ['']
           else
             base = word
-            gates = crawl_gates(name_pin)
+            gates = name_pin.gates
           end
           parts = base.split('::')
           gates.each do |gate|
@@ -40,21 +40,6 @@ module Solargraph
         end
 
         private
-
-        # @param pin [Pin::Closure]
-        # @return [::Array<String>]
-        def crawl_gates pin
-          clos = pin
-          until clos.nil?
-            if clos.is_a?(Pin::Namespace)
-              gates = clos.gates
-              gates.push('') if gates.empty?
-              return gates
-            end
-            clos = clos.closure
-          end
-          ['']
-        end
 
         # @param pins [::Array<Pin::Base>]
         # @param api_map [ApiMap]

--- a/lib/solargraph/source/chain/constant.rb
+++ b/lib/solargraph/source/chain/constant.rb
@@ -17,29 +17,32 @@ module Solargraph
             base = word
             gates = name_pin.gates
           end
-          fqns = api_map.send(:store).constants.resolve(base, gates)
-          return api_map.get_path_pins(fqns) if fqns
+          fqns = api_map.resolve(base, gates)
+          api_map.get_path_pins(fqns)
 
-          parts = base.split('::')
-          gates.each do |gate|
-            # @todo 'Wrong argument type for
-            #   Solargraph::Source::Chain::Constant#deep_constant_type:
-            #   gate expected String, received generic<Elem>' is because
-            #   we lose 'rooted' information in the 'Chain::Array' class
-            #   internally, leaving ::Array#each shadowed when it
-            #   shouldn't be.
-            type = deep_constant_type(gate, api_map)
-            # Use deep inference to resolve root
-            parts[0..-2].each do |sym|
-              pins = api_map.get_constants('', type.namespace).select{ |pin| pin.name == sym }
-              type = first_pin_type(pins, api_map)
-              break if type.undefined?
-            end
-            next if type.undefined?
-            result = api_map.get_constants('', type.namespace).select { |pin| pin.name == parts.last }
-            return result unless result.empty?
-          end
-          []
+          # @todo This routine may no longer be necessary. Store::Constants can
+          #   resolve constant aliases in the form of `Foo = Bar`.
+          #
+          # parts = base.split('::')
+          # gates.each do |gate|
+          #   # @todo 'Wrong argument type for
+          #   #   Solargraph::Source::Chain::Constant#deep_constant_type:
+          #   #   gate expected String, received generic<Elem>' is because
+          #   #   we lose 'rooted' information in the 'Chain::Array' class
+          #   #   internally, leaving ::Array#each shadowed when it
+          #   #   shouldn't be.
+          #   type = deep_constant_type(gate, api_map)
+          #   # Use deep inference to resolve root
+          #   parts[0..-2].each do |sym|
+          #     pins = api_map.get_constants('', type.namespace).select{ |pin| pin.name == sym }
+          #     type = first_pin_type(pins, api_map)
+          #     break if type.undefined?
+          #   end
+          #   next if type.undefined?
+          #   result = api_map.get_constants('', type.namespace).select { |pin| pin.name == parts.last }
+          #   return result unless result.empty?
+          # end
+          # []
         end
 
         private

--- a/lib/solargraph/source/chain/constant.rb
+++ b/lib/solargraph/source/chain/constant.rb
@@ -19,60 +19,6 @@ module Solargraph
           end
           fqns = api_map.resolve(base, gates)
           api_map.get_path_pins(fqns)
-
-          # @todo This routine may no longer be necessary. Store::Constants can
-          #   resolve constant aliases in the form of `Foo = Bar`.
-          #
-          # parts = base.split('::')
-          # gates.each do |gate|
-          #   # @todo 'Wrong argument type for
-          #   #   Solargraph::Source::Chain::Constant#deep_constant_type:
-          #   #   gate expected String, received generic<Elem>' is because
-          #   #   we lose 'rooted' information in the 'Chain::Array' class
-          #   #   internally, leaving ::Array#each shadowed when it
-          #   #   shouldn't be.
-          #   type = deep_constant_type(gate, api_map)
-          #   # Use deep inference to resolve root
-          #   parts[0..-2].each do |sym|
-          #     pins = api_map.get_constants('', type.namespace).select{ |pin| pin.name == sym }
-          #     type = first_pin_type(pins, api_map)
-          #     break if type.undefined?
-          #   end
-          #   next if type.undefined?
-          #   result = api_map.get_constants('', type.namespace).select { |pin| pin.name == parts.last }
-          #   return result unless result.empty?
-          # end
-          # []
-        end
-
-        private
-
-        # @param pins [::Array<Pin::Base>]
-        # @param api_map [ApiMap]
-        # @return [ComplexType]
-        def first_pin_type(pins, api_map)
-          type = ComplexType::UNDEFINED
-          pins.each do |pin|
-            type = pin.typify(api_map)
-            break if type.defined?
-            type = pin.probe(api_map)
-            break if type.defined?
-          end
-          type
-        end
-
-        # @param gate [String]
-        # @param api_map [ApiMap]
-        # @return [ComplexType]
-        def deep_constant_type(gate, api_map)
-          type = ComplexType::ROOT
-          return type if gate == ''
-          gate.split('::').each do |word|
-            pins = api_map.get_constants('', type.namespace).select { |pin| pin.name == word }
-            type = first_pin_type(pins, api_map)
-            break if type.undefined?
-          end
-          type
         end
       end
     end

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -96,7 +96,7 @@ module Solargraph
     def method_return_type_problems_for pin
       return [] if pin.is_a?(Pin::MethodAlias)
       result = []
-      declared = pin.typify(api_map).self_to_type(pin.full_context).qualify(api_map, pin.full_context.tag)
+      declared = pin.typify(api_map).self_to_type(pin.full_context).qualify(api_map, *pin.closure.gates)
       if declared.undefined?
         if pin.return_type.undefined? && rules.require_type_tags?
           if pin.attribute?
@@ -506,7 +506,7 @@ module Solargraph
         next if tag.types.nil?
         result[tag.name.to_s] = {
           tagged: tag.types.join(', '),
-          qualified: Solargraph::ComplexType.try_parse(*tag.types).qualify(api_map, pin.full_context.namespace)
+          qualified: Solargraph::ComplexType.try_parse(*tag.types).qualify(api_map, *pin.closure.gates)
         }
       end
       result

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -535,14 +535,16 @@ describe Solargraph::ApiMap do
     expect(fqns).to eq('Foo::Bar')
   end
 
-  it 'handles multiple type parameters without losing cache coherence' do
+  # @todo Qualify methods might not accept parametrized types anymore
+  xit 'handles multiple type parameters without losing cache coherence' do
     tag = @api_map.qualify('Array<String>')
     expect(tag).to eq('Array<String>')
     tag = @api_map.qualify('Array<Integer>')
     expect(tag).to eq('Array<Integer>')
   end
 
-  it 'handles multiple type parameters without losing cache coherence' do
+  # @todo Qualify methods might not accept parametrized types anymore
+  xit 'handles multiple type parameters without losing cache coherence' do
     tag = @api_map.qualify('Hash{Integer => String}')
     expect(tag).to eq('Hash{Integer => String}')
   end
@@ -560,7 +562,7 @@ describe Solargraph::ApiMap do
       end
     ))
     @api_map.map source
-    fqns = @api_map.qualify('Bar', 'Foo::Includer')
+    fqns = @api_map.qualify('Bar', 'Foo::Includer', 'Foo', '')
     expect(fqns).to eq('Foo::Bar')
   end
 

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -423,7 +423,7 @@ describe 'YARD type specifier list parsing' do
       it 'squashes literal types when simplifying literals of same type' do
         api_map = Solargraph::ApiMap.new
         type = Solargraph::ComplexType.parse('1, 2, 3')
-        type = type.qualify(api_map)
+        type = type.qualify(api_map, '')
         expect(type.to_s).to eq('1, 2, 3')
         expect(type.tags).to eq('1, 2, 3')
         expect(type.simple_tags).to eq('Integer')

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -903,6 +903,7 @@ describe Solargraph::SourceMap::Clip do
 
   it 'finds inferred type definitions' do
     source = Solargraph::Source.load_string(%(
+      module OtherNamespace; end
       class OtherNamespace::MyClass; end
       module SomeNamespace
         class Foo
@@ -925,7 +926,7 @@ describe Solargraph::SourceMap::Clip do
     api_map.map source
     clip = api_map.clip_at('test.rb', [13, 33])
     expect(clip.types.map(&:path)).to eq(['SomeNamespace::Foo']) # other_variable
-    clip = api_map.clip_at('test.rb', [17, 33])
+    clip = api_map.clip_at('test.rb', [18, 33])
     expect(clip.types.map(&:path)).to eq(['SomeNamespace::Foo', 'SomeNamespace::Bar', 'OtherNamespace::MyClass'])
   end
 


### PR DESCRIPTION
Optimize constant resolution by making better use of gates, leveraging the store's path indexes, and avoiding unnecessary type inference.

`ApiMap#resolve` is similar to `ApiMap#qualify` in that its purpose is to find fully qualified (absolute) namespaces, with two exceptions:
* `#resolve` is only concerned with real namespaces. It does not support parametrized types or special types like literals, `self`, and `Boolean`.
* `#resolve` never performs type inference.

In general, I would recommend using `#resolve` over `#qualify` where possible. The only place where `#qualify` is still necessary is in complex types. I hope to refactor them to handle qualification internally while further reducing type inference.