### PR TITLE
Convert RBS implicit nil annotations

### DIFF
--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -553,7 +553,7 @@ module Solargraph
       # @return [void]
       def method_def_to_sigs decl, pin
         # rubocop:disable Style/SafeNavigationChainLength
-        implicit_nil = decl.overloads.first&.annotations&.map(&:string)&.include?('implicitly-returns-nil')
+        implicit_nil = decl.overloads.first&.annotations&.map(&:string)&.include?('implicitly-returns-nil') || false
         # rubocop:enable Style/SafeNavigationChainLength
         # @param overload [RBS::AST::Members::MethodDefinition::Overload]
         decl.overloads.map do |overload|

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -552,16 +552,17 @@ module Solargraph
       # @param pin [Pin::Method]
       # @return [void]
       def method_def_to_sigs decl, pin
+        implicit_nil = decl.overloads.first&.annotations&.map(&:string)&.include?('implicitly-returns-nil')
         # @param overload [RBS::AST::Members::MethodDefinition::Overload]
         decl.overloads.map do |overload|
           # @sg-ignore Wrong argument type for Solargraph::RbsMap::Conversions#location_decl_to_pin_location:
           #   location expected RBS::Location, nil, received RBS::Location<:type, :type_params>, RBS::AST::Members::Attribute::loc, nil
           type_location = location_decl_to_pin_location(overload.method_type.location)
           generics = type_parameter_names(overload.method_type)
-          signature_parameters, signature_return_type = parts_of_function(overload.method_type, pin)
+          signature_parameters, signature_return_type = parts_of_function(overload.method_type, pin, implicit_nil)
           rbs_block = overload.method_type.block
           block = if rbs_block
-                    block_parameters, block_return_type = parts_of_function(rbs_block, pin)
+                    block_parameters, block_return_type = parts_of_function(rbs_block, pin, implicit_nil)
                     Pin::Signature.new(generics: generics, parameters: block_parameters,
                                        return_type: block_return_type, source: :rbs,
                                        type_location: type_location, closure: pin)
@@ -588,14 +589,15 @@ module Solargraph
 
       # @param type [RBS::MethodType, RBS::Types::Block]
       # @param pin [Pin::Method]
+      # @param implicit_nil [Boolean]
       # @return [Array(Array<Pin::Parameter>, ComplexType)]
-      def parts_of_function type, pin
+      def parts_of_function type, pin, implicit_nil
         type_location = pin.type_location
         if defined?(RBS::Types::UntypedFunction) && type.type.is_a?(RBS::Types::UntypedFunction)
           return [
             [Solargraph::Pin::Parameter.new(decl: :restarg, name: 'arg', closure: pin, source: :rbs,
                                             type_location: type_location)],
-            method_type_to_type(type)
+            method_type_to_type(type, implicit_nil)
           ]
         end
 
@@ -659,7 +661,7 @@ module Solargraph
                                                          source: :rbs, type_location: type_location)
         end
 
-        return_type = method_type_to_type(type)
+        return_type = method_type_to_type(type, implicit_nil)
         [parameters, return_type]
       end
 
@@ -843,8 +845,10 @@ module Solargraph
 
       # @param type [RBS::MethodType, RBS::Types::Block]
       # @return [ComplexType, ComplexType::UniqueType]
-      def method_type_to_type type
-        other_type_to_type type.type.return_type
+      def method_type_to_type type, implicit_nil
+        tag = other_type_to_type type.type.return_type
+        return ComplexType.parse(tag.to_s + ', nil') if tag && implicit_nil
+        tag
       end
 
       # @param type [RBS::Types::Bases::Base,Object] RBS type object.

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -849,7 +849,7 @@ module Solargraph
       # @return [ComplexType, ComplexType::UniqueType]
       def method_type_to_type type, implicit_nil
         tag = other_type_to_type type.type.return_type
-        return ComplexType.parse("#{tag.to_s}, nil") if tag && implicit_nil
+        return ComplexType.parse("#{tag}, nil") if tag && implicit_nil
         tag
       end
 

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -846,6 +846,7 @@ module Solargraph
       end
 
       # @param type [RBS::MethodType, RBS::Types::Block]
+      # @param implicit_nil [Boolean]
       # @return [ComplexType, ComplexType::UniqueType]
       def method_type_to_type type, implicit_nil
         tag = other_type_to_type type.type.return_type

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -552,7 +552,9 @@ module Solargraph
       # @param pin [Pin::Method]
       # @return [void]
       def method_def_to_sigs decl, pin
+        # rubocop:disable Style/SafeNavigationChainLength
         implicit_nil = decl.overloads.first&.annotations&.map(&:string)&.include?('implicitly-returns-nil')
+        # rubocop:enable Style/SafeNavigationChainLength
         # @param overload [RBS::AST::Members::MethodDefinition::Overload]
         decl.overloads.map do |overload|
           # @sg-ignore Wrong argument type for Solargraph::RbsMap::Conversions#location_decl_to_pin_location:
@@ -847,7 +849,7 @@ module Solargraph
       # @return [ComplexType, ComplexType::UniqueType]
       def method_type_to_type type, implicit_nil
         tag = other_type_to_type type.type.return_type
-        return ComplexType.parse(tag.to_s + ', nil') if tag && implicit_nil
+        return ComplexType.parse("#{tag.to_s}, nil") if tag && implicit_nil
         tag
       end
 

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -954,7 +954,7 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     api_map = Solargraph::ApiMap.new.map(source)
 
     clip = api_map.clip_at('test.rb', [6, 10])
-    expect(clip.infer.to_s).to eq('String')
+    expect(clip.infer.to_s).to eq('String, nil')
 
     clip = api_map.clip_at('test.rb', [7, 17])
     expect(clip.infer.to_s).to eq('nil')

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -368,7 +368,7 @@ describe Solargraph::Pin::Method do
     api_map.map source
     pin = api_map.get_path_pins('Foo#bar').first
     type = pin.probe(api_map)
-    expect(type.to_s).to eq('String')
+    expect(type.to_s).to eq('String, nil')
   end
 
   it 'infers from multiple-assignment chains' do

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -445,7 +445,7 @@ describe Solargraph::Source::Chain::Call do
     foo_pin = api_map.source_map('test.rb').pins.find { |p| p.name == 'foo' }
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(4, 8))
     type = chain.infer(api_map, foo_pin, api_map.source_map('test.rb').locals)
-    expect(type.rooted_tags).to eq('::Array, ::Hash{::String => undefined}, ::String, ::Integer')
+    expect(type.rooted_tags).to eq('::Array, ::Hash{::String => undefined}, ::String, ::Integer, nil')
   end
 
   it 'preserves undefined and underdefined tyypes in resolution' do

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1129,7 +1129,7 @@ describe Solargraph::SourceMap::Clip do
     clip = map.clip_at('test.rb', Solargraph::Position.new(4, 15))
     expect(clip.infer.to_s).to eq('Array<String>, nil')
     clip = map.clip_at('test.rb', Solargraph::Position.new(5, 15))
-    expect(clip.infer.to_s).to eq('String')
+    expect(clip.infer.to_s).to eq('String, nil')
   end
 
   it 'infers overloads with splats' do
@@ -1779,7 +1779,7 @@ describe Solargraph::SourceMap::Clip do
     api_map = Solargraph::ApiMap.new.map(source)
     clip = api_map.clip_at('test.rb', [5, 6])
     type = clip.infer
-    expect(type.to_s).to eq('Enumerable<String>')
+    expect(type.to_s).to eq('Enumerable<String>, nil')
     clip = api_map.clip_at('test.rb', [7, 6])
     type = clip.infer
     expect(type.to_s).to eq('String, nil')


### PR DESCRIPTION
Check for the `implicitly-returns-nil` annotation in RBS overloads and adjust the return types accordingly.