### PR TITLE
Bump overcommit to ~> 0.71.0 (fixes broken Solargraph pre-commit hook)

### DIFF
--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |s|
   #
   # even more specific on RuboCop itself, which is written into _todo
   # file.
-  s.add_development_dependency 'overcommit', '~> 0.68.0'
+  s.add_development_dependency 'overcommit', '~> 0.71.0'
   s.add_development_dependency 'rubocop', '~> 1.80.0.0'
   s.add_development_dependency 'rubocop-rake', '~> 0.7.1'
   s.add_development_dependency 'rubocop-rspec', '~> 3.6.0'


### PR DESCRIPTION
## Summary

`Overcommit::Hook::PreCommit::Solargraph` (bundled with the `overcommit`
gem) runs `solargraph typecheck --level strong` on changed files and
parses the output to decide pass/fail. Its `MESSAGE_REGEX` in 0.68.0
only matches solargraph's older `file:line - message` format; current
solargraph outputs `file:line: message` (colon, not " - "), so the
regex never matches and the hook always reports the confusing
`Solargraph failed to run`, even when solargraph ran fine and simply
found (or didn't find) real issues. Reproduced on a clean checkout of
this repo with no changes at all — every commit currently hits this.

`overcommit` 0.71.0 fixes the regex
(`/^\s*(?<file>...):(?<line>\d+)( -|:) /`) to accept both separators,
so the hook now reports actual typecheck findings instead of the
generic failure message, and (via Overcommit's own line-scoping logic)
correctly downgrades findings on lines a commit didn't touch to
warnings rather than failures.

## Test plan

- [x] `bundle update overcommit` → 0.71.0
- [x] Verified locally: touching an unrelated line in a file with known
      pre-existing `--level strong` findings (untouched by the diff)
      now reports `⚠ All pre-commit hooks passed, but with warnings`
      instead of a hard failure with an opaque message.
- [x] `bundle exec rspec` — full suite green (same 2 pre-existing,
      unrelated failures as on master).
