### PR TITLE
YARD macros - More typecheck fixes

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -107,6 +107,7 @@ module Solargraph
     # @return [self]
     def catalog bench
       @source_map_hash = bench.source_map_hash
+      # @type [Array<Pin::Base>]
       iced_pins = bench.icebox.flat_map(&:pins)
       live_pins = bench.live_map&.all_pins || []
       conventions_environ.clear
@@ -143,7 +144,9 @@ module Solargraph
       pins_with_macros.each do |pin_with_macro|
         dsl_method_sends.select { |dsl_method_send| dsl_method_send.matches?(pin_with_macro) }.each do |dsl_method_send|
           ref = dsl_method_send.location
-          source_map = source_map_hash[ref.filename]
+          next unless ref
+          source_map = source_map_hash[ref.filename.to_s]
+          next unless source_map
           pin_with_macro.macros.each do |macro|
             macro_pins += macro.generate_pins_from(dsl_method_send, source_map)
           end

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -176,7 +176,7 @@ module Solargraph
         result
       end
 
-      # @return [Hash{String => YARD::Tags::MacroDirective}]
+      # @return [Hash{String => YardMap::Macro}]
       def named_macros
         @named_macros ||= begin
           result = {}

--- a/lib/solargraph/parser/parser_gem/node_methods.rb
+++ b/lib/solargraph/parser/parser_gem/node_methods.rb
@@ -104,6 +104,8 @@ module Solargraph
         # Convert a DSL method call argument with directly inferrable simple params.
         # @param node [Parser::AST::Node]
         # @return [String, Integer, Float, Symbol, Array, Hash, Source::Chain, nil]
+        # @sg-ignore "does not match inferred type ::String, ::Parser::AST::Node" - this probably comes from the
+        # `.children[0]` call, which is not recognized as returning a literal value.
         def simple_convert node
           return nil unless Parser.is_ast_node?(node)
 

--- a/lib/solargraph/parser/parser_gem/node_processors/send_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/send_node.rb
@@ -307,17 +307,19 @@ module Solargraph
           # @param method_name [Symbol]
           # @return [void]
           def process_dsl_method method_name
+            # @type [Array<Pin::Ephemeral::ClassMethodSend::ArgumentValue>]
+            # @sg-ignore .map return type could not be inferred properly
+            arguments = node.children[2..]&.map do |a|
+              Pin::Ephemeral::ClassMethodSend::ArgumentValue.new(value: simple_convert(a))
+            end || []
+
             pins.push Pin::Ephemeral::ClassMethodSend.new(
               location: get_node_location(node),
               closure: region.closure,
               name: method_name.to_s,
               code: region.source.code_for(node),
               comments: comments_for(node).to_s,
-              arguments: node.children[2..].map do |a|
-                Solargraph::Pin::Ephemeral::ClassMethodSend::ArgumentValue.new(
-                  value: simple_convert(a)
-                )
-              end,
+              arguments: arguments,
               source: :parser
             )
           end

--- a/lib/solargraph/pin/common.rb
+++ b/lib/solargraph/pin/common.rb
@@ -80,7 +80,7 @@ module Solargraph
         here = closure
         until here.nil?
           yield here
-          here = here.closure
+          here = here&.closure
         end
       end
 

--- a/lib/solargraph/pin/ephemeral/class_method_send.rb
+++ b/lib/solargraph/pin/ephemeral/class_method_send.rb
@@ -17,7 +17,7 @@ module Solargraph
 
         # @param name [String] - name of the method called
         # @param comments [String] - comments above the method call
-        # @param arguments [Array<Argument>] - arguments of the method
+        # @param arguments [Array<ArgumentValue>] - arguments of the method
         # @param code [String] - code of the method call
         # @param closure [Solargraph::Pin::Closure, nil]
         # @param [Hash{Symbol => Object}] splat - forwarded to Pin::Base (e.g. :location, :source)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -198,13 +198,7 @@ module Solargraph
         # @return [Pin::Base]
         def process_macro pin, api_map, context, locals
           pin.macros.each do |macro|
-            # @todo 'Wrong argument type for
-            #   Solargraph::Source::Chain::Call#inner_process_macro:
-            #   macro expected YARD::Tags::MacroDirective, received
-            #   generic<Elem>' is because we lose 'rooted' information
-            #   in the 'Chain::Array' class internally, leaving
-            #   ::Array#each shadowed when it shouldn't be.
-            result = inner_process_macro(pin, macro, api_map, context, locals)
+            result = inner_process_macro(pin, macro.directive, api_map, context, locals)
             return result unless result.return_type.undefined?
           end
           Pin::ProxyType.anonymous(ComplexType::UNDEFINED, source: :chain)
@@ -219,7 +213,7 @@ module Solargraph
           pin.directives.each do |dir|
             macro = api_map.named_macro(dir.tag.name)
             next if macro.nil?
-            result = inner_process_macro(pin, macro, api_map, context, locals)
+            result = inner_process_macro(pin, macro.directive, api_map, context, locals)
             return result unless result.return_type.undefined?
           end
           Pin::ProxyType.anonymous ComplexType::UNDEFINED, source: :chain

--- a/lib/solargraph/yard_map/directives/attribute_directive.rb
+++ b/lib/solargraph/yard_map/directives/attribute_directive.rb
@@ -45,7 +45,7 @@ module Solargraph
             )
             new_pins.push(write_pin)
             write_pin.parameters.push Pin::Parameter.new(name: 'value', decl: :arg, closure: write_pin, source: :yard_map)
-            if write_pin.return_type.defined?
+            if write_pin.return_type&.defined?
               write_pin.docstring.add_tag YARD::Tags::Tag.new(:param, '', write_pin.return_type.to_s.split(', '), 'value')
             end
           end
@@ -57,7 +57,7 @@ module Solargraph
         # @param [Position] position
         # @return [Pin::Closure]
         def closure_at pins, position
-          pins.select { |pin| pin.is_a?(Pin::Closure) and pin.location.range.contain?(position) }.last
+          pins.select { |pin| pin.is_a?(Pin::Closure) and pin.location&.range&.contain?(position) }.last
         end
       end
     end

--- a/lib/solargraph/yard_map/directives/domain_directive.rb
+++ b/lib/solargraph/yard_map/directives/domain_directive.rb
@@ -20,9 +20,9 @@ module Solargraph
 
         # @param [Array<Pin::Base>] pins
         # @param [Position] position
-        # @return [Pin::Closure]
+        # @return [Pin::Namespace]
         def closure_at pins, position
-          pins.select { |pin| pin.is_a?(Pin::Closure) and pin.location.range.contain?(position) }.last
+          pins.select { |pin| pin.is_a?(Pin::Namespace) and pin.location&.range&.contain?(position) }.last
         end
       end
     end

--- a/lib/solargraph/yard_map/directives/method_directive.rb
+++ b/lib/solargraph/yard_map/directives/method_directive.rb
@@ -14,7 +14,8 @@ module Solargraph
         # @return [Array<Solargraph::Pin::Method>]
         def process_directive source, pins, source_position, comment_position, directive
           namespace = closure_at(pins, source_position) || pins.first
-          namespace = closure_at(pins, comment_position) if namespace.location.range.start.line < comment_position.line
+
+          namespace = closure_at(pins, comment_position) if namespace.location&.range&.start&.line&.< comment_position.line # rubocop:disable Style/SafeNavigationChainLength
           begin
             src = Solargraph::Source.load_string("def #{directive.tag.name};end", source.filename)
             region = Parser::Region.new(source: src, closure: namespace)
@@ -42,7 +43,7 @@ module Solargraph
         # @param [Position] position
         # @return [Pin::Closure]
         def closure_at pins, position
-          pins.select { |pin| pin.is_a?(Pin::Closure) and pin.location.range.contain?(position) }.last
+          pins.select { |pin| pin.is_a?(Pin::Closure) and pin.location&.range&.contain?(position) }.last
         end
       end
     end

--- a/lib/solargraph/yard_map/directives/override_directive.rb
+++ b/lib/solargraph/yard_map/directives/override_directive.rb
@@ -22,7 +22,7 @@ module Solargraph
         # @param [Position] position
         # @return [Pin::Closure]
         def closure_at pins, position
-          pins.select { |pin| pin.is_a?(Pin::Closure) and pin.location.range.contain?(position) }.last
+          pins.select { |pin| pin.is_a?(Pin::Closure) and pin.location&.range&.contain?(position) }.last
         end
       end
     end

--- a/lib/solargraph/yard_map/directives/parse_directive.rb
+++ b/lib/solargraph/yard_map/directives/parse_directive.rb
@@ -25,14 +25,17 @@ module Solargraph
                    comment_position.line
                  end
           Parser.process_node(src.node, region, pins_copy)
-          new_pins = pins_copy[old_pins_index..]
+          new_pins = pins_copy[old_pins_index..] || []
           new_pins.each do |p|
             # @todo Smelly instance variable access
+            next if p.location.nil?
+            # @sg-ignore Unresolved call to range on Solargraph::Location, nil - does not account for next clause above.
             p.location.range.start.instance_variable_set(:@line, p.location.range.start.line + loff)
+            # @sg-ignore Unresolved call to range on Solargraph::Location, nil
             p.location.range.ending.instance_variable_set(:@line, p.location.range.ending.line + loff)
           end
 
-          new_pins || []
+          new_pins
         rescue Parser::SyntaxError
           # @todo Handle parser errors in !parse directives
           []
@@ -42,7 +45,7 @@ module Solargraph
         # @param [Position] position
         # @return [Pin::Closure]
         def closure_at pins, position
-          pins.select { |pin| pin.is_a?(Pin::Closure) and pin.location.range.contain?(position) }.last
+          pins.select { |pin| pin.is_a?(Pin::Closure) and pin.location&.range&.contain?(position) }.last
         end
       end
     end

--- a/lib/solargraph/yard_map/directives/visibility_directive.rb
+++ b/lib/solargraph/yard_map/directives/visibility_directive.rb
@@ -22,9 +22,7 @@ module Solargraph
 
           name = directive.tag.name
           closure = closure_at(pins, source_position) || pins.first
-          if closure.location.range.start.line < comment_position.line
-            closure = closure_at(pins, comment_position)
-          end
+          closure = closure_at(pins, comment_position) if closure.location&.range&.start&.line&.< comment_position.line # rubocop:disable Style/SafeNavigationChainLength
           if closure.is_a?(Pin::Method) && no_empty_lines?(source.code, comment_position.line, source_position.line)
             # @todo Smelly instance variable access
             closure.instance_variable_set(:@visibility, kind)
@@ -54,7 +52,9 @@ module Solargraph
         # @param [Integer] line1
         # @param [Integer] line2
         # @return [Boolean]
+        # @sg-ignore return type could not be inferred
         def no_empty_lines? code, line1, line2
+          # @sg-ignore unresolved call none? on the array.
           code.lines[line1..line2].none? { |line| line.strip.empty? }
         end
 
@@ -62,7 +62,7 @@ module Solargraph
         # @param [Position] position
         # @return [Pin::Closure]
         def closure_at pins, position
-          pins.select { |pin| pin.is_a?(Pin::Closure) and pin.location.range.contain?(position) }.last
+          pins.select { |pin| pin.is_a?(Pin::Closure) and pin.location&.range&.contain?(position) }.last
         end
       end
     end

--- a/lib/solargraph/yard_map/macro.rb
+++ b/lib/solargraph/yard_map/macro.rb
@@ -12,7 +12,7 @@ module Solargraph
         def from_directive directive, method_pin
           macro_name = directive.tag.name.empty? ? method_pin.path.downcase : directive.tag.name
           method_object = method_object_from_pin(method_pin)
-          macro_object = YARD::CodeObjects::MacroObject.create(macro_name, directive.tag.text.to_s, method_object)
+          macro_object = YARD::CodeObjects::MacroObject.create(macro_name.to_s, directive.tag.text.to_s, method_object)
           new(macro_object, method_pin, directive)
         end
 
@@ -75,7 +75,7 @@ module Solargraph
         # @param generated_pins [Array<Pin::Base>]
         generate_yardoc_from(dsl_method_send).reduce([]) do |generated_pins, directive|
           directive_processor = YardMap::Directives.for(directive)
-          next generated_pins unless directive_processor
+          next generated_pins unless directive_processor && call_location
           generated_pins + directive_processor.process_directive(
             source_map.source, source_map.pins, call_location.range.start, call_location.range.start, directive
           )

--- a/lib/solargraph/yard_map/mapper.rb
+++ b/lib/solargraph/yard_map/mapper.rb
@@ -25,6 +25,7 @@ module Solargraph
         end
         # Some yardocs contain documentation for dependencies that can be
         # ignored here. The YardMap will load dependencies separately.
+        # @sg-ignore does not consider `pin.location.nil? || ` condition
         @pins.keep_if { |pin| pin.location.nil? || File.file?(pin.location.filename) } if @spec
         @pins
       end


### PR DESCRIPTION
Follow-up on https://github.com/castwide/solargraph/pull/1187. 

Fixes for https://github.com/castwide/solargraph/actions/runs/25907054191/job/76142689409?pr=1187

```
Errors on modified lines:
/home/runner/work/solargraph/solargraph/lib/solargraph/api_map.rb:129 - Unresolved call to is_a?
/home/runner/work/solargraph/solargraph/lib/solargraph/api_map.rb:146 - Unresolved call to filename
/home/runner/work/solargraph/solargraph/lib/solargraph/parser/parser_gem/node_methods.rb:107 - Declared return type ::String, ::Integer, ::Float, ::Symbol, ::Array, ::Hash, ::Solargraph::Source::Chain, nil does not match inferred type ::String, ::Parser::AST::Node, ::Array, ::Hash, ::Solargraph::Source::Chain, nil for Solargraph::Parser::ParserGem::NodeMethods.simple_convert
/home/runner/work/solargraph/solargraph/lib/solargraph/parser/parser_gem/node_methods.rb:107 - Declared return type ::String, ::Integer, ::Float, ::Symbol, ::Array, ::Hash, ::Solargraph::Source::Chain, nil does not match inferred type ::String, ::Parser::AST::Node, ::Array, ::Hash, ::Solargraph::Source::Chain, nil for Solargraph::Parser::ParserGem::NodeMethods#simple_convert
/home/runner/work/solargraph/solargraph/lib/solargraph/parser/parser_gem/node_processors/send_node.rb:316 - Unresolved call to map on Array<Parser::AST::Node>, nil
/home/runner/work/solargraph/solargraph/lib/solargraph/pin/common.rb:83 - Unresolved call to closure
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/attribute_directive.rb:48 - Unresolved call to defined? on Solargraph::ComplexType, nil
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/attribute_directive.rb:60 - Unresolved call to range on Solargraph::Location, nil
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/domain_directive.rb:17 - Unresolved call to domains
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/domain_directive.rb:25 - Unresolved call to range on Solargraph::Location, nil
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/method_directive.rb:17 - Unresolved call to range on Solargraph::Location, nil
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/method_directive.rb:45 - Unresolved call to range on Solargraph::Location, nil
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/override_directive.rb:25 - Unresolved call to range on Solargraph::Location, nil
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/parse_directive.rb:29 - Unresolved call to each
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/parse_directive.rb:45 - Unresolved call to range on Solargraph::Location, nil
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/visibility_directive.rb:25 - Unresolved call to range on Solargraph::Location, nil
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/visibility_directive.rb:57 - Solargraph::YardMap::Directives::VisibilityDirective.no_empty_lines? return type could not be inferred
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/visibility_directive.rb:57 - Solargraph::YardMap::Directives::VisibilityDirective#no_empty_lines? return type could not be inferred
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/visibility_directive.rb:58 - Unresolved call to none? on Array<String>, nil
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/directives/visibility_directive.rb:65 - Unresolved call to range on Solargraph::Location, nil
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/macro.rb:80 - Unresolved call to range
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/macro.rb:80 - Unresolved call to range
Errors on lines you didn't modify:
/home/runner/work/solargraph/solargraph/lib/solargraph/api_map.rb:182 - Declared return type ::Solargraph::YardMap::Macro, nil does not match inferred type ::YARD::Tags::MacroDirective for Solargraph::ApiMap#named_macro
/home/runner/work/solargraph/solargraph/lib/solargraph/source/chain/call.rb:207 - Wrong argument type for Solargraph::Source::Chain::Call#inner_process_macro: macro expected YARD::Tags::MacroDirective, received Solargraph::YardMap::Macro
/home/runner/work/solargraph/solargraph/lib/solargraph/source/chain/call.rb:222 - Wrong argument type for Solargraph::Source::Chain::Call#inner_process_macro: macro expected YARD::Tags::MacroDirective, received Solargraph::YardMap::Macro
/home/runner/work/solargraph/solargraph/lib/solargraph/yard_map/mapper.rb:28 - Unresolved call to filename on Solargraph::Location, nil
```