### PR TITLE
Fix stale Hash::_Key expectations from upstream RBS core drift

### DIFF
--- a/spec/convention/activesupport_concern_spec.rb
+++ b/spec/convention/activesupport_concern_spec.rb
@@ -187,11 +187,17 @@ describe Solargraph::Convention::ActiveSupportConcern do
       end
 
       it 'finds superclass method pin parameter type' do
-        # RBS core's Hash#[] takes its key as the _Key duck-type interface, not
-        # the generic K, so instantiating Hash{Symbol => untyped} does not
-        # substitute the param type - see ruby/rbs core/hash.rbs.
+        # RBS core's Hash#[] started taking its key as the _Key duck-type
+        # interface instead of the generic K as of RBS 4.1.0, so instantiating
+        # Hash{Symbol => untyped} no longer substitutes the param type on
+        # newer RBS - see ruby/rbs core/hash.rbs.
+        expected = if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
+                     ['::Hash::_Key']
+                   else
+                     ['Symbol']
+                   end
         expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
-                 .uniq).to eq(['::Hash::_Key'])
+                 .uniq).to eq(expected)
       end
     end
   end

--- a/spec/convention/activesupport_concern_spec.rb
+++ b/spec/convention/activesupport_concern_spec.rb
@@ -187,8 +187,11 @@ describe Solargraph::Convention::ActiveSupportConcern do
       end
 
       it 'finds superclass method pin parameter type' do
+        # RBS core's Hash#[] takes its key as the _Key duck-type interface, not
+        # the generic K, so instantiating Hash{Symbol => untyped} does not
+        # substitute the param type - see ruby/rbs core/hash.rbs.
         expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
-                 .uniq).to eq(['Symbol'])
+                 .uniq).to eq(['::Hash::_Key'])
       end
     end
   end

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -142,8 +142,11 @@ describe Solargraph::RbsMap::Conversions do
       end
 
       it 'finds superclass method pin parameter type' do
+        # RBS core's Hash#[] takes its key as the _Key duck-type interface, not
+        # the generic K, so instantiating Hash{Symbol => untyped} does not
+        # substitute the param type - see ruby/rbs core/hash.rbs.
         expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
-                 .uniq).to eq(['Symbol'])
+                 .uniq).to eq(['::Hash::_Key'])
       end
     end
   end

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -142,11 +142,17 @@ describe Solargraph::RbsMap::Conversions do
       end
 
       it 'finds superclass method pin parameter type' do
-        # RBS core's Hash#[] takes its key as the _Key duck-type interface, not
-        # the generic K, so instantiating Hash{Symbol => untyped} does not
-        # substitute the param type - see ruby/rbs core/hash.rbs.
+        # RBS core's Hash#[] started taking its key as the _Key duck-type
+        # interface instead of the generic K as of RBS 4.1.0, so instantiating
+        # Hash{Symbol => untyped} no longer substitutes the param type on
+        # newer RBS - see ruby/rbs core/hash.rbs.
+        expected = if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
+                     ['::Hash::_Key']
+                   else
+                     ['Symbol']
+                   end
         expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
-                 .uniq).to eq(['::Hash::_Key'])
+                 .uniq).to eq(expected)
       end
     end
   end


### PR DESCRIPTION
## Summary

While babysitting CI on #1219, I found the `rails`, `rspec`, `regression`, and
`run_solargraph_rspec_specs` jobs were already red on `master` before my change, due to an
unrelated upstream drift: RBS core's `Hash#[]` now types its key parameter as the `_Key`
duck-type interface rather than the generic `K`. That means instantiating `Hash{Symbol =>
untyped}` no longer substitutes `Symbol` for the key param type.

Two specs added for #1042 hardcoded the old `Symbol` expectation. This PR updates them to the
now-correct `::Hash::_Key`, with a comment explaining why.

## Verification

- Confirmed both specs fail identically on unmodified `master` (before this change) and pass
  after this fix.
- `bundle exec rspec spec/convention/activesupport_concern_spec.rb spec/rbs_map/conversions_spec.rb`
  → 24 examples, 0 failures.
- Full `bundle exec rspec` run locally: 1619 examples, 0 failures (aside from 2 machine-local
  failures in `spec/shell_spec.rb` caused by a gem conflict on my own workstation, unrelated to
  any code here — confirmed those also fail identically on unmodified `master`).

## Test plan

- [x] Targeted specs pass locally
- [x] Full local spec suite passes (excluding pre-existing machine-local failures, see above)
- [ ] CI green

---
*Generated with [Claude Code](https://claude.com/claude-code)*
