### PR TITLE
Limit default include glob to current directory

### DIFF
--- a/lib/solargraph/workspace/config.rb
+++ b/lib/solargraph/workspace/config.rb
@@ -168,7 +168,7 @@ module Solargraph
       # @return [Hash{String => Array, Hash, Integer}]
       def default_config
         {
-          'include' => ['Rakefile', 'Gemfile', '*.gemspec', '**/*.rb'],
+          'include' => ['Rakefile', 'Gemfile', '*.gemspec', './**/*.rb'],
           'exclude' => ['spec/**/*', 'test/**/*', 'vendor/**/*', '.bundle/**/*'],
           'require' => [],
           'domains' => [],


### PR DESCRIPTION
Since the workspace config's includes are now capable of including paths outside of the current workspace, the default include glob `**/*.rb` is too broad. Change it to `./**/*.rb` to ensure that its default behavior includes the current workspace only.