### PR TITLE
Allow vernier gem to be used optionally, but don't require it

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -37,6 +37,9 @@ jobs:
       - name: Update to best available RBS
         run: |
           bundle update --pre rbs # use latest available for this Ruby version
+          # Add optional gem to be able to typecheck related code
+          echo "gem 'vernier', '>1.0', '<2'" >> .Gemfile
+          bundle install
 
       - name: Restore cache of gem annotations
         id: dot-cache-restore

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -33,6 +33,8 @@ jobs:
       run: |
         echo 'gem "solargraph-rails"' > .Gemfile
         echo 'gem "solargraph-rspec"' >> .Gemfile
+        # Add optional gem to be able to typecheck related code
+        echo "gem 'vernier', '>1.0', '<2'" >> .Gemfile
         bundle install
         bundle update --pre rbs
     - name: Configure to use plugins
@@ -65,6 +67,8 @@ jobs:
     - name: Install gems
       run: |
         echo 'gem "solargraph-rails"' > .Gemfile
+        # Add optional gem to be able to typecheck related code
+        echo "gem 'vernier', '>1.0', '<2'" >> .Gemfile
         bundle install
         bundle update --pre rbs
     - name: Configure to use plugins
@@ -94,6 +98,8 @@ jobs:
     - name: Install gems
       run: |
         echo 'gem "solargraph-rspec"' >> .Gemfile
+        # Add optional gem to be able to typecheck related code
+        echo "gem 'vernier', '>1.0', '<2'" >> .Gemfile
         bundle install
         bundle update --pre rbs
     - name: Configure to use plugins

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -31,6 +31,8 @@ jobs:
         bundler-cache: false
     - name: Install gems
       run: |
+        # Add optional gem to be able to typecheck related code
+        echo "gem 'vernier', '>1.0', '<2'" >> .Gemfile
         bundle install
         bundle update --pre rbs # use latest available for this Ruby version
     - name: Install gem types

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -69,6 +69,11 @@ Metrics/ParameterLists:
 Style/ClassVars:
   Enabled: false
 
+# Allow $stderr.puts for communication with users as 'warn' can be
+# suppressed for unrelated reasons.
+Style/StderrPuts:
+  Enabled: false
+
 #
 # Set a relaxed standard on harder-to-address item for ease of
 # contribution - if you are good at refactoring, we welcome PRs to

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -376,7 +376,7 @@ module Solargraph
       begin
         require 'vernier'
       rescue LoadError
-        $stderr.puts 'vernier gem not found. Add this line to your .Gemfile and run `bundle install` to use this command:'
+        $stderr.puts 'vernier gem not found. Please install this dependency:'
         $stderr.puts
         $stderr.puts "  gem 'vernier', '>1.0', '<2'"
 

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -376,7 +376,10 @@ module Solargraph
       begin
         require 'vernier'
       rescue LoadError
-        warn 'vernier gem not found. Install with: gem install vernier'
+        $stderr.puts 'vernier gem not found. Add this line to your .Gemfile and run `bundle install` to use this command:'
+        $stderr.puts
+        $stderr.puts "  gem 'vernier', '>1.0', '<2'"
+
         return
       end
 

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -71,7 +71,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'simplecov', '~> 0.21'
   s.add_development_dependency 'simplecov-lcov', '~> 0.8'
   s.add_development_dependency 'undercover', '~> 0.7'
-  s.add_development_dependency 'vernier', '< 2'
   s.add_development_dependency 'webmock', '~> 3.6'
   # work around missing yard dependency needed as of Ruby 3.5
   s.add_development_dependency 'irb', '~> 1.15'


### PR DESCRIPTION
Ensures solargraph can still be used on the Microsoft Windows platform