### PR TITLE
Fix recursive-mutex deadlock in Library#sync_catalog

### DIFF
--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -605,8 +605,12 @@ module Solargraph
         queued_gemspec_cache.push(spec)
         return if pending - queued_gemspec_cache.length < 1
 
-        catalog
-        sync_catalog
+        # Try the next cacheable gemspec. This method is always called
+        # from inside sync_catalog's mutex (either directly or via this
+        # same recursive call), so recursing through sync_catalog here
+        # would try to re-lock a mutex this thread already holds and
+        # deadlock (https://github.com/castwide/solargraph/issues/1111).
+        cache_next_gemspec
       else
         logger.info "Caching #{spec.name} #{spec.version}"
         Thread.new do

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -657,4 +657,25 @@ describe Solargraph::Library do
       end
     end
   end
+
+  describe '#sync_catalog' do
+    # Regression test for https://github.com/castwide/solargraph/issues/1111
+    #
+    # When the first cacheable gemspec is already being cached by another
+    # process, cache_next_gemspec enqueues it and, if other gemspecs are
+    # still pending, recurses to try the next one. That recursion must not
+    # go back through sync_catalog's own mutex, or it deadlocks with a
+    # ThreadError on the thread that is already inside the mutex.
+    it 'does not deadlock when the next cacheable gemspec is already being processed elsewhere' do
+      library = described_class.new
+      api_map = library.send(:api_map)
+      gemspecs = (1..3).map { |i| instance_double(Gem::Specification, name: "gem_#{i}", version: Gem::Version.new('1.0.0')) }
+      allow(api_map).to receive(:catalog)
+      allow(api_map).to receive_messages(uncached_yard_gemspecs: gemspecs, uncached_rbs_collection_gemspecs: [], uncached_gemspecs: gemspecs, source_maps: [], pins: [])
+      allow(Solargraph::Yardoc).to receive(:processing?).and_return(true)
+
+      library.catalog
+      expect { library.send(:sync_catalog) }.not_to raise_error
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Fixes #1111 (`ThreadError: deadlock; recursive locking`).

`Library#cache_next_gemspec`'s "already being processed" branch enqueues
the gemspec and, if other gemspecs are still pending, recurses to try
the next one. It did this by calling `sync_catalog` again — but
`cache_next_gemspec` is only ever reached from inside `sync_catalog`'s
own `mutex.synchronize` block (either directly, or transitively via
this same recursive path on the same thread), so re-entering
`sync_catalog` tries to re-lock a non-reentrant `Thread::Mutex` the
current thread already holds, raising the deadlock error from #1111's
stack trace exactly.

The fix recurses into `cache_next_gemspec` directly instead of through
`sync_catalog`, since the mutex is already held for the entire call
chain by the time this branch runs.

This bug predates the pin-caching rework and its revert (#1180) — it
was introduced in #990 and is independent of that whole saga, but it's
one of the "deadlocked threads" issues mentioned in #1180's PR
description as motivation for reverting, so I wanted to get it fixed
and out of the way on its own before looking at anything else in that
area.

## Test plan

- [x] Added a regression spec (`spec/library_spec.rb`) that stubs
      `Yardoc.processing?` to force the recursive branch with multiple
      pending gemspecs; it reproduces the exact deadlock on current
      master and passes after the fix.
- [x] `bundle exec rspec` — full suite green (2 pre-existing, unrelated
      failures in `rbs_map/conversions_spec.rb` / `activesupport_concern_spec.rb`
      reproduce identically on master without this change).
- [x] `bundle exec rubocop` clean on changed files.
