### PR TITLE
Typecheck attribute return tags against their backing ivar's type

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -403,11 +403,10 @@ module Solargraph
     # @param candidates [Array<Pin::BaseVariable>]
     # @param name [String]
     # @param closure [Pin::Closure]
-    # @param location [Location]
+    # @param location [Location, nil]
     #
     # @return [Pin::BaseVariable, nil]
     def var_at_location candidates, name, closure, location
-      # @todo Location can be nil if clips have trouble finding node recipients
       return unless location
 
       with_correct_name = candidates.select { |pin| pin.name == name }

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -14,7 +14,7 @@ module Solargraph
         # @return [String]
         attr_reader :word
 
-        # @return [Location]
+        # @return [Location, nil]
         attr_reader :location
 
         # @return [::Array<Chain>]

--- a/lib/solargraph/source/chain/instance_variable.rb
+++ b/lib/solargraph/source/chain/instance_variable.rb
@@ -13,10 +13,6 @@ module Solargraph
           @location = location
         end
 
-        # @sg-ignore Declared return type
-        #   ::Array<::Solargraph::Pin::Base> does not match inferred
-        #   type ::Array<::Solargraph::Pin::BaseVariable, ::NilClass>
-        #   for Solargraph::Source::Chain::InstanceVariable#resolve
         def resolve api_map, name_pin, locals
           ivars = api_map.get_instance_variable_pins(name_pin.context.namespace, name_pin.context.scope).select do |p|
             p.name == word
@@ -27,8 +23,7 @@ module Solargraph
 
         private
 
-        # @todo: Missed nil violation
-        # @return [Location]
+        # @return [Location, nil]
         attr_reader :location
       end
     end

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -162,10 +162,19 @@ module Solargraph
           result.push Problem.new(pin.location, "Untyped method #{pin.path} could not be inferred")
         end
       elsif rules.validate_tags?
-        unless pin.node.nil? || declared.void? || virtual_pin?(pin) || abstract?(pin)
+        # Attribute pins never have a node (attr_reader/attr_writer/attr_accessor are
+        # synthesized, not parsed method bodies), but their inferred type is still
+        # meaningful: #probe walks the backing ivar's assignments via infer_from_iv.
+        # Without this carve-out, a manually-written @return tag on an attribute is
+        # never cross-checked against how the ivar is actually assigned (e.g. a nilable
+        # default in the constructor), so a bad tag silently passes at every level.
+        unless (pin.node.nil? && !pin.attribute?) || declared.void? || virtual_pin?(pin) || abstract?(pin)
           inferred = pin.probe(api_map).self_to_type(pin.full_context)
           if inferred.undefined?
-            unless rules.ignore_all_undefined? || external?(pin)
+            # An attribute with no locally-discoverable ivar assignment (set via a
+            # mixin, metaprogramming, etc.) isn't a tag/inference mismatch - just
+            # unproven. Only methods with an actual body get flagged for this.
+            unless rules.ignore_all_undefined? || external?(pin) || pin.attribute?
               result.push Problem.new(pin.location, "#{pin.path} return type could not be inferred", pin: pin)
             end
           else

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -6,6 +6,39 @@ describe Solargraph::TypeChecker do
       Solargraph::TypeChecker.load_string(code, 'test.rb', :strong)
     end
 
+    it 'requires strict return tags for attributes when nil is involved' do
+      checker = type_checker(%(
+        class Foo
+          # @param bar [String, nil]
+          def initialize(bar = nil)
+            @bar = bar
+          end
+
+          # The tag is [String] but @bar can be nil per the constructor
+          #
+          # @return [String]
+          attr_reader :bar
+        end
+      ))
+      expect(checker.problems).to be_one
+      expect(checker.problems.first.message).to include('does not match inferred type')
+    end
+
+    it 'does not flag attributes whose declared type already allows nil' do
+      checker = type_checker(%(
+        class Foo
+          # @param bar [String, nil]
+          def initialize(bar = nil)
+            @bar = bar
+          end
+
+          # @return [String, nil]
+          attr_reader :bar
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
     it 'requires strict return tags when nil is involved and used second in a ternary' do
       checker = type_checker(%(
         class Foo


### PR DESCRIPTION
## Summary

`TypeChecker#method_return_type_problems_for` skips the declared-vs-inferred
comparison whenever `pin.node.nil?`. `attr_reader`/`attr_writer`/`attr_accessor`
pins are built without a `node:` (`process_attribute` in `send_node.rb`), so
a manually-written `@return` tag on any attribute has never been checked
against how its ivar is actually assigned, at any typecheck level.

`Pin::Method#probe` already infers a type for attributes via `infer_from_iv`
(used elsewhere in this file for the "missing tag" branch); this PR reuses it
for the declared-vs-inferred comparison. Attributes with no locally-discoverable
ivar assignment (mixin, metaprogramming) stay silent - unproven, not a mismatch.

Fixes two concrete `attr_reader :location` mismatches it was masking, in
`Chain::Call` and `Chain::InstanceVariable` (the latter had a
`@todo: Missed nil violation` comment above the bad tag), plus the matching
`@param` on `ApiMap#var_at_location`.

## New signal this surfaces

Full self-typecheck at `strict`/`strong` adds ~7/26 new problems repo-wide
(on top of the existing backlog tolerated via `continue-on-error: true`).
Spot-checked - look like real pre-existing mismatches, flagged as follow-up.

## Test plan

- [x] `spec/type_checker/levels/strong_spec.rb` (2 new cases)
- [x] `spec/type_checker_spec.rb spec/type_checker/levels/* spec/type_checker/rules_spec.rb` - 284 examples, 0 failures
- [x] `rubocop` on changed files - no new offenses
- [x] `strict`/`strong` self-typecheck stays 0 problems on `api_map.rb`,
      `chain/call.rb`, `chain/instance_variable.rb`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Vo1kewasiF1ywEQAT5Bth9
