### PR TITLE
Check object equality in Pin::Base#nearly?

### DIFF
--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -491,7 +491,7 @@ module Solargraph
           # @sg-ignore Translate to something flow sensitive typing understands
           name == other.name &&
           # @sg-ignore flow sensitive typing needs to handle attrs
-          (closure == other.closure || (closure && closure.nearly?(other.closure))) &&
+          (closure.equal?(other.closure) || (closure&.nearly?(other.closure))) &&
           # @sg-ignore Translate to something flow sensitive typing understands
           (comments == other.comments ||
            # @sg-ignore Translate to something flow sensitive typing understands

--- a/spec/pin/base_spec.rb
+++ b/spec/pin/base_spec.rb
@@ -79,4 +79,13 @@ describe Solargraph::Pin::Base do
       expect(pin.macro_names).to eq(['addcomment', 'returnself'])
     end
   end
+
+  describe '#nearly?' do
+    it 'avoids recursion when two pins have the same closure' do
+      pin1 = Solargraph::Pin::Base.new(name: 'foo')
+      pin1.closure = pin1
+      pin2 = Solargraph::Pin::Base.new(name: 'foo', closure: pin1)
+      expect { pin1.nearly?(pin2) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
ref #1212

Checking `closure == other.closure` in `#nearly?` can go into infinite recursion when a pin acts as its own closure.