### PR TITLE
Transitive macros

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -136,6 +136,20 @@ module Solargraph
     def process_macros
       macro_pins = []
       source_maps.each do |source_map|
+        source_map.pins.select(&:maybe_macros?).each do |pin|
+          pin.comments.scan(/\s*?@macro +(\S+).*?\n/).each do |match|
+            directive = named_macro(match[0])
+            next unless directive
+            macro = Solargraph::YardMap::Macro.from_directive(directive, pin)
+            expanded = macro.macro_object.expand([pin.name, *pin.parameters.map(&:name)])
+            docstring = Solargraph::Source.parse_docstring(expanded).to_docstring
+            pin.docstring.delete_tags(*docstring.tags.map(&:tag_name)) if docstring.tags.any?
+            pin.docstring.add_tag(*docstring.tags)
+            # @todo Smelly instance variable access
+            pin.instance_variable_set(:@return_type, ComplexType.try_parse(*pin.docstring.tags(:return).flat_map(&:types)))
+            # @todo Appending the comment breaks the tags
+          end
+        end
         source_map.macro_method_candidates(store.macro_method_names).each do |node|
           closure = source_map.locate_closure_pin(node.location.line, node.location.column)
           chain = Solargraph::Parser::ParserGem::NodeChainer.chain(node)

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -136,17 +136,6 @@ module Solargraph
     def process_macros
       macro_pins = []
       source_maps.each do |source_map|
-        source_map.pins.select(&:maybe_macros?).each do |pin|
-          pin.comments.scan(/\s*?@macro +(\S+).*?\n/).each do |match|
-            directive = named_macro(match[0])
-            next unless directive
-            macro = Solargraph::YardMap::Macro.from_directive(directive, pin)
-            expanded = macro.macro_object.expand([pin.name, *pin.parameters.map(&:name)])
-            docstring = Solargraph::Source.parse_docstring(expanded).to_docstring
-            pin.docstring.add_tag(*docstring.tags)
-            # @todo Appending the comment breaks the tags
-          end
-        end
         source_map.macro_method_candidates(store.macro_method_names).each do |node|
           closure = source_map.locate_closure_pin(node.location.line, node.location.column)
           chain = Solargraph::Parser::ParserGem::NodeChainer.chain(node)

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -143,10 +143,7 @@ module Solargraph
             macro = Solargraph::YardMap::Macro.from_directive(directive, pin)
             expanded = macro.macro_object.expand([pin.name, *pin.parameters.map(&:name)])
             docstring = Solargraph::Source.parse_docstring(expanded).to_docstring
-            pin.docstring.delete_tags(*docstring.tags.map(&:tag_name)) if docstring.tags.any?
             pin.docstring.add_tag(*docstring.tags)
-            # @todo Smelly instance variable access
-            pin.instance_variable_set(:@return_type, ComplexType.try_parse(*pin.docstring.tags(:return).flat_map(&:types)))
             # @todo Appending the comment breaks the tags
           end
         end

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -33,13 +33,12 @@ module Solargraph
     # @param gates [Array<String>]
     #
     # @return [ComplexType]
-    def qualify api_map, *gates, preserve: [], replace: preserve
+    def qualify api_map, *gates
       red = reduce_object
       types = red.items.map do |t|
-        next ComplexType.try_parse(replace[preserve.index(t.name)]) if preserve.include?(t.name)
         next t if %w[nil void undefined].include?(t.name)
         next t if ['::Boolean'].include?(t.rooted_name)
-        api_map.unalias(t.name) || t.qualify(api_map, *gates, preserve: preserve, replace: replace)
+        api_map.unalias(t.name) || t.qualify(api_map, *gates)
       end
       ComplexType.new(types).reduce_object
     end
@@ -297,6 +296,10 @@ module Solargraph
         raise "Please remove leading :: and set rooted with recreate() instead - #{new_name}"
       end
       ComplexType.new(map { |ut| ut.transform(new_name, &transform_type) })
+    end
+
+    def expand named_types
+      ComplexType.new(map { |ut| ut.expand(named_types) })
     end
 
     # @return [self]

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -33,12 +33,13 @@ module Solargraph
     # @param gates [Array<String>]
     #
     # @return [ComplexType]
-    def qualify api_map, *gates
+    def qualify api_map, *gates, preserve: [], replace: preserve
       red = reduce_object
       types = red.items.map do |t|
+        next ComplexType.try_parse(replace[preserve.index(t.name)]) if preserve.include?(t.name)
         next t if %w[nil void undefined].include?(t.name)
         next t if ['::Boolean'].include?(t.rooted_name)
-        api_map.unalias(t.name) || t.qualify(api_map, *gates)
+        api_map.unalias(t.name) || t.qualify(api_map, *gates, preserve: preserve, replace: replace)
       end
       ComplexType.new(types).reduce_object
     end

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -552,8 +552,9 @@ module Solargraph
       # @param api_map [ApiMap] The ApiMap that performs qualification
       # @param gates [Array<String>] The namespaces from which to resolve names
       # @return [self, ComplexType, UniqueType] The generated ComplexType
-      def qualify api_map, *gates
+      def qualify api_map, *gates, preserve: [], replace: preserve
         transform do |t|
+          next ComplexType.try_parse(replace[preserve.index(t.name)]) if preserve.include?(t.name)
           next t if t.name == GENERIC_TAG_NAME
           next t if t.duck_type? || t.void? || t.undefined? || t.literal?
           open = t.rooted? ? [''] : gates

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -547,14 +547,17 @@ module Solargraph
         yield new_type
       end
 
+      def expand named_types
+        named_types[name] || self
+      end
+
       # Generate a ComplexType that fully qualifies this type's namespaces.
       #
       # @param api_map [ApiMap] The ApiMap that performs qualification
       # @param gates [Array<String>] The namespaces from which to resolve names
       # @return [self, ComplexType, UniqueType] The generated ComplexType
-      def qualify api_map, *gates, preserve: [], replace: preserve
+      def qualify api_map, *gates
         transform do |t|
-          next ComplexType.try_parse(replace[preserve.index(t.name)]) if preserve.include?(t.name)
           next t if t.name == GENERIC_TAG_NAME
           next t if t.duck_type? || t.void? || t.undefined? || t.literal?
           open = t.rooted? ? [''] : gates

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -569,6 +569,10 @@ module Solargraph
         return_type.qualify(api_map, *(closure&.gates || ['']))
       end
 
+      def maybe_macros?
+        comments.include?('@macro')        
+      end
+
       # Infer the pin's return type via static code analysis.
       #
       # @param api_map [ApiMap]

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -637,6 +637,8 @@ module Solargraph
         result = dup
         result.return_type = return_type
         result.proxied = true
+        # Macros should have been processed already
+        result.macro_names.clear
         result
       end
 

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -539,6 +539,15 @@ module Solargraph
         @macros ||= collect_macros
       end
 
+      def macro_names
+        parse_comments unless @macro_names
+        @macro_names ||= collect_macro_names
+      end
+
+      def macro_names?
+        macro_names.any?
+      end
+
       # Perform a quick check to see if this pin possibly includes YARD
       # directives. This method does not require parsing the comments.
       #
@@ -569,8 +578,13 @@ module Solargraph
         return_type.qualify(api_map, *(closure&.gates || ['']))
       end
 
+      # @todo Candidate for deprecation (see ApiMap#process_macros)
       def maybe_macros?
         comments.include?('@macro')        
+      end
+
+      def macros_names?
+        macro_names.any?
       end
 
       # Infer the pin's return type via static code analysis.
@@ -721,12 +735,14 @@ module Solargraph
         if comments.nil? || comments.empty? || comments.strip.end_with?('@overload')
           @docstring = nil
           @directives = []
+          @macro_names = []
         else
           # HACK: Pass a dummy code object to the parser for plugins that
           # expect it not to be nil
           parse = Solargraph::Source.parse_docstring(comments)
           @docstring = parse.to_docstring
           @directives = parse.directives
+          @macro_names = collect_macro_names
         end
       end
 
@@ -773,6 +789,10 @@ module Solargraph
         parse.directives.select { |d| d.tag.tag_name == 'macro' }.map do |macro_directive|
           Solargraph::YardMap::Macro.from_directive macro_directive, self
         end
+      end
+
+      def collect_macro_names
+        "#{comments}\n".scan(/\s*?@macro +(\S+).*?[\n]/).map { |match| match[0] }
       end
     end
   end

--- a/lib/solargraph/pin/callable.rb
+++ b/lib/solargraph/pin/callable.rb
@@ -162,7 +162,7 @@ module Solargraph
 
       def typify api_map
         type = return_type
-        return type.qualify(api_map, *gates, preserve: parameter_names) if type.defined?
+        return type.qualify(api_map, *gates) if type.defined?
         if method_name.end_with?('?')
           logger.debug { "Callable#typify(self=#{self}) => Boolean (? suffix)" }
           ComplexType::BOOLEAN

--- a/lib/solargraph/pin/callable.rb
+++ b/lib/solargraph/pin/callable.rb
@@ -161,8 +161,8 @@ module Solargraph
       end
 
       def typify api_map
-        type = super
-        return type if type.defined?
+        type = return_type
+        return type.qualify(api_map, *gates, preserve: parameter_names) if type.defined?
         if method_name.end_with?('?')
           logger.debug { "Callable#typify(self=#{self}) => Boolean (? suffix)" }
           ComplexType::BOOLEAN

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -592,7 +592,6 @@ module Solargraph
 
       # @return [ComplexType]
       def generate_complex_type
-        Solargraph.logger.warn("I should check the macros") if macro_names?
         tags = docstring.tags(:return).map(&:types).flatten.compact
         return ComplexType::UNDEFINED if tags.empty?
         ComplexType.try_parse(*tags)

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -279,7 +279,19 @@ module Solargraph
           # @sg-ignore Need to add nil check here
           "Method#typify(self=#{self}, binder=#{binder}, closure=#{closure}, context=#{context.rooted_tags}, return_type=#{return_type.rooted_tags}) - starting"
         end
-        decl = super
+        decl = if macro_names?
+          types = macro_names.flat_map do |mac|
+            directive = api_map.named_macro(mac)
+            next unless directive
+            macro = Solargraph::YardMap::Macro.from_directive(directive, self)
+            expanded = macro.macro_object.expand([name, *parameter_names])
+            docstring = Solargraph::Source.parse_docstring(expanded).to_docstring
+            docstring.tags(:return).flat_map(&:types)
+          end
+          ComplexType.try_parse(*types)
+        else
+          super
+        end
         unless decl.undefined?
           logger.debug do
             "Method#typify(self=#{self}, binder=#{binder}, closure=#{closure}, context=#{context}) => #{decl.rooted_tags.inspect} - decl found"
@@ -580,6 +592,7 @@ module Solargraph
 
       # @return [ComplexType]
       def generate_complex_type
+        Solargraph.logger.warn("I should check the macros") if macro_names?
         tags = docstring.tags(:return).map(&:types).flatten.compact
         return ComplexType::UNDEFINED if tags.empty?
         ComplexType.try_parse(*tags)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -127,10 +127,15 @@ module Solargraph
                                 block_call_type(api_map, name_pin, locals)
                               end
                 end
-                # @type new_signature_pin [Pin::Signature]
                 new_signature_pin = ol.resolve_generics_from_context_until_complete(ol.generics, atypes, nil, nil,
                                                                                     blocktype)
-                new_return_type = new_signature_pin.return_type
+                # @todo It shouldn't be necessary to choose either generics or macros
+                new_return_type = if new_signature_pin.return_type.defined?
+                  new_signature_pin.return_type
+                else
+                  named_types = p.parameter_names.zip(arguments.map { |arg| ComplexType.try_parse(simple_convert(arg.node).to_s) }).to_h
+                  p.typify(api_map).expand(named_types)
+                end
                 self_type = if head?
                               # If we're at the head of the chain, we called a
                               # method somewhere that marked itself as returning
@@ -153,8 +158,7 @@ module Solargraph
                 # the docs were written - from the method pin.
                 # @todo Need to add nil check here
                 if new_return_type.defined?
-                  type = with_params(new_return_type.self_to_type(self_type), self_type).qualify(api_map,
-                                                                                                 *p.gates, preserve: ol.parameter_names, replace: arguments.map { |arg| simple_convert(arg.node).to_s })
+                  type = with_params(new_return_type.self_to_type(self_type), self_type).qualify(api_map, *p.gates)
                 end
                 type ||= ComplexType::UNDEFINED
               end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -154,7 +154,7 @@ module Solargraph
                 # @todo Need to add nil check here
                 if new_return_type.defined?
                   type = with_params(new_return_type.self_to_type(self_type), self_type).qualify(api_map,
-                                                                                                 *p.gates)
+                                                                                                 *p.gates, preserve: ol.parameter_names, replace: arguments.map { |arg| simple_convert(arg.node).to_s })
                 end
                 type ||= ComplexType::UNDEFINED
               end

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -184,4 +184,21 @@ describe Solargraph::ApiMap do
       expect(pins.map(&:path)).to include('Foo::Bar#baz')
     end
   end
+
+  describe '#typify' do
+    it 'expands named macros' do
+      source = Solargraph::Source.load_string(%(
+        # @!macro [new] klassify
+        #   @return [Array<$1>]
+        class Example
+          # @macro klassify
+          def foo(klass)
+          end  
+        end
+      ))
+      api_map = Solargraph::ApiMap.new.map(source)
+      pin = api_map.get_path_pins('Example#foo').first
+      expect(pin.typify(api_map).to_s).to eq('Array<klass>')
+    end
+  end
 end

--- a/spec/pin/base_spec.rb
+++ b/spec/pin/base_spec.rb
@@ -72,4 +72,11 @@ describe Solargraph::Pin::Base do
       expect(pin.typify(api_map).to_s).to eq('RBS::Types::Function, RBS::Types::UntypedFunction')
     end
   end
+
+  describe '#macro_names' do
+    it 'returns names' do
+      pin = described_class.new(name: 'Example', comments: "@macro addcomment\n@macro returnself")
+      expect(pin.macro_names).to eq(['addcomment', 'returnself'])
+    end
+  end
 end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -274,7 +274,6 @@ describe Solargraph::SourceMap::Clip do
   end
 
   it 'infers types from named macros' do
-    pending 'WIP'
     source = Solargraph::Source.load_string(%(
       # @!macro firstarg
       #   @return [$1]

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -290,6 +290,24 @@ describe Solargraph::SourceMap::Clip do
     expect(clip.infer.tag).to eq('String')
   end
 
+  it 'infers parameterized types from named macros' do
+    pending "Macros and generics don't mix yet"
+    source = Solargraph::Source.load_string(%(
+      # @!macro firstarg
+      #   @return [Array<$1>]
+      class Foo
+        # @macro firstarg
+        def bar klass
+        end
+      end
+      Foo.new.bar(String)
+    ), 'test.rb')
+    map = Solargraph::ApiMap.new
+    map.map source
+    clip = map.clip_at('test.rb', Solargraph::Position.new(8, 14))
+    expect(clip.infer.tag).to eq('Array<String>')
+  end
+
   it 'completes generated methods from attached dsl macros' do
     source = Solargraph::Source.load_string(%(
       class Macro


### PR DESCRIPTION
This is a reimplementation of #1202 that expands macros during mapping. It's likely to change again, but this works with the current architecture.