### PR TITLE
Handle runtime without bundle

### DIFF
--- a/lib/solargraph/workspace/gemspecs.rb
+++ b/lib/solargraph/workspace/gemspecs.rb
@@ -219,6 +219,8 @@ module Solargraph
 
       # @sg-ignore need boolish support for ? methods
       def in_this_bundle?
+        return false unless ENV.key?('BUNDLE_GEMFILE')
+
         Bundler.definition&.lockfile&.to_s&.start_with?(directory)
       end
 


### PR DESCRIPTION
`Workspace::Gemspecs` throws errors if it tries to find required gemspecs without a configured bundle. This can occur in any use case where the `solargraph` executable is not running in a bundled environment, regardless of whether the workspace itself has a bundler configuration.