### PR TITLE
Support Bundler 4

### DIFF
--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency 'ast', '~> 2.4.3'
   s.add_runtime_dependency 'backport', '~> 1.2'
   s.add_runtime_dependency 'benchmark', '~> 0.4'
-  s.add_runtime_dependency 'bundler', '~> 2.0'
+  s.add_runtime_dependency 'bundler', '>= 2.0'
   s.add_runtime_dependency 'diff-lcs', '~> 1.4'
   s.add_runtime_dependency 'jaro_winkler', '~> 1.6', '>= 1.6.1'
   s.add_runtime_dependency 'kramdown', '~> 2.3'


### PR DESCRIPTION
Installing with Bundler 4.0.2 fails with this error:
```sh
$ bundle update --all
Fetching gem metadata from https://rubygems.org/.........
Resolving dependencies...
Could not find compatible versions

Because every version of solargraph depends on bundler ~> 2.0
  and the current Bundler version (4.0.2) does not satisfy bundler ~> 2.0,
  solargraph cannot be used.
So, because Gemfile depends on solargraph >= 0,
  version solving has failed.

Your bundle requires a different version of Bundler than the one you're running.
Install the necessary version with `gem install bundler:2.7.2` and rerun bundler using `bundle _2.7.2_ update --all`
```
To fix, just make the upper bound less strict by using `>=` instead of `~>`