### PR TITLE
Pin rdoc to ~> 7.0

### DIFF
--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -45,6 +45,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'parser', '~> 3.0'
   s.add_dependency 'prism', '~> 1.4'
   s.add_dependency 'rbs', '>= 3.10.0'
+  s.add_dependency 'rdoc', '~> 7.0'
   s.add_dependency 'reverse_markdown', '~> 3.0'
   s.add_dependency 'rubocop', '~> 1.76'
   s.add_dependency 'sord', '~> 7.0'


### PR DESCRIPTION
RDoc 8.0.0 introduces a bug to the `$solargraph/document` message:

```
WARN] Error processing document: [ArgumentError] wrong number of arguments (given 1, expected 0)
[DEBUG] [...]/versions/4.0.3/lib/ruby/gems/4.0.0/gems/rdoc-8.0.0/lib/rdoc/markup/to_html.rb:127:in 'RDoc::Markup::ToHtml#initialize'
```

Pin rdoc to ~> 7.0 until the problem can be resolved either in solargraph itself or a patch to rdoc.