### PR TITLE
Allow arguments to satisfy RBS interface-typed parameters

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -25,14 +25,14 @@ jobs:
         #   It currently 404s ("Unavailable version head for ruby"), failing CI:
         #   https://github.com/castwide/solargraph/actions/runs/25863741955/job/76000137015?pr=1187
         ruby-version: ['3.1', '3.2', '3.3', '3.4', '4.0']
-        rbs-version: ['3.10.0', '4.0.1', '4.0.2', '4.1.0']
+        rbs-version: ['3.10.0', '4.0.3', '4.1.1', '4.1.1.pre.1']
         exclude:
           - ruby-version: '3.1'
-            rbs-version: '4.0.1'
+            rbs-version: '4.0.3'
           - ruby-version: '3.1'
-            rbs-version: '4.0.2'
+            rbs-version: '4.1.1'
           - ruby-version: '3.1'
-            rbs-version: '4.1.0'
+            rbs-version: '4.1.1.pre.1'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -25,14 +25,14 @@ jobs:
         #   It currently 404s ("Unavailable version head for ruby"), failing CI:
         #   https://github.com/castwide/solargraph/actions/runs/25863741955/job/76000137015?pr=1187
         ruby-version: ['3.1', '3.2', '3.3', '3.4', '4.0']
-        rbs-version: ['3.10.0', '4.0.0', '4.0.1', '4.0.2']
+        rbs-version: ['3.10.0', '4.0.1', '4.0.2', '4.1.0']
         exclude:
-          - ruby-version: '3.1'
-            rbs-version: '4.0.0'
           - ruby-version: '3.1'
             rbs-version: '4.0.1'
           - ruby-version: '3.1'
             rbs-version: '4.0.2'
+          - ruby-version: '3.1'
+            rbs-version: '4.1.0'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -25,14 +25,12 @@ jobs:
         #   It currently 404s ("Unavailable version head for ruby"), failing CI:
         #   https://github.com/castwide/solargraph/actions/runs/25863741955/job/76000137015?pr=1187
         ruby-version: ['3.1', '3.2', '3.3', '3.4', '4.0']
-        rbs-version: ['3.10.0', '4.0.3', '4.1.1', '4.1.1.pre.1']
+        rbs-version: ['3.10.0', '4.0.3', '4.1.1']
         exclude:
           - ruby-version: '3.1'
             rbs-version: '4.0.3'
           - ruby-version: '3.1'
             rbs-version: '4.1.1'
-          - ruby-version: '3.1'
-            rbs-version: '4.1.1.pre.1'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -227,10 +227,17 @@ module Solargraph
         ptype = typify api_map
         return true if ptype.undefined?
 
+        # RBS interfaces (e.g., Hash::_Key) describe duck types that
+        # Solargraph can't verify structurally without an explicit
+        # `include`, which core gems don't declare for every class that
+        # happens to satisfy them (e.g., every object responds to
+        # Hash::_Key's #hash and #eql?). Treat an argument as compatible
+        # with an interface-typed parameter rather than rejecting the
+        # overload outright.
         return true if atype.conforms_to?(api_map,
                                           ptype,
                                           :method_call,
-                                          %i[allow_empty_params allow_undefined])
+                                          %i[allow_empty_params allow_undefined allow_unmatched_interface])
         ptype.generic?
       end
 

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -227,13 +227,9 @@ module Solargraph
         ptype = typify api_map
         return true if ptype.undefined?
 
-        # RBS interfaces (e.g., Hash::_Key) describe duck types that
-        # Solargraph can't verify structurally without an explicit
-        # `include`, which core gems don't declare for every class that
-        # happens to satisfy them (e.g., every object responds to
-        # Hash::_Key's #hash and #eql?). Treat an argument as compatible
-        # with an interface-typed parameter rather than rejecting the
-        # overload outright.
+        # RBS interfaces (e.g., Hash::_Key) describe duck types core gems
+        # don't `include` on every satisfying class, so Solargraph can't
+        # verify them structurally; treat a match as compatible instead.
         return true if atype.conforms_to?(api_map,
                                           ptype,
                                           :method_call,

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -892,5 +892,35 @@ describe Solargraph::TypeChecker do
       # an error when trying to declare sub as Subclass
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
+
+    it 'resolves Hash#fetch return type on Hash{Symbol => Class<X>} without leaking a generic placeholder' do
+      # https://github.com/castwide/solargraph/issues/1227
+      #
+      # As of RBS 4.1.0, Hash#fetch's single-argument overload takes
+      # its key as the ::Hash::_Key duck-type interface instead of the
+      # generic K (see ruby/rbs core/hash.rbs). Solargraph couldn't
+      # prove a Symbol argument satisfies that interface, so it fell
+      # back to merging the return types of all of Hash#fetch's
+      # overloads (including the unresolved block-form's `generic<X>`)
+      # instead of picking the single-argument overload.
+      checker = type_checker(%(
+        class Foo; end
+
+        class Holder
+          # @return [Hash{Symbol => Class<Foo>}]
+          def registry
+            { x: Foo }
+          end
+
+          # @return [Foo]
+          def use_it
+            # @type [Class<Foo>]
+            clazz = registry.fetch(:x)
+            clazz.new
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq([])
+    end
   end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -998,16 +998,7 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
 
-    it 'resolves Hash#fetch return type on Hash{Symbol => Class<X>} without leaking a generic placeholder' do
-      # https://github.com/castwide/solargraph/issues/1227
-      #
-      # As of RBS 4.1.0, Hash#fetch's single-argument overload takes
-      # its key as the ::Hash::_Key duck-type interface instead of the
-      # generic K (see ruby/rbs core/hash.rbs). Solargraph couldn't
-      # prove a Symbol argument satisfies that interface, so it fell
-      # back to merging the return types of all of Hash#fetch's
-      # overloads (including the unresolved block-form's `generic<X>`)
-      # instead of picking the single-argument overload.
+    it "picks Hash#fetch's Hash::_Key-typed overload for a Symbol key instead of merging in the block form's generic" do
       checker = type_checker(%(
         class Foo; end
 


### PR DESCRIPTION
*🤖 Filed by Claude, not Vince — acting on his behalf via his GitHub credentials.*

Fixes #1227.

## Problem

As of RBS 4.1.0, `Hash#fetch`'s single-argument overload takes its key as the `::Hash::_Key` duck-type interface instead of the generic `K` (see `ruby/rbs` `core/hash.rbs`). `Pin::Parameter#compatible_arg?` had no way to confirm an argument satisfies an interface without an explicit `include` declaration — which core gems don't add for every class that happens to satisfy `Hash::_Key`'s `#hash`/`#eql?` contract — so the single-arg overload was rejected as a non-match for a plain `Symbol` argument.

`Call#inferred_pins` then fell back to merging the return types of *all* of `Hash#fetch`'s overloads (including the unresolved `generic<X>` placeholder from the block-taking overload) instead of resolving the one overload that actually matched the call, producing a spurious typecheck error like:

```
Declared type Class<Foo> does not match inferred type Class<Foo>, generic<X> for variable clazz
```

on any `Hash{Symbol => Class<X>}#fetch(:key)` call under `rbs >= 4.1.0`.

## Fix

Pass `:allow_unmatched_interface` into the conformance check in `Pin::Parameter#compatible_arg?`, so an argument is treated as compatible with an interface-typed parameter rather than rejecting the overload outright. This mirrors how `TypeChecker` already treats unmatched interfaces when comparing declared vs. inferred types (`type_checker.rb:80`).

## Testing

- Added a regression spec in `spec/type_checker/levels/strong_spec.rb` reproducing the exact repro from #1227; confirmed it fails without the fix and passes with it.
- `bundle exec rspec`: 1618 examples, 0 failures (65 pre-existing pending, unrelated to this change).
- `bundle exec rubocop` on changed files: no offenses.
- `bundle exec rake typecheck`: 548 problems (down from 551 on the same base commit without this change) — the remaining problems are pre-existing RBS 4.1.0 drift unrelated to this fix, out of scope here.