### PR TITLE
Work around erb bundle problem with RBS pre-release

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,5 +1,3 @@
-# https://github.com/ruby/rbs/pull/2833
-
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support
@@ -72,10 +70,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        # see https://github.com/castwide/solargraph/actions/runs/19391419903/job/55485410493?pr=1119
-        #
-        # match version in Gemfile.lock and use same version below
-        bundler: 2.5.23
         bundler-cache: false
     - name: Set rbs version
       run: echo "gem 'rbs', '${{ matrix.rbs-version }}'" >> .Gemfile
@@ -87,7 +81,7 @@ jobs:
       run: echo "gem 'tsort'" >> .Gemfile
     - name: Install gems
       run: |
-        bundle _2.5.23_ install
+        bundle install
         bundle update rbs # use latest available for this Ruby version
     - name: Update types
       run: bundle exec rbs collection update
@@ -105,10 +99,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.4'
-        # see https://github.com/castwide/solargraph/actions/runs/19391419903/job/55485410493?pr=1119
-        #
-        # match version in Gemfile.lock and use same version below
-        bundler: 2.5.23
         bundler-cache: false
     - name: Install gems
       run: bundle install

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -1,3 +1,5 @@
+# https://github.com/ruby/rbs/pull/2833
+
 # This workflow uses actions that are not certified by GitHub.
 # They are provided by a third-party and are governed by
 # separate terms of service, privacy policy, and support

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -70,7 +70,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby-version }}
-        bundler-cache: false
+        bundler-cache: true
     - name: Set rbs version
       run: echo "gem 'rbs', '${{ matrix.rbs-version }}'" >> .Gemfile
     #  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.5.0+2/gems/rbs-3.9.4/lib/rbs.rb:11:
@@ -79,9 +79,8 @@ jobs:
     #    starting from Ruby 3.6.0
     - name: Work around legacy rbs deprecation on ruby > 3.4
       run: echo "gem 'tsort'" >> .Gemfile
-    - name: Install gems
+    - name: Update gems
       run: |
-        bundle install
         bundle update rbs # use latest available for this Ruby version
     - name: Update types
       run: bundle exec rbs collection update
@@ -99,9 +98,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.4'
-        bundler-cache: false
-    - name: Install gems
-      run: bundle install
+        bundler-cache: true
     - name: Update types
       run: bundle exec rbs collection update
     - name: Run tests


### PR DESCRIPTION
https://github.com/castwide/solargraph/actions/runs/21547640233/job/62091456310?pr=1168 is now happening with the latest RBS pre-release, which seems to be reproducing:
* https://github.com/ruby/rbs/pull/2833

Removing some of our previous bundler workarounds and using the setup-ruby action to install the bundler both seems to work around the issue as well as give us faster builds by caching the bundle install step.