### PR TITLE
Flaky pathname issue

### DIFF
--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -4,9 +4,9 @@ require 'benchmark'
 require 'thor'
 require 'yard'
 require 'yaml'
+require 'pathname'
 require 'sord'
 require 'tmpdir'
-
 
 module Solargraph
   class Shell < Thor


### PR DESCRIPTION
Some environments report an uninitialized constant `Pathname` error that originates in `Shell`. A similar error used to occur in `RbsMap`. The most likely root cause is a bug in certain combinations of Ruby and RBS versions. The easiest solution is to `require 'pathname'` explicitly.