### PR TITLE
Temporary job stubs

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -59,6 +59,8 @@ jobs:
         run: |
           bundle exec overcommit --sign
           SOLARGRAPH_ASSERTS=on bundle exec overcommit --run --diff origin/master
+        # @todo Temporary, expect to revert in 0.60
+        continue-on-error: true
   rubocop:
     name: rubocop
     runs-on: ubuntu-latest
@@ -95,6 +97,8 @@ jobs:
 
     - name: Run rbs validate
       run: bundle exec rbs validate
+      # @todo Temporary, expect to revert in 0.60
+      continue-on-error: true
   rubocop_todo:
     name: .rubocop_todo.yml
     runs-on: ubuntu-latest
@@ -112,6 +116,8 @@ jobs:
 
     - name: Run RuboCop
       run: bundle exec rubocop -c .rubocop.yml
+      # @todo Temporary, expect to revert in 0.60
+      continue-on-error: true
 
     - name: Run RuboCop against todo file
       continue-on-error: true

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -45,6 +45,8 @@ jobs:
       run: bundle exec rbs collection update
     - name: Ensure typechecking still works
       run: bundle exec solargraph typecheck --level strong
+      # @todo Temporary, expect to revert in 0.60
+      continue-on-error: true
     - name: Ensure specs still run
       run: bundle exec rake spec
   rails:
@@ -78,6 +80,8 @@ jobs:
       run: bundle exec rbs collection update
     - name: Ensure typechecking still works
       run: bundle exec solargraph typecheck --level strong
+      # @todo Temporary, expect to revert in 0.60
+      continue-on-error: true
     - name: Ensure specs still run
       run: bundle exec rake spec
   rspec:
@@ -109,6 +113,8 @@ jobs:
       run: bundle exec rbs collection update
     - name: Ensure typechecking still works
       run: bundle exec solargraph typecheck --level strong
+      # @todo Temporary, expect to revert in 0.60
+      continue-on-error: true
     - name: Ensure specs still run
       run: bundle exec rake spec
 
@@ -229,3 +235,5 @@ jobs:
         ALLOW_IMPROVEMENTS=true bundle exec rake spec
       env:
         MATRIX_RAILS_VERSION: "7.0"
+      # @todo Temporary, expect to revert in 0.60
+      continue-on-error: true

--- a/.github/workflows/typecheck.yml
+++ b/.github/workflows/typecheck.yml
@@ -38,3 +38,5 @@ jobs:
       run: bundle exec rbs collection install
     - name: Typecheck self
       run: SOLARGRAPH_ASSERTS=on bundle exec solargraph typecheck --level strong
+      # @todo Temporary, expect to revert in 0.60
+      continue-on-error: true


### PR DESCRIPTION
A few of the checks have gotten especially noisy while the codebase is in flux. I'm temporarily setting `continue-on-error` on the jobs and hope to get them sorted by version 0.60.