### PR TITLE
Reduce number of build jobs for faster CI feedback

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -23,12 +23,26 @@ jobs:
       matrix:
         ruby-version: ['3.0', '3.1', '3.2', '3.3', '3.4', 'head']
         rbs-version: ['3.6.1', '3.9.4', '4.0.0.dev.4']
-        # Ruby 3.0 doesn't work with RBS 3.9.4 or 4.0.0.dev.4
         exclude:
+          # Ruby 3.0 doesn't work with RBS 3.9.4 or 4.0.0.dev.4
           - ruby-version: '3.0'
             rbs-version: '3.9.4'
           - ruby-version: '3.0'
             rbs-version: '4.0.0.dev.4'
+          # only include the 3.1 variants we include later
+          - ruby-version: '3.1'
+          # only include the 3.2 variants we include later
+          - ruby-version: '3.2'
+          # only include the 3.3 variants we include later
+          - ruby-version: '3.3'
+        include:
+          - ruby-version: '3.1'
+            rbs_version: '3.6.1'
+          - ruby-version: '3.2'
+            rbs_version: '3.9.4'
+          - ruby-version: '3.3'
+            rbs_version: '4.0.0.dev.4'
+
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby


### PR DESCRIPTION
This takes out some lower value combinations - ideally we could keep the number of jobs to <= 20, which is the max that GHA will run simultaneously here.