### PR TITLE
Use rbs 3.9.5 in tests

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -32,6 +32,8 @@ jobs:
           # Missing require in 'rbs collection update' - hopefully
           # fixed in next RBS release
           - ruby-version: '4.0'
+            rbs-version: '3.6.1'
+          - ruby-version: '4.0'
             rbs-version: '4.0.0.dev.4'
     steps:
     - uses: actions/checkout@v3


### PR DESCRIPTION
RBS 3.9.5 adds a missing `require 'fileutils'` that caused problems in some environments.