### PR TITLE
Cache generated maps in rspec workflows

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -18,6 +18,8 @@ permissions:
 
 jobs:
   rspec:
+    env:
+      SOLARGRAPH_CACHE: ./solargraph-cache
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -45,11 +47,16 @@ jobs:
     #    starting from Ruby 3.6.0
     - name: Work around legacy rbs deprecation on ruby > 3.4
       run: echo "gem 'tsort'" >> .Gemfile
-    - name: Update gems
-      run: |
-        bundle update rbs # use latest available for this Ruby version
     - name: Update types
       run: bundle exec rbs collection update
+    - name: Cache documentation
+      id: cache-documentation
+      uses: actions/cache@v5
+      with:
+        path: ./solargraph-cache
+        key: ${{ runner.os }}-solargraph-cache
+    - name: Generate documentation
+      run: bundle exec solargraph gems
     - name: Run tests
       run: bundle exec rake spec
   undercover:

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -47,6 +47,9 @@ jobs:
     #    starting from Ruby 3.6.0
     - name: Work around legacy rbs deprecation on ruby > 3.4
       run: echo "gem 'tsort'" >> .Gemfile
+    - name: Update gems
+      run: |
+        bundle update rbs # use latest available for this Ruby version
     - name: Update types
       run: bundle exec rbs collection update
     - name: Cache documentation

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -19,7 +19,7 @@ permissions:
 jobs:
   rspec:
     env:
-      SOLARGRAPH_CACHE: ./solargraph-cache
+      SOLARGRAPH_CACHE: ~/solargraph-cache
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -56,7 +56,7 @@ jobs:
       id: cache-documentation
       uses: actions/cache@v5
       with:
-        path: ./solargraph-cache
+        path: ~/solargraph-cache
         key: ${{ runner.os }}-solargraph-cache
     - name: Generate YARD documentation
       if: steps.cache-documentation.outputs.cache-hit != 'true'

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -52,14 +52,15 @@ jobs:
         bundle update rbs # use latest available for this Ruby version
     - name: Update types
       run: bundle exec rbs collection update
-    - name: Cache documentation
+    - name: Cache YARD documentation
       id: cache-documentation
       uses: actions/cache@v5
       with:
         path: ./solargraph-cache
         key: ${{ runner.os }}-solargraph-cache
-    - name: Generate documentation
-      run: bundle exec solargraph gems
+    - name: Generate YARD documentation
+      if: steps.cache-documentation.outputs.cache-hit != 'true'
+      run: bundle exec solargraph yardoc
     - name: Run tests
       run: bundle exec rake spec
   undercover:

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -221,6 +221,14 @@ module Solargraph
       end
     end
 
+    # @todo Gem selection
+    desc 'yardoc', 'Generate yardocs for all gems'
+    option :rebuild, type: :boolean, desc: 'Rebuild existing yardocs', default: false
+    # @return [void]
+    def yardoc
+      Gem::Specification.to_a.each { |spec| do_yard_cache spec, rebuild: options[:rebuild] }
+    end
+
     desc 'reporters', 'Get a list of diagnostics reporters'
     # @return [void]
     def reporters
@@ -549,6 +557,15 @@ module Solargraph
           pins = rbs_map.pins || []
           PinCache.serialize_rbs_collection_gem(gemspec, rbs_map.cache_key, pins)
         end
+      end
+    end
+
+    # @param gemspec [Gem::Specification, nil]
+    # @param rebuild [Boolean]
+    def do_yard_cache gemspec, rebuild: false
+      if rebuild || !PinCache.has_yard?(gemspec)
+        pins = GemPins.build_yard_pins(['yard-activesupport-concern'], gemspec)
+        PinCache.serialize_yard_gem(gemspec, pins)
       end
     end
   end


### PR DESCRIPTION
Maintain a cache for documentation across the rspec workflow. This should eliminate the need to regenerate YARD documentation for each run.