### PR TITLE
Fix pin combination consistency issue

### DIFF
--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -354,7 +354,7 @@ module Solargraph
         end
         # arbitrary way of choosing a pin
         # @sg-ignore Need _1 support
-        [val1, val2].compact.min_by { _1.best_location.to_s }
+        [val1, val2].compact.max_by { File.basename(_1.best_location.to_s) }
       end
 
       # @return [void]


### PR DESCRIPTION
I was hitting a strange 'works on my machine' issue and figured it out that I wasn't seeing it because of a difference in where files lived in CI vs my machine.  This resulted in different pin info being selected during combination, as we were using the file location when we had no better way to prefer one over the other.

This should make the result more consistent, making user and CI pin-combination-triggered issues easier to reproduce.