### PR TITLE
Process macro directives from included and extended modules

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -140,13 +140,14 @@ module Solargraph
       Solargraph.logger.debug { "ApiMap#process_macros: named macros: #{store.named_macros.keys.join(', ')}" }
       source_maps.each do |source_map|
         method_candidates = source_map.macro_method_candidates(store.macro_method_names)
+        Solargraph.logger.warn "Candidates: #{method_candidates}"
         Solargraph.logger.debug { "ApiMap#process_macros: processing source map for #{source_map.filename} with #{method_candidates.size} macro method candidates" }
         method_candidates.each do |node|
           closure = source_map.locate_closure_pin(node.location.line, node.location.column)
           chain = Solargraph::Parser::ParserGem::NodeChainer.chain(node)
           if node.children[0].nil? && store.macro_method_name_pins.key?(node.children[1].to_s)
             match = store.macro_method_name_pins[node.children[1].to_s].find do |pin|
-              super_and_sub?(pin.namespace, closure.name)
+              get_complex_type_methods(closure.return_type).include?(pin)
             end
             if match
               match.macros.each do |macro|

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -201,4 +201,27 @@ describe Solargraph::ApiMap do
       expect(pin.typify(api_map).to_s).to eq('Array<klass>')
     end
   end
+
+  describe '#process_macros' do
+    it 'processes macro directives from extended modules' do
+      source = Solargraph::Source.load_string(%(
+        module Extension
+          # @!macro
+          #   @!method $1
+          #   @return [$2]
+          def make_method(name, klass)
+          end  
+        end
+
+        class Example
+          extend Extension
+
+          make_method :macro_method, String
+        end
+      ))
+      api_map = Solargraph::ApiMap.new.map(source)
+      pin = api_map.get_path_pins('Example#macro_method').first
+      expect(pin.return_type.to_s).to eq('String')
+    end
+  end
 end


### PR DESCRIPTION
The current `process_macros` method depends on the caller's closure defining the macro method or having it defined in a superclass. It excludes macro methods defined in modules. Instead, look for the pin with the defined macro in the closure's method pins using `get_complex_type_methods`.