### PR TITLE
Stub combine_same_type_arity_signatures

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -361,3 +361,6 @@ YARD/TagTypeSyntax:
 # URISchemes: http, https
 Layout/LineLength:
   Max: 224
+
+Naming/BlockForwarding:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.59.0 - May 12, 2026
+## 0.59.0 - May 13, 2026
 - Ensure pathname is required for rbs in shell caching processes (#1183)
 - Pre-release branch 2026-01-12 (#1152)
 - 2026-01-27 dev branch (#1165)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - Limit default include glob to current directory (#1184) 
 - Require Ruby >= 3.1.0
 - Require RBS >= 3.10.0
+- Stub combine_same_type_arity_signatures (#1186)
 
 ## 0.58.3 - March 9, 2026
 - Ignore workspace dependencies in cache processes (#1174)

--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -344,7 +344,7 @@ module Solargraph
     end
 
     # @param gemspec [Gem::Specification]
-    # @param version [Gem::Version]
+    # @param version [Gem::Version, String]
     # @return [Gem::Specification]
     def change_gemspec_version gemspec, version
       Gem::Specification.find_by_name(gemspec.name, "= #{version}")

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -505,6 +505,9 @@ module Solargraph
       #
       # @return [Array<Pin::Signature>]
       def combine_same_type_arity_signatures same_type_arity_signatures
+        # @todo Stubbing this method while we debug an infinite loop bug in Ruby 3.x
+        return same_type_arity_signatures
+
         # This is an O(n^2) operation, so bail out if n is not small
         return same_type_arity_signatures if same_type_arity_signatures.length > 10
 

--- a/lib/solargraph/source_map/mapper.rb
+++ b/lib/solargraph/source_map/mapper.rb
@@ -224,7 +224,6 @@ module Solargraph
           # @sg-ignore flow sensitive typing should be able to handle redefinition
           namespace.domains.concat directive.tag.types unless directive.tag.types.nil?
         when 'override'
-          # @sg-ignore Need to add nil check here
           pins.push Pin::Reference::Override.new(location, directive.tag.name, docstring.tags,
                                                  source: :source_map)
         when 'macro'

--- a/spec/pin/combine_with_spec.rb
+++ b/spec/pin/combine_with_spec.rb
@@ -8,7 +8,7 @@ describe Solargraph::Pin::Base, '#combine_with' do
     expect(combined.return_type.to_s).to eq('String, Integer')
   end
 
-  it 'combines return types with another method without type parameters' do
+  xit 'combines return types with another method without type parameters' do
     pin1 = Solargraph::Pin::Method.new(name: 'foo', parameters: [], comments: '@return [Array<String>]')
     pin2 = Solargraph::Pin::Method.new(name: 'foo', parameters: [], comments: '@return [Array]')
     combined = pin1.combine_with(pin2)
@@ -28,12 +28,12 @@ describe Solargraph::Pin::Base, '#combine_with' do
 
     let(:normal_pin) { Solargraph::Pin::Method.new(name: 'foo', parameters: [], comments: '@return [self]') }
 
-    it 'combines a dodgy return type with a valid one' do
+    xit 'combines a dodgy return type with a valid one' do
       combined = dodgy_location_pin.combine_with(normal_pin)
       expect(combined.return_type.to_s).to eq('self')
     end
 
-    it 'combines a valid return type with a dodgy one' do
+    xit 'combines a valid return type with a dodgy one' do
       combined = normal_pin.combine_with(dodgy_location_pin)
       expect(combined.return_type.to_s).to eq('self')
     end
@@ -54,12 +54,12 @@ describe Solargraph::Pin::Base, '#combine_with' do
 
     let(:selfy_pin) { Solargraph::Pin::Method.new(name: 'foo', closure: closure, parameters: [], comments: '@return [self]') }
 
-    it 'combines a selfy return type with a likely-selfy one' do
+    xit 'combines a selfy return type with a likely-selfy one' do
       combined = likely_selfy_pin.combine_with(selfy_pin)
       expect(combined.return_type.to_s).to eq('self')
     end
 
-    it 'combines a likely-selfy return type with a selfy one' do
+    xit 'combines a likely-selfy return type with a selfy one' do
       combined = selfy_pin.combine_with(likely_selfy_pin)
       expect(combined.return_type.to_s).to eq('self')
     end

--- a/spec/pin/combine_with_spec.rb
+++ b/spec/pin/combine_with_spec.rb
@@ -9,7 +9,7 @@ describe Solargraph::Pin::Base, '#combine_with' do
   end
 
   it 'combines return types with another method without type parameters' do
-    pending "See Pin::Method#combine_same_type_arity_signatures"
+    pending 'See Pin::Method#combine_same_type_arity_signatures'
     pin1 = Solargraph::Pin::Method.new(name: 'foo', parameters: [], comments: '@return [Array<String>]')
     pin2 = Solargraph::Pin::Method.new(name: 'foo', parameters: [], comments: '@return [Array]')
     combined = pin1.combine_with(pin2)
@@ -30,13 +30,13 @@ describe Solargraph::Pin::Base, '#combine_with' do
     let(:normal_pin) { Solargraph::Pin::Method.new(name: 'foo', parameters: [], comments: '@return [self]') }
 
     it 'combines a dodgy return type with a valid one' do
-      pending "See Pin::Method#combine_same_type_arity_signatures"
+      pending 'See Pin::Method#combine_same_type_arity_signatures'
       combined = dodgy_location_pin.combine_with(normal_pin)
       expect(combined.return_type.to_s).to eq('self')
     end
 
     it 'combines a valid return type with a dodgy one' do
-      pending "See Pin::Method#combine_same_type_arity_signatures"
+      pending 'See Pin::Method#combine_same_type_arity_signatures'
       combined = normal_pin.combine_with(dodgy_location_pin)
       expect(combined.return_type.to_s).to eq('self')
     end
@@ -58,13 +58,13 @@ describe Solargraph::Pin::Base, '#combine_with' do
     let(:selfy_pin) { Solargraph::Pin::Method.new(name: 'foo', closure: closure, parameters: [], comments: '@return [self]') }
 
     it 'combines a selfy return type with a likely-selfy one' do
-      pending "See Pin::Method#combine_same_type_arity_signatures"
+      pending 'See Pin::Method#combine_same_type_arity_signatures'
       combined = likely_selfy_pin.combine_with(selfy_pin)
       expect(combined.return_type.to_s).to eq('self')
     end
 
     it 'combines a likely-selfy return type with a selfy one' do
-      pending "See Pin::Method#combine_same_type_arity_signatures"
+      pending 'See Pin::Method#combine_same_type_arity_signatures'
       combined = selfy_pin.combine_with(likely_selfy_pin)
       expect(combined.return_type.to_s).to eq('self')
     end

--- a/spec/pin/combine_with_spec.rb
+++ b/spec/pin/combine_with_spec.rb
@@ -8,7 +8,8 @@ describe Solargraph::Pin::Base, '#combine_with' do
     expect(combined.return_type.to_s).to eq('String, Integer')
   end
 
-  xit 'combines return types with another method without type parameters' do
+  it 'combines return types with another method without type parameters' do
+    pending "See Pin::Method#combine_same_type_arity_signatures"
     pin1 = Solargraph::Pin::Method.new(name: 'foo', parameters: [], comments: '@return [Array<String>]')
     pin2 = Solargraph::Pin::Method.new(name: 'foo', parameters: [], comments: '@return [Array]')
     combined = pin1.combine_with(pin2)
@@ -28,12 +29,14 @@ describe Solargraph::Pin::Base, '#combine_with' do
 
     let(:normal_pin) { Solargraph::Pin::Method.new(name: 'foo', parameters: [], comments: '@return [self]') }
 
-    xit 'combines a dodgy return type with a valid one' do
+    it 'combines a dodgy return type with a valid one' do
+      pending "See Pin::Method#combine_same_type_arity_signatures"
       combined = dodgy_location_pin.combine_with(normal_pin)
       expect(combined.return_type.to_s).to eq('self')
     end
 
-    xit 'combines a valid return type with a dodgy one' do
+    it 'combines a valid return type with a dodgy one' do
+      pending "See Pin::Method#combine_same_type_arity_signatures"
       combined = normal_pin.combine_with(dodgy_location_pin)
       expect(combined.return_type.to_s).to eq('self')
     end
@@ -54,12 +57,14 @@ describe Solargraph::Pin::Base, '#combine_with' do
 
     let(:selfy_pin) { Solargraph::Pin::Method.new(name: 'foo', closure: closure, parameters: [], comments: '@return [self]') }
 
-    xit 'combines a selfy return type with a likely-selfy one' do
+    it 'combines a selfy return type with a likely-selfy one' do
+      pending "See Pin::Method#combine_same_type_arity_signatures"
       combined = likely_selfy_pin.combine_with(selfy_pin)
       expect(combined.return_type.to_s).to eq('self')
     end
 
-    xit 'combines a likely-selfy return type with a selfy one' do
+    it 'combines a likely-selfy return type with a selfy one' do
+      pending "See Pin::Method#combine_same_type_arity_signatures"
       combined = selfy_pin.combine_with(likely_selfy_pin)
       expect(combined.return_type.to_s).to eq('self')
     end


### PR DESCRIPTION
This functionality needs to be stubbed while we debug an infinite loop bug in Ruby 3.x.