### PR TITLE
Raise InvalidOffsetError for offsets > text

### DIFF
--- a/lib/solargraph/position.rb
+++ b/lib/solargraph/position.rb
@@ -53,27 +53,27 @@ module Solargraph
 
     # Get a numeric offset for the specified text and position.
     #
+    #
     # @param text [String]
     # @param position [Position]
     # @return [Integer]
     def self.to_offset text, position
       return 0 if text.empty?
-      newline_index = -1
-      cursor = 0
-      line = -1
 
+      newline_index = -1
+      line = -1
       last_line_index = 0
+
       while (newline_index = text.index("\n", newline_index + 1)) && line <= position.line
         line += 1
         break if line == position.line
+
         line_length = newline_index - last_line_index
-
-        cursor += line_length.zero? ? 1 : line_length
-
         last_line_index = newline_index
       end
 
-      cursor + position.character
+      last_line_index += 1 if position.line > 0
+      last_line_index + position.character
     end
 
     # Get a numeric offset for the specified text and a position identified

--- a/lib/solargraph/position.rb
+++ b/lib/solargraph/position.rb
@@ -53,7 +53,6 @@ module Solargraph
 
     # Get a numeric offset for the specified text and position.
     #
-    #
     # @param text [String]
     # @param position [Position]
     # @return [Integer]
@@ -88,6 +87,8 @@ module Solargraph
     end
 
     # Get a position for the specified text and offset.
+    #
+    # @raise [InvalidOffsetError] if the offset is outside the text range
     #
     # @param text [String]
     # @param offset [Integer]

--- a/lib/solargraph/position.rb
+++ b/lib/solargraph/position.rb
@@ -93,7 +93,7 @@ module Solargraph
     # @param offset [Integer]
     # @return [Position]
     def self.from_offset text, offset
-     raise InvalidOffsetError if offset > text.length
+      raise InvalidOffsetError if offset > text.length
 
       cursor = 0
       line = 0

--- a/lib/solargraph/position.rb
+++ b/lib/solargraph/position.rb
@@ -93,6 +93,8 @@ module Solargraph
     # @param offset [Integer]
     # @return [Position]
     def self.from_offset text, offset
+     raise InvalidOffsetError if offset > text.length
+
       cursor = 0
       line = 0
       character = offset

--- a/spec/position_spec.rb
+++ b/spec/position_spec.rb
@@ -18,6 +18,7 @@ describe Solargraph::Position do
     expect(Solargraph::Position.to_offset(text, Solargraph::Position.new(0, 4))).to eq(4)
     expect(Solargraph::Position.to_offset(text, Solargraph::Position.new(2, 12))).to eq(29)
     expect(Solargraph::Position.to_offset(text, Solargraph::Position.new(2, 27))).to eq(44)
+    expect(Solargraph::Position.to_offset(text, Solargraph::Position.new(3, 8))).to eq(58)
   end
 
   it 'constructs position from offset' do
@@ -32,5 +33,11 @@ describe Solargraph::Position do
     expect {
       Solargraph::Position.normalize('0, 1')
     }.to raise_error(ArgumentError)
+  end
+
+  it 'avoids fencepost errors' do
+    text = "      class Foo\n        def bar baz, boo = 'boo'\n        end\n      end\n    "
+    offset = Solargraph::Position.to_offset(text, Solargraph::Position.new(3, 6))
+    expect(offset).to eq(67)
   end
 end

--- a/spec/position_spec.rb
+++ b/spec/position_spec.rb
@@ -40,4 +40,10 @@ describe Solargraph::Position do
     offset = Solargraph::Position.to_offset(text, Solargraph::Position.new(3, 6))
     expect(offset).to eq(67)
   end
+
+  it 'avoids fencepost errors with multiple blank lines' do
+    text = "      class Foo\n        def bar baz, boo = 'boo'\n\n        end\n      end\n    "
+    offset = Solargraph::Position.to_offset(text, Solargraph::Position.new(4, 6))
+    expect(offset).to eq(68)
+  end
 end


### PR DESCRIPTION
`Position.from_offset` needs to raise `InvalidOffsetError` when the offset is greater than the length of the text.

This fixes a regression bug introduced by a conflict between #1054 and #1105.