### PR TITLE
Ignore workspace dependencies in cache processes

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -178,6 +178,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         # solargraph-rails supports Ruby 3.0+
+        # This job uses 3.2 due to a problem compiling sqlite3 in earlier versions
         ruby-version: '3.2'
         bundler-cache: false
         bundler: latest

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -31,7 +31,6 @@ jobs:
         version: 1.0
     - name: Install gems
       run: |
-        gem update --system
         echo 'gem "solargraph-rails"' > .Gemfile
         echo 'gem "solargraph-rspec"' >> .Gemfile
         bundle install
@@ -63,7 +62,6 @@ jobs:
         version: 1.0
     - name: Install gems
       run: |
-        gem update --system
         echo 'gem "solargraph-rails"' > .Gemfile
         bundle install
         bundle update rbs
@@ -93,7 +91,6 @@ jobs:
         version: 1.0
     - name: Install gems
       run: |
-        gem update --system
         echo 'gem "solargraph-rspec"' >> .Gemfile
         bundle install
         bundle update rbs
@@ -128,7 +125,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: '3.1'
+        ruby-version: '3.2'
         rubygems: latest
         bundler-cache: false
     - name: Install gems
@@ -136,7 +133,6 @@ jobs:
        set -x
 
        cd ../solargraph-rspec
-       gem update --system
        echo "gem 'solargraph', path: '../solargraph'" >> Gemfile
        bundle config path ${{ env.BUNDLE_PATH }}
        bundle install --jobs 4 --retry 3
@@ -148,11 +144,11 @@ jobs:
        #   3.5.0, but your Gemfile requires date 3.4.1. Prepending
        #   `bundle exec` to your command may solve
        #   this. (Gem::LoadError)
-       bundle exec appraisal update date
+       #bundle exec appraisal update date
        # For some reason on ruby 3.1 it defaults to an old version: 1.3.2
        # https://github.com/lekemula/solargraph-rspec/actions/runs/17814581205/job/50645370316?pr=22
        # We update manually to the latest
-       bundle exec appraisal update rspec-rails
+       #bundle exec appraisal update rspec-rails
     - name: Configure .solargraph.yml
       run: |
         cd ../solargraph-rspec
@@ -182,7 +178,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         # solargraph-rails supports Ruby 3.0+
-        ruby-version: '3.0'
+        ruby-version: '3.2'
         bundler-cache: false
         bundler: latest
       env:
@@ -190,7 +186,6 @@ jobs:
     - name: Install gems
       run: |
        set -x
-       gem update --system
        BUNDLE_PATH="${GITHUB_WORKSPACE:?}/vendor/bundle"
        export BUNDLE_PATH
        cd ../solargraph-rails

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -31,6 +31,7 @@ jobs:
         version: 1.0
     - name: Install gems
       run: |
+        gem update --system
         echo 'gem "solargraph-rails"' > .Gemfile
         echo 'gem "solargraph-rspec"' >> .Gemfile
         bundle install
@@ -62,6 +63,7 @@ jobs:
         version: 1.0
     - name: Install gems
       run: |
+        gem update --system
         echo 'gem "solargraph-rails"' > .Gemfile
         bundle install
         bundle update rbs
@@ -91,6 +93,7 @@ jobs:
         version: 1.0
     - name: Install gems
       run: |
+        gem update --system
         echo 'gem "solargraph-rspec"' >> .Gemfile
         bundle install
         bundle update rbs
@@ -133,6 +136,7 @@ jobs:
        set -x
 
        cd ../solargraph-rspec
+       gem update --system
        echo "gem 'solargraph', path: '../solargraph'" >> Gemfile
        bundle config path ${{ env.BUNDLE_PATH }}
        bundle install --jobs 4 --retry 3
@@ -186,6 +190,7 @@ jobs:
     - name: Install gems
       run: |
        set -x
+       gem update --system
        BUNDLE_PATH="${GITHUB_WORKSPACE:?}/vendor/bundle"
        export BUNDLE_PATH
        cd ../solargraph-rails

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -144,11 +144,11 @@ jobs:
        #   3.5.0, but your Gemfile requires date 3.4.1. Prepending
        #   `bundle exec` to your command may solve
        #   this. (Gem::LoadError)
-       #bundle exec appraisal update date
+       bundle exec appraisal update date
        # For some reason on ruby 3.1 it defaults to an old version: 1.3.2
        # https://github.com/lekemula/solargraph-rspec/actions/runs/17814581205/job/50645370316?pr=22
        # We update manually to the latest
-       #bundle exec appraisal update rspec-rails
+       bundle exec appraisal update rspec-rails
     - name: Configure .solargraph.yml
       run: |
         cd ../solargraph-rspec

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -111,10 +111,10 @@ module Solargraph
         PinCache.serialize_yard_gem(gemspec, pins)
       end
 
-      if options[:rebuild] || !PinCache.has_rbs_collection?(gemspec)
-        rbs_map = RbsMap.from_gemspec(gemspec, nil, nil)
-        pins = rbs_map.pins
-        rbs_version_cache_key = rbs_map.cache_key
+      rbs_map = RbsMap.from_gemspec(gemspec, nil, nil)
+      pins = rbs_map.pins
+      rbs_version_cache_key = rbs_map.cache_key
+      if options[:rebuild] || !PinCache.has_rbs_collection?(gemspec, rbs_version_cache_key)
         # cache pins even if result is zero, so we don't retry building pins
         pins ||= []
         PinCache.serialize_rbs_collection_gem(gemspec, rbs_version_cache_key, pins)

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -104,9 +104,21 @@ module Solargraph
     # @param gem [String]
     # @param version [String, nil]
     def cache gem, version = nil
-      api_map = Solargraph::ApiMap.load(Dir.pwd)
-      spec = Gem::Specification.find_by_name(gem, version)
-      api_map.cache_gem(spec, rebuild: options[:rebuild], out: $stdout)
+      gemspec = Gem::Specification.find_by_name(gem, version)
+
+      if options[:rebuild] || !PinCache.has_yard?(gemspec)
+        pins = GemPins.build_yard_pins(['yard-activesupport-concern'], gemspec)
+        PinCache.serialize_yard_gem(gemspec, pins)
+      end
+
+      if options[:rebuild] || !PinCache.has_rbs_collection?(gemspec)
+        rbs_map = RbsMap.from_gemspec(gemspec, nil, nil)
+        pins = rbs_map.pins
+        rbs_version_cache_key = rbs_map.cache_key
+        # cache pins even if result is zero, so we don't retry building pins
+        pins ||= []
+        PinCache.serialize_rbs_collection_gem(gemspec, rbs_version_cache_key, pins)
+      end
     end
 
     desc 'uncache GEM [...GEM]', "Delete specific cached gem documentation"

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -111,13 +111,12 @@ module Solargraph
         PinCache.serialize_yard_gem(gemspec, pins)
       end
 
-      rbs_map = RbsMap.from_gemspec(gemspec, nil, nil)
-      pins = rbs_map.pins
-      rbs_version_cache_key = rbs_map.cache_key
-      if options[:rebuild] || !PinCache.has_rbs_collection?(gemspec, rbs_version_cache_key)
+      workspace = Solargraph::Workspace.new(Dir.pwd)
+      rbs_map = RbsMap.from_gemspec(gemspec, workspace.rbs_collection_path, workspace.rbs_collection_config_path)
+      if options[:rebuild] || !PinCache.has_rbs_collection?(gemspec, rbs_map.cache_key)
         # cache pins even if result is zero, so we don't retry building pins
-        pins ||= []
-        PinCache.serialize_rbs_collection_gem(gemspec, rbs_version_cache_key, pins)
+        pins = rbs_map.pins || []
+        PinCache.serialize_rbs_collection_gem(gemspec, rbs_map.cache_key, pins)
       end
     end
 


### PR DESCRIPTION
ref #1169 

The `solargraph cache` command should not depend on workspace maps to cache gems.