### PR TITLE
Infer method return type from YARD macros

### DIFF
--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -161,6 +161,7 @@ module Solargraph
               break if type.defined?
             end
             p = p.with_single_signature(new_signature_pin) unless new_signature_pin.nil?
+            type = macro_return_type(p, api_map) || type if type.undefined?
             next p.proxy(type) if type.defined?
             p
           end
@@ -180,6 +181,22 @@ module Solargraph
               selfy == pin.return_type ? pin : pin.proxy(selfy)
             end
           end
+        end
+
+        # @param pin [Pin::Method]
+        # @param api_map [ApiMap]
+        # @return [ComplexType, nil]
+        def macro_return_type pin, api_map
+          return nil if pin.macros.empty?
+          call_params = [word, *arguments.map { |arg| simple_convert(arg.node).to_s }]
+          pin.macros.each do |macro|
+            expanded = macro.macro_object.expand(call_params)
+            return_tag = Solargraph::Source.parse_docstring(expanded).to_docstring.tag(:return)
+            next if return_tag.nil? || return_tag.types.nil? || return_tag.types.empty?
+            type = ComplexType.try_parse(*return_tag.types)
+            return type.qualify(api_map, *pin.gates) if type.defined?
+          end
+          nil
         end
 
         # @param docstring [YARD::Docstring]

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -96,7 +96,6 @@ describe Solargraph::Source::Chain::Call do
   end
 
   it 'infers types from macros' do
-    pending 'WIP'
     source = Solargraph::Source.load_string(%(
       class Foo
         # @!macro


### PR DESCRIPTION
Fixes the WIP `'infers types from macros'` spec — infers a method's return type from its YARD `@return` macro tag when signature resolution finds none:

```ruby
class Foo
  # @!macro
  #   @return [$1]
  def self.bar; end
end

Foo.bar(String) # => String
```

> **AI disclaimer:** I located *where* the fix was needed; the `macro_return_type` method implementation was written by AI (Claude Code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)