### PR TITLE
Parameters shadow local variables with same name

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -23,7 +23,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.4 # keep same as typecheck.yml
+        ruby-version: 4.0 # keep same as typecheck.yml
         bundler-cache: true
     - uses: awalsh128/cache-apt-pkgs-action@latest
       with:

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 3.4
+        ruby-version: 4.0
         bundler-cache: false
     - name: Install gems
       run: |

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -31,7 +31,9 @@ module Solargraph
       end
 
       def combine_with other, attrs = {}
-        # Parameters can be combined with local variables
+        # Parameters can only be combined with local variables in the same closure
+        return self unless other.closure == closure
+
         new_attrs = if other.is_a?(Parameter)
                       {
                         decl: assert_same(other, :decl),

--- a/spec/pin/parameter_spec.rb
+++ b/spec/pin/parameter_spec.rb
@@ -202,6 +202,22 @@ describe Solargraph::Pin::Parameter do
     expect(pin1.combine_with(pin2).comments).to eq('a comment')
   end
 
+  it 'does not combine with local variables in different closures' do
+    source = Solargraph::Source.load_string(%(
+      class Example
+        # @return [Array<String>]
+        def strings; end
+      end
+      example = Example.new
+      str = example.strings.find { |str| str == 'foo' }
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    pin1, pin2 = api_map.source_map('test.rb').locals.select { |pin| pin.name == 'str' }
+    combo = pin2.combine_with(pin1)
+    expect(combo).to be(pin2)
+  end
+
   it 'infers undefined types by default' do
     source = Solargraph::Source.load_string(%(
       func do |foo|


### PR DESCRIPTION
Combining variables can raise errors when a local variable is combined with a parameter in a different closure.

Reproducible example:
```ruby
class Example
  # @return [Array<String>]
  def strings; end
end
example = Example.new
str = example.strings.find { |str| str == 'foo' }
```

Errors occur because the `str` local variable is in a namespace and the parameter expects its closure to have parameters, e.g.:

```
NoMethodError: undefined method 'parameter_names' for an instance of Solargraph::Pin::Namespace
```

Since the parameter shadows the local variable, there's no reason to combine them. The simplest solution is for `Parameter#combine_with` to avoid combining with variables that are not in its closure.