### PR TITLE
Enable solargraph-rspec tests

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -109,7 +109,8 @@ jobs:
     # check out solargraph-rspec as well as this project, and point the former to use the latter as a local gem
     runs-on: ubuntu-latest
     env:
-      SOLARGRAPH_CACHE: ${{ github.workspace }}/solargraph-rspec/vendor/solargraph/cache
+      SOLARGRAPH_CACHE: ${{ github.workspace }}/../solargraph-rspec/vendor/solargraph/cache
+      BUNDLE_PATH: ${{ github.workspace }}/../solargraph-rspec/vendor/bundle
     steps:
     - uses: actions/checkout@v3
     - name: clone https://github.com/lekemula/solargraph-rspec/
@@ -121,12 +122,17 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 3.4
-        bundler-cache: true
+        bundler-cache: false
     - name: Install gems
       run: |
        cd ../solargraph-rspec
        echo "gem 'solargraph', path: '../solargraph'" >> Gemfile
-       bundle install
+       bundle config path ${{ env.BUNDLE_PATH }}
+       bundle install --jobs 4 --retry 3
+    - name: Configure .solargraph.yml
+      run: |
+        cd ../solargraph-rspec
+        cp .solargraph.yml.example .solargraph.yml
     - name: Solargraph generate RSpec gems YARD and RBS pins
       run: |
         cd ../solargraph-rspec
@@ -135,7 +141,7 @@ jobs:
     - name: Run specs
       run: |
         cd ../solargraph-rspec
-        bundle exec rspec
+        bundle exec rspec --format progress
 
   run_solargraph_rails_specs:
     # check out solargraph-rails as well as this project, and point the former to use the latter as a local gem


### PR DESCRIPTION
https://github.com/castwide/solargraph/actions/runs/17897241460/job/50885481518?pr=1087

Thank you, @apiology, for setting this important workflow. I think it's very useful to make it work also for solargraph-rspec to prevent regressions in the future. I also appreciate the reminder about the `act`, which was a lifesaver!	

I assume the other CI failures are not related to this PR, if otherwise, let me know!

### Future Work

I think we need to revisit caching of gems/yard/rbs files across the CI workflows. See [similar work](https://github.com/lekemula/solargraph-rspec/commit/e492aa0d6ee87e648f973584b4086d1355021a18) on solargraph-rspec.
