### PR TITLE
Limit pin combination to doc maps

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -721,7 +721,7 @@ module Solargraph
       logger.debug do
         "ApiMap#resolve_method_aliases(pins=#{pins.map(&:name)}, visibility=#{visibility}) => #{with_resolved_aliases.map(&:name)}"
       end
-      GemPins.combine_method_pins_by_path(with_resolved_aliases)
+      with_resolved_aliases
     end
 
     # @return [Workspace, nil]

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -71,10 +71,9 @@ module Solargraph
       # @param visibility [Array<Symbol>]
       # @return [Enumerable<Solargraph::Pin::Method>]
       def get_methods fqns, scope: :instance, visibility: [:public]
-        all_pins = namespace_children(fqns).select do |pin|
+        namespace_children(fqns).select do |pin|
           pin.is_a?(Pin::Method) && pin.scope == scope && visibility.include?(pin.visibility)
         end
-        GemPins.combine_method_pins_by_path(all_pins)
       end
 
       BOOLEAN_SUPERCLASS_PIN = Pin::Reference::Superclass.new(name: 'Boolean', closure: Pin::ROOT_PIN,

--- a/lib/solargraph/gem_pins.rb
+++ b/lib/solargraph/gem_pins.rb
@@ -11,17 +11,6 @@ module Solargraph
       include Logging
     end
 
-    # @param pins [Array<Pin::Base>]
-    # @return [Array<Pin::Base>]
-    def self.combine_method_pins_by_path pins
-      method_pins, alias_pins = pins.partition { |pin| pin.instance_of?(Pin::Method) }
-      by_path = method_pins.group_by(&:path)
-      by_path.transform_values! do |pins|
-        GemPins.combine_method_pins(*pins)
-      end
-      by_path.values + alias_pins
-    end
-
     # @param pins [Array<Pin::Method>]
     # @return [Pin::Method, nil]
     def self.combine_method_pins(*pins)


### PR DESCRIPTION
The primary purpose of combining pins in the `GemPins` module is to consolidate RBS and YARD data. We shouldn't need to do it in `ApiMap` or `ApiMap::Store` because the code in the workspace is already the authoritative source.

@apiology If you have a use case where combining workspace pins is necessary, please let me know.
