### PR TITLE
Macros Performance - Remove redundant chain.define (?)

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -150,11 +150,6 @@ module Solargraph
               next
             end
           end
-          pin = chain.define(self, closure, []).first
-          next unless pin&.macros&.any?
-          pin.macros.each do |macro|
-            macro_pins.concat macro.generate_pins_from(chain, pin, source_map)
-          end
         end
       end
       macro_pins


### PR DESCRIPTION
This seems to be causing the performance issues reported https://github.com/castwide/solargraph/pull/1194#issuecomment-4580077778

After removing these lines, specs still were passing locally, and I could not see the performance degradation as reported in the comment above.

<img width="1786" height="918" alt="image" src="https://github.com/user-attachments/assets/107c1b60-8acb-4ffa-aee7-2e519b7b4384" />


<img width="1180" height="455" alt="image" src="https://github.com/user-attachments/assets/a8bf2e00-dab9-4500-8685-75fe8b35a45e" />


 