### PR TITLE
Fix Gemspecs#in_this_bundle? crash when no Gemfile is discoverable

### DIFF
--- a/lib/solargraph/workspace/gemspecs.rb
+++ b/lib/solargraph/workspace/gemspecs.rb
@@ -220,6 +220,12 @@ module Solargraph
       # @sg-ignore need boolish support for ? methods
       def in_this_bundle?
         Bundler.definition&.lockfile&.to_s&.start_with?(directory)
+      rescue Bundler::GemfileNotFound
+        # Solargraph itself isn't running under a discoverable Gemfile
+        # (e.g. installed and invoked as a standalone gem), so it can't
+        # be "this bundle" - fall back to treating the workspace as an
+        # external bundle.
+        false
       end
 
       # @return [Array<Gem::Specification, Bundler::LazySpecification, Bundler::StubSpecification>]

--- a/spec/workspace/gemspecs_find_gem_spec.rb
+++ b/spec/workspace/gemspecs_find_gem_spec.rb
@@ -97,4 +97,23 @@ describe Solargraph::Workspace::Gemspecs, '#find_gem' do
       end
     end
   end
+
+  context 'when Solargraph itself is not running under a discoverable Gemfile' do
+    # Regression test: Bundler.definition raises Bundler::GemfileNotFound
+    # (rather than returning nil) when no Gemfile is discoverable from the
+    # current process, e.g. when Solargraph is installed and invoked as a
+    # standalone gem. #in_this_bundle? must not let that exception escape.
+    let(:dir_path) { File.realpath(Dir.mktmpdir) }
+    let(:name) { 'solargraph' }
+    let(:version) { nil }
+
+    before do
+      allow(Bundler).to receive(:definition).and_raise(Bundler::GemfileNotFound, 'Could not locate Gemfile')
+    end
+
+    it 'falls back to resolving gems ignoring any local bundle instead of raising' do
+      expect { gemspec }.not_to raise_error
+      expect(gemspec.name).to eq(name)
+    end
+  end
 end


### PR DESCRIPTION
## Summary

- `Workspace::Gemspecs#in_this_bundle?` calls `Bundler.definition&.lockfile&.to_s&.start_with?(directory)`, but `Bundler.definition` raises `Bundler::GemfileNotFound` (not `nil`) when no Gemfile is discoverable from the current process's working directory. The safe-navigation chain doesn't help since the exception happens while evaluating `Bundler.definition` itself.
- This crashes any caller of `in_this_bundle?` (e.g. `find_gem`, `all_gemspecs_from_bundle`) whenever Solargraph itself is running outside of any bundle context - e.g. installed and invoked as a standalone gem.
- Rescues the exception and treats the workspace as not being "this bundle" in that case, falling back to the existing external-bundle resolution path.

Note: `Workspace::Gemspecs` is currently unused by the rest of `lib/` (this is a real, isolated bug fix in existing, tested code - not a functional change to Solargraph's current behavior).

## Test plan

- [x] Added a regression spec in `spec/workspace/gemspecs_find_gem_spec.rb` that stubs `Bundler.definition` to raise `Bundler::GemfileNotFound` and asserts `find_gem` falls back cleanly instead of raising
- [x] Verified locally: reverting just the `lib` fix (keeping the new spec) reproduces the exact crash (`Bundler::GemfileNotFound` uncaught at `gemspecs.rb:222`); restoring the fix makes it pass
- [x] `bundle exec rspec spec/workspace/` - 53 examples, 0 failures
- [x] `bundle exec rubocop lib/solargraph/workspace/gemspecs.rb spec/workspace/gemspecs_find_gem_spec.rb` - no offenses
- [x] `bundle exec solargraph typecheck --level strong` - confirmed identical 8 pre-existing findings on baseline (line numbers only shift by the added lines); no new findings introduced

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NdhWz9sGH13UicXmPwb4p9
