### PR TITLE
Ensure pathname is required for rbs in shell caching processes

### DIFF
--- a/lib/solargraph/pin_cache.rb
+++ b/lib/solargraph/pin_cache.rb
@@ -1,5 +1,6 @@
 require 'yard-activesupport-concern'
 require 'fileutils'
+require 'pathname' # @todo Required by RBS but not loaded in some use cases
 require 'rbs'
 
 module Solargraph

--- a/spec/shell_spec.rb
+++ b/spec/shell_spec.rb
@@ -294,8 +294,8 @@ describe Solargraph::Shell do
       it 'succeeds' do
         Dir.mktmpdir do |tmpdir|
           File.write(File.join(tmpdir, 'test.rb'), 'foo')
-          _o, _e, s = Open3.capture3(unbundled_env, 'ruby', command_path, 'cache', 'rspec', chdir: tmpdir)
-          expect(s).to be_success
+          _o, e, s = Open3.capture3(unbundled_env, 'ruby', command_path, 'cache', 'rspec', chdir: tmpdir)
+          expect(s).to be_success, "expected success, got error with message #{e.inspect}"
         end
       end
     end
@@ -304,8 +304,8 @@ describe Solargraph::Shell do
       it 'succeeds' do
         Dir.mktmpdir do |tmpdir|
           File.write(File.join(tmpdir, 'test.rb'), 'foo')
-          _o, _e, s = Open3.capture3(unbundled_env, 'ruby', command_path, 'gems', 'rspec', chdir: tmpdir)
-          expect(s).to be_success
+          _o, e, s = Open3.capture3(unbundled_env, 'ruby', command_path, 'gems', 'rspec', chdir: tmpdir)
+          expect(s).to be_success, "expected success, got error with message #{e.inspect}"
         end
       end
     end


### PR DESCRIPTION
Requiring rbs from `PinCache` can result in an error due to pathname not being loaded in certain use cases, particularly when caching gems from shell commands in unbundled environments. The quick workaround is to `require 'pathname'` explicitly.