### PR TITLE
Add intersection (A & B) types, including Hash-based record support

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -126,10 +126,13 @@ jobs:
       BUNDLE_PATH: ${{ github.workspace }}/../solargraph-rspec/vendor/bundle
     steps:
     - uses: actions/checkout@v3
-    - name: clone https://github.com/lekemula/solargraph-rspec/
+    # lekemula/solargraph-rspec#36 raises the expectations this branch's
+    # more precise Hash record inference now satisfies.
+    - name: clone https://github.com/lekemula/solargraph-rspec/ pull/36
       run: |
        cd ..
-       git clone https://github.com/lekemula/solargraph-rspec.git
+       # git clone https://github.com/lekemula/solargraph-rspec.git
+       git clone --branch fix-hash-literal-type-precision https://github.com/apiology/solargraph-rspec.git
        cd solargraph-rspec
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -134,7 +134,7 @@ jobs:
        # pending https://github.com/lekemula/solargraph-rspec/pull/31
        git clone https://github.com/apiology/solargraph-rspec.git
        cd solargraph-rspec
-       git checkout test_solargraph_prereleases
+       git checkout fix-stale-hash-literal-assertions
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -126,12 +126,14 @@ jobs:
       BUNDLE_PATH: ${{ github.workspace }}/../solargraph-rspec/vendor/bundle
     steps:
     - uses: actions/checkout@v3
-    - name: clone https://github.com/lekemula/solargraph-rspec/
+    # lekemula/solargraph-rspec#36 raises the expectations this branch's
+    # more precise Hash record inference now satisfies.
+    - name: clone https://github.com/lekemula/solargraph-rspec/ pull/36
       run: |
        cd ..
-       git clone https://github.com/lekemula/solargraph-rspec.git
+       # git clone https://github.com/lekemula/solargraph-rspec.git
+       git clone --branch fix-hash-literal-type-precision https://github.com/apiology/solargraph-rspec.git
        cd solargraph-rspec
-       # git checkout fix-stale-hash-literal-assertions
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -93,6 +93,8 @@ Metrics/AbcSize:
 # AllowedMethods: refine
 Metrics/BlockLength:
   Max: 61
+  Exclude:
+    - 'lib/solargraph/complex_type.rb'
 
 # Configuration parameters: CountBlocks, CountModifierForms.
 Metrics/BlockNesting:
@@ -110,6 +112,7 @@ Metrics/ClassLength:
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.
 Metrics/CyclomaticComplexity:
   Exclude:
+    - 'lib/solargraph/complex_type.rb'
     - 'lib/solargraph/type_checker.rb'
 
 # Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.
@@ -132,6 +135,7 @@ Metrics/ParameterLists:
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.
 Metrics/PerceivedComplexity:
   Exclude:
+    - 'lib/solargraph/complex_type.rb'
     - 'lib/solargraph/parser/parser_gem/node_chainer.rb'
     - 'lib/solargraph/type_checker.rb'
 

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -578,7 +578,10 @@ module Solargraph
     # @return [Array<Solargraph::Pin::Method>]
     def get_method_stack rooted_tag, name, scope: :instance, visibility: %i[private protected public],
                          preserve_generics: false
-      rooted_type = ComplexType.parse(rooted_tag)
+      # rooted_tag is inference-derived, so an unparseable tag means
+      # "no methods here", the same way #get_methods already treats it,
+      # rather than an exception that aborts the whole request.
+      rooted_type = ComplexType.try_parse(rooted_tag)
       fqns = rooted_type.namespace
       namespace_pin = store.get_path_pins(fqns).first
       methods = if namespace_pin.is_a?(Pin::Constant)
@@ -824,7 +827,7 @@ module Solargraph
     # @param no_core [Boolean] Skip core classes if true
     # @return [Array<Pin::Base>]
     def inner_get_methods rooted_tag, scope, visibility, deep, skip, no_core = false
-      rooted_type = ComplexType.parse(rooted_tag).force_rooted
+      rooted_type = ComplexType.try_parse(rooted_tag).force_rooted
       fqns = rooted_type.namespace
       rooted_type.all_params
       namespace_pin = store.get_path_pins(fqns).select { |p| p.is_a?(Pin::Namespace) }.first

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -577,9 +577,6 @@ module Solargraph
     # @return [Array<Solargraph::Pin::Method>]
     def get_method_stack rooted_tag, name, scope: :instance, visibility: %i[private protected public],
                          preserve_generics: false
-      # rooted_tag is inference-derived, so an unparseable tag means
-      # "no methods here", the same way #get_methods already treats it,
-      # rather than an exception that aborts the whole request.
       rooted_type = ComplexType.try_parse(rooted_tag)
       fqns = rooted_type.namespace
       namespace_pin = store.get_path_pins(fqns).first

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -542,7 +542,7 @@ module Solargraph
       # protected and private methods are visible.
       return [] if complex_type.undefined? || complex_type.void?
       result = Set.new
-      complex_type.each do |type|
+      complex_type.items.each do |type|
         if type.duck_type?
           result.add Pin::DuckMethod.new(name: type.to_s[1..], source: :api_map)
           result.merge get_methods('Object')

--- a/lib/solargraph/api_map/constants.rb
+++ b/lib/solargraph/api_map/constants.rb
@@ -84,6 +84,11 @@ module Solargraph
                        type.tag == 'Boolean'
 
         gates.push '' unless gates.include?('')
+        unique_type = type.first
+        if unique_type.is_a?(ComplexType::UniqueType::Intersection)
+          return qualify_conjuncts(unique_type, gates)
+        end
+
         fqns = resolve(type.rooted_namespace, *gates)
         return unless fqns
         pin = store.get_path_pins(fqns).first
@@ -105,6 +110,23 @@ module Solargraph
 
       # @return [Store]
       attr_reader :store
+
+      # An intersection has no single namespace, so each conjunct is
+      # qualified on its own; a conjunct that cannot be resolved
+      # leaves the whole type unresolvable.
+      #
+      # @param intersection [ComplexType::UniqueType::Intersection]
+      # @param gates [Array<String>]
+      # @return [ComplexType, nil]
+      def qualify_conjuncts intersection, gates
+        qualified = intersection.conjuncts.map do |conjunct|
+          qualified_conjunct = qualify_type(conjunct, *gates)
+          return nil if qualified_conjunct.nil?
+
+          qualified_conjunct
+        end
+        ComplexType.new([ComplexType::UniqueType::Intersection.new(qualified)])
+      end
 
       # @param name [String]
       # @param gates [Array<String>]

--- a/lib/solargraph/api_map/constants.rb
+++ b/lib/solargraph/api_map/constants.rb
@@ -120,7 +120,8 @@ module Solargraph
       # @return [ComplexType, nil]
       def qualify_conjuncts intersection, gates
         qualified = intersection.conjuncts.map do |conjunct|
-          qualified_conjunct = qualify_type(conjunct, *gates)
+          # qualify_type needs a ComplexType: it calls #first, which no UniqueType has.
+          qualified_conjunct = qualify_type(ComplexType.new([conjunct]), *gates)
           return nil if qualified_conjunct.nil?
 
           qualified_conjunct

--- a/lib/solargraph/api_map/constants.rb
+++ b/lib/solargraph/api_map/constants.rb
@@ -84,7 +84,7 @@ module Solargraph
                        type.tag == 'Boolean'
 
         gates.push '' unless gates.include?('')
-        unique_type = type.first
+        unique_type = type.items.first
         if unique_type.is_a?(ComplexType::UniqueType::Intersection)
           return qualify_conjuncts(unique_type, gates)
         end

--- a/lib/solargraph/api_map/source_to_yard.rb
+++ b/lib/solargraph/api_map/source_to_yard.rb
@@ -36,17 +36,13 @@ module Solargraph
           if pin.type == :class
             # @param obj [YARD::CodeObjects::RootObject]
             code_object_map[pin.path] ||= YARD::CodeObjects::ClassObject.new(root_code_object, pin.path) do |obj|
-              # @sg-ignore flow sensitive typing needs to handle attrs
               next if pin.location.nil? || pin.location.filename.nil?
-              # @sg-ignore flow sensitive typing needs to handle attrs
               obj.add_file(pin.location.filename, pin.location.range.start.line, !pin.comments.empty?)
             end
           else
             # @param obj [YARD::CodeObjects::RootObject]
             code_object_map[pin.path] ||= YARD::CodeObjects::ModuleObject.new(root_code_object, pin.path) do |obj|
-              # @sg-ignore flow sensitive typing needs to handle attrs
               next if pin.location.nil? || pin.location.filename.nil?
-              # @sg-ignore flow sensitive typing needs to handle attrs
               obj.add_file(pin.location.filename, pin.location.range.start.line, !pin.comments.empty?)
             end
           end
@@ -77,9 +73,7 @@ module Solargraph
           code_object_map[pin.path] ||= YARD::CodeObjects::MethodObject.new(
             code_object_at(pin.namespace, YARD::CodeObjects::NamespaceObject), pin.name, pin.scope
           ) do |obj|
-            # @sg-ignore flow sensitive typing needs to handle attrs
             next if pin.location.nil? || pin.location.filename.nil?
-            # @sg-ignore flow sensitive typing needs to handle attrs
             obj.add_file pin.location.filename, pin.location.range.start.line
           end
           method_object = code_object_at(pin.path, YARD::CodeObjects::MethodObject)

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -450,72 +450,7 @@ module Solargraph
         types = []
         key_types = nil
         strings.each do |type_string|
-          point_stack = 0
-          curly_stack = 0
-          paren_stack = 0
-          base = String.new
-          subtype_string = String.new
-          # @param char [String]
-          type_string&.each_char do |char|
-            if char == '='
-              # raise ComplexTypeError, "Invalid = in type #{type_string}" unless curly_stack > 0
-            elsif char == '<'
-              point_stack += 1
-            elsif char == '>'
-              if subtype_string.end_with?('=') && curly_stack.positive?
-                subtype_string += char
-              elsif base.end_with?('=')
-                raise ComplexTypeError, 'Invalid hash thing' unless key_types.nil?
-                # types.push ComplexType.new([UniqueType.new(base[0..-2].strip)])
-                # @sg-ignore Need to add nil check here
-                types.push UniqueType.parse(base[0..-2].strip, subtype_string)
-                # @todo this should either expand key_type's type
-                #   automatically or complain about not being
-                #   compatible with key_type's type in type checking
-                key_types = types
-                types = []
-                base.clear
-                subtype_string.clear
-                next
-              else
-                raise ComplexTypeError, "Invalid close in type #{type_string}" if point_stack.zero?
-                point_stack -= 1
-                subtype_string += char
-              end
-              next
-            elsif char == '{'
-              curly_stack += 1
-            elsif char == '}'
-              curly_stack -= 1
-              subtype_string += char
-              raise ComplexTypeError, "Invalid close in type #{type_string}" if curly_stack.negative?
-              next
-            elsif char == '('
-              paren_stack += 1
-            elsif char == ')'
-              paren_stack -= 1
-              subtype_string += char
-              raise ComplexTypeError, "Invalid close in type #{type_string}" if paren_stack.negative?
-              next
-            elsif char == ',' && point_stack.zero? && curly_stack.zero? && paren_stack.zero?
-              # types.push ComplexType.new([UniqueType.new(base.strip, subtype_string.strip)])
-              types.push UniqueType.parse(base.strip, subtype_string.strip)
-              base.clear
-              subtype_string.clear
-              next
-            end
-            if point_stack.zero? && curly_stack.zero? && paren_stack.zero?
-              base.concat char
-            else
-              subtype_string.concat char
-            end
-          end
-          if point_stack != 0 || curly_stack != 0 || paren_stack != 0
-            raise ComplexTypeError,
-                  "Unclosed subtype in #{type_string}"
-          end
-          # types.push ComplexType.new([UniqueType.new(base, subtype_string)])
-          types.push UniqueType.parse(base.strip, subtype_string.strip)
+          types, key_types = parse_type_string(type_string, types, key_types)
         end
         unless key_types.nil?
           raise ComplexTypeError, 'Invalid use of key/value parameters' unless partial
@@ -534,6 +469,125 @@ module Solargraph
       rescue ComplexTypeError => e
         Solargraph.logger.info "Error parsing complex type `#{strings.join(', ')}`: #{e.message}"
         ComplexType::UNDEFINED
+      end
+
+      private
+
+      # Parses a single type string (one comma-separated slot of a
+      # types specifier list) and appends the resulting type(s) to
+      # +types+.
+      #
+      # A top-level `&` (not nested in `<>`, `{}`, or `()`) builds a
+      # ComplexType::UniqueType::Intersection instead of a plain
+      # UniqueType. This applies equally to ordinary YARD type tags
+      # and to RBS-derived tags, since both are parsed here; YARD has
+      # no official intersection syntax yet (see
+      # https://github.com/lsegal/yard/issues/1644), so this is a
+      # Solargraph extension using RBS's `&` convention.
+      #
+      # @param type_string [String, nil]
+      # @param types [Array<ComplexType::UniqueType>]
+      # @param key_types [Array<ComplexType::UniqueType>, nil]
+      # @return [Array(Array<ComplexType::UniqueType>, Array<ComplexType::UniqueType>, nil)]
+      def parse_type_string type_string, types, key_types
+        point_stack = 0
+        curly_stack = 0
+        paren_stack = 0
+        base = String.new
+        subtype_string = String.new
+        # conjuncts of an intersection type (`A & B`) seen so far in
+        # the segment currently being parsed
+        # @type [Array<ComplexType::UniqueType>]
+        conjuncts = []
+        # @param char [String]
+        type_string&.each_char do |char|
+          if char == '='
+            # raise ComplexTypeError, "Invalid = in type #{type_string}" unless curly_stack > 0
+          elsif char == '<'
+            point_stack += 1
+          elsif char == '>'
+            if subtype_string.end_with?('=') && curly_stack.positive?
+              subtype_string += char
+            elsif base.end_with?('=')
+              raise ComplexTypeError, 'Invalid hash thing' unless key_types.nil?
+              # types.push ComplexType.new([UniqueType.new(base[0..-2].strip)])
+              # @sg-ignore Need to add nil check here
+              types.push close_intersection(conjuncts, UniqueType.parse(base[0..-2].strip, subtype_string))
+              # @todo this should either expand key_type's type
+              #   automatically or complain about not being
+              #   compatible with key_type's type in type checking
+              key_types = types
+              types = []
+              conjuncts = []
+              base.clear
+              subtype_string.clear
+              next
+            else
+              raise ComplexTypeError, "Invalid close in type #{type_string}" if point_stack.zero?
+              point_stack -= 1
+              subtype_string += char
+            end
+            next
+          elsif char == '{'
+            curly_stack += 1
+          elsif char == '}'
+            curly_stack -= 1
+            subtype_string += char
+            raise ComplexTypeError, "Invalid close in type #{type_string}" if curly_stack.negative?
+            next
+          elsif char == '('
+            paren_stack += 1
+          elsif char == ')'
+            paren_stack -= 1
+            subtype_string += char
+            raise ComplexTypeError, "Invalid close in type #{type_string}" if paren_stack.negative?
+            next
+          elsif char == '&' && top_level?(point_stack, curly_stack, paren_stack)
+            conjuncts.push UniqueType.parse(base.strip, subtype_string.strip)
+            base.clear
+            subtype_string.clear
+            next
+          elsif char == ',' && top_level?(point_stack, curly_stack, paren_stack)
+            # types.push ComplexType.new([UniqueType.new(base.strip, subtype_string.strip)])
+            types.push close_intersection(conjuncts, UniqueType.parse(base.strip, subtype_string.strip))
+            conjuncts = []
+            base.clear
+            subtype_string.clear
+            next
+          end
+          if top_level?(point_stack, curly_stack, paren_stack)
+            base.concat char
+          else
+            subtype_string.concat char
+          end
+        end
+        if point_stack != 0 || curly_stack != 0 || paren_stack != 0
+          raise ComplexTypeError,
+                "Unclosed subtype in #{type_string}"
+        end
+        # types.push ComplexType.new([UniqueType.new(base, subtype_string)])
+        types.push close_intersection(conjuncts, UniqueType.parse(base.strip, subtype_string.strip))
+        [types, key_types]
+      end
+
+      # @param point_stack [Integer]
+      # @param curly_stack [Integer]
+      # @param paren_stack [Integer]
+      # @return [Boolean]
+      def top_level? point_stack, curly_stack, paren_stack
+        point_stack.zero? && curly_stack.zero? && paren_stack.zero?
+      end
+
+      # Wraps a just-parsed unique type together with any pending
+      # intersection conjuncts (types seen so far in this segment,
+      # separated by `&`) into a single UniqueType.
+      #
+      # @param conjuncts [Array<ComplexType::UniqueType>]
+      # @param final_type [ComplexType::UniqueType]
+      # @return [ComplexType::UniqueType]
+      def close_intersection conjuncts, final_type
+        return final_type if conjuncts.empty?
+        UniqueType::Intersection.new(conjuncts + [final_type])
       end
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -251,7 +251,15 @@ module Solargraph
       expected.each do |exp|
         next unless exp.duck_type?
         quack = exp.to_s[1..]
-        return false unless inferred.all? { |inf| unique_type_quacks?(api_map, quack, inf) }
+        return false if quack.nil?
+        unique_type = inferred.to_a.first
+        return false if unique_type.nil?
+        quacks = if unique_type.is_a?(UniqueType::Intersection)
+                   intersection_conjunct_quacks?(api_map, quack, unique_type)
+                 else
+                   !api_map.get_method_stack(unique_type.namespace, quack, scope: unique_type.scope).empty?
+                 end
+        return false unless quacks
       end
       true
     end
@@ -267,19 +275,18 @@ module Solargraph
     # its own alternatives does.
     #
     # @param api_map [ApiMap]
-    # @param quack [String, nil]
+    # @param quack [String]
     # @param unique_type [ComplexType::UniqueType]
     # @return [Boolean]
-    def unique_type_quacks? api_map, quack, unique_type
+    def intersection_conjunct_quacks? api_map, quack, unique_type
       if unique_type.is_a?(UniqueType::Intersection)
         return unique_type.conjuncts.any? do |conjunct|
-          conjunct.all? { |ut| unique_type_quacks?(api_map, quack, ut) }
+          conjunct.all? { |ut| intersection_conjunct_quacks?(api_map, quack, ut) }
         end
       end
       # A duck-typed conjunct only vouches for the one method its own
       # tag names - it has no namespace to look other methods up on.
       return unique_type.to_s[1..] == quack if unique_type.duck_type?
-      return false if quack.nil?
       !api_map.get_method_stack(unique_type.namespace, quack, scope: unique_type.scope).empty?
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -379,13 +379,16 @@ module Solargraph
     # Flow-sensitive type narrowing: given a type learned from a
     # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down to
     # the more specific of each compatible pair between the two
-    # sides. This is a set-refinement over alternatives, not a real
-    # intersection type - it never builds a compound type to
-    # represent unrelated members; if nothing on either side
-    # conforms to the other, the result is UNDEFINED. Contrast with
-    # ComplexType::UniqueType::Intersection, which represents a
-    # single value simultaneously satisfying multiple (possibly
-    # unrelated) types, as in the RBS/YARD `A & B` syntax.
+    # sides. When neither side is already known to be a subtype of
+    # the other but one is positively confirmed to be a mix-in (e.g.
+    # a declared class and an unrelated module), both facts are still
+    # true at once, so the pair is combined into a
+    # ComplexType::UniqueType::Intersection rather than discarded.
+    # Everything else - two different concrete classes (impossible;
+    # an object has exactly one class), or either side being a
+    # namespace we can't positively identify - falls back to the
+    # original behavior of dropping the pair; only if every pair is
+    # either dropped or empty does the result fall back to UNDEFINED.
     #
     # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
     #
@@ -403,6 +406,8 @@ module Solargraph
             types << candidate
           elsif ut.conforms_to?(api_map, candidate, :assignment)
             types << ut
+          elsif mixin_pairing?(api_map, ut, candidate)
+            types << UniqueType::Intersection.new([ComplexType.new([ut]), ComplexType.new([candidate])])
           end
         end
       end
@@ -427,6 +432,35 @@ module Solargraph
 
     def bottom?
       @items.all?(&:bot?)
+    end
+
+    # Whether combining these two into an intersection is safe. Only
+    # true when at least one side is *positively confirmed* to be a
+    # mix-in: any class can pick up any module, so a class-and-module
+    # pairing is always plausible. Everything else - two different
+    # concrete classes (impossible; an object has exactly one class),
+    # or a namespace we have no pin for (synthetic names like
+    # `Boolean`, generics, literals, duck types, or simply unresolved)
+    # - defaults to false, preserving the original drop-the-pair
+    # behavior. This is deliberately conservative: it only recognizes
+    # the specific case it was added for rather than guessing about
+    # everything narrow_with might be asked to combine.
+    #
+    # @param api_map [ApiMap]
+    # @param declared [ComplexType::UniqueType]
+    # @param candidate [ComplexType::UniqueType]
+    # @return [Boolean]
+    def mixin_pairing? api_map, declared, candidate
+      namespace_kind(api_map, declared) == :module || namespace_kind(api_map, candidate) == :module
+    end
+
+    # @param api_map [ApiMap]
+    # @param unique_type [ComplexType::UniqueType]
+    # @return [Symbol, nil] :class, :module, or nil if unknown
+    def namespace_kind api_map, unique_type
+      # @type [Pin::Namespace, nil]
+      pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }
+      pin&.type
     end
 
     class << self

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -376,21 +376,32 @@ module Solargraph
       ComplexType.new(types)
     end
 
-    # @see https://en.wikipedia.org/wiki/Intersection_type
+    # Flow-sensitive type narrowing: given a type learned from a
+    # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down to
+    # the more specific of each compatible pair between the two
+    # sides. This is a set-refinement over alternatives, not a real
+    # intersection type - it never builds a compound type to
+    # represent unrelated members; if nothing on either side
+    # conforms to the other, the result is UNDEFINED. Contrast with
+    # ComplexType::UniqueType::Intersection, which represents a
+    # single value simultaneously satisfying multiple (possibly
+    # unrelated) types, as in the RBS/YARD `A & B` syntax.
     #
-    # @param intersection_type [ComplexType, ComplexType::UniqueType, nil]
+    # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
+    #
+    # @param narrowing_type [ComplexType, ComplexType::UniqueType, nil]
     # @param api_map [ApiMap]
     # @return [self, ComplexType::UniqueType]
-    def intersect_with intersection_type, api_map
-      return self if intersection_type.nil?
-      return intersection_type if undefined?
+    def narrow_with narrowing_type, api_map
+      return self if narrowing_type.nil?
+      return narrowing_type if undefined?
       types = []
       # try to find common types via conformance
       items.each do |ut|
-        intersection_type.each do |int_type|
-          if int_type.conforms_to?(api_map, ut, :assignment)
-            types << int_type
-          elsif ut.conforms_to?(api_map, int_type, :assignment)
+        narrowing_type.each do |candidate|
+          if candidate.conforms_to?(api_map, ut, :assignment)
+            types << candidate
+          elsif ut.conforms_to?(api_map, candidate, :assignment)
             types << ut
           end
         end

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -251,10 +251,36 @@ module Solargraph
       expected.each do |exp|
         next unless exp.duck_type?
         quack = exp.to_s[1..]
-        # @sg-ignore Need to add nil check here
-        return false if api_map.get_method_stack(inferred.namespace, quack, scope: inferred.scope).empty?
+        return false unless inferred.all? { |inf| unique_type_quacks?(api_map, quack, inf) }
       end
       true
+    end
+
+    # Intersection#namespace/#scope only report the first conjunct,
+    # which loses the "any one conjunct satisfies" semantics an
+    # intersection needs against a duck-typed expectation - e.g. a
+    # mock stubbed to satisfy an interface, typed `SomeMockClass &
+    # #some_method`, has to be checked against every conjunct rather
+    # than the first one. A conjunct is itself a full ComplexType (RBS
+    # allows a union as one member of an intersection), so a union
+    # conjunct only counts as satisfying the duck type if every one of
+    # its own alternatives does.
+    #
+    # @param api_map [ApiMap]
+    # @param quack [String, nil]
+    # @param unique_type [ComplexType::UniqueType]
+    # @return [Boolean]
+    def unique_type_quacks? api_map, quack, unique_type
+      if unique_type.is_a?(UniqueType::Intersection)
+        return unique_type.conjuncts.any? do |conjunct|
+          conjunct.all? { |ut| unique_type_quacks?(api_map, quack, ut) }
+        end
+      end
+      # A duck-typed conjunct only vouches for the one method its own
+      # tag names - it has no namespace to look other methods up on.
+      return unique_type.to_s[1..] == quack if unique_type.duck_type?
+      # @sg-ignore Need to add nil check here
+      !api_map.get_method_stack(unique_type.namespace, quack, scope: unique_type.scope).empty?
     end
 
     # @return [String]

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -275,14 +275,7 @@ module Solargraph
     private :duck_type_provides?
 
     # Intersection#namespace/#scope only report the first conjunct,
-    # which loses the "any one conjunct satisfies" semantics an
-    # intersection needs against a duck-typed expectation - e.g. a
-    # mock stubbed to satisfy an interface, typed `SomeMockClass &
-    # #some_method`, has to be checked against every conjunct rather
-    # than the first one. A conjunct is itself a full ComplexType (RBS
-    # allows a union as one member of an intersection), so a union
-    # conjunct only counts as satisfying the duck type if every one of
-    # its own alternatives does.
+    # so this checks every conjunct against the duck type directly.
     #
     # @param api_map [ApiMap]
     # @param quack [String]
@@ -294,8 +287,7 @@ module Solargraph
           conjunct.all? { |ut| intersection_conjunct_quacks?(api_map, quack, ut) }
         end
       end
-      # A duck-typed conjunct only vouches for the one method its own
-      # tag names - it has no namespace to look other methods up on.
+      # A duck-typed conjunct only vouches for its own named method.
       return unique_type.to_s[1..] == quack if unique_type.duck_type?
       !api_map.get_method_stack(unique_type.namespace, quack, scope: unique_type.scope).empty?
     end
@@ -488,9 +480,9 @@ module Solargraph
 
     # @param api_map [ApiMap]
     # @param unique_type [ComplexType::UniqueType]
+    # @sg-ignore return type could not be inferred
     # @return [:class, :module, nil] nil when the namespace has no pin
     def namespace_kind api_map, unique_type
-      # @type [Pin::Namespace, nil]
       pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }
       pin&.type
     end
@@ -569,8 +561,11 @@ module Solargraph
                 #   automatically or complain about not being
                 #   compatible with key_type's type in type checking
                 key_types = types
+                # @type [Array<ComplexType::UniqueType, ComplexType>]
                 types = []
+                # @type [Array<ComplexType>]
                 conjuncts = []
+                # @type [Array<ComplexType, ComplexType::UniqueType>]
                 disjuncts = []
                 base.clear
                 subtype_string.clear

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -5,6 +5,9 @@ module Solargraph
   #
   class ComplexType
     GENERIC_TAG_NAME = 'generic'
+
+    # the quote characters that open and close a string literal type
+    QUOTE_CHARACTERS = ['"', "'"].freeze
     # @!parse
     #   include TypeMethods
     include Equality
@@ -541,7 +544,7 @@ module Solargraph
               # inside a string literal every character is content, so
               # separators and brackets carry no syntactic meaning
               quote = nil if char == quote
-            elsif char == '"' || char == "'"
+            elsif QUOTE_CHARACTERS.include?(char)
               quote = char
             elsif char == '='
               # raise ComplexTypeError, "Invalid = in type #{type_string}" unless curly_stack > 0

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -508,7 +508,7 @@ module Solargraph
         subtype_string = String.new
         # conjuncts of an intersection type (`A & B`) seen so far in
         # the segment currently being parsed
-        # @type [Array<ComplexType::UniqueType>]
+        # @type [Array<ComplexType>]
         conjuncts = []
         # @param char [String]
         type_string&.each_char do |char|
@@ -554,7 +554,7 @@ module Solargraph
             raise ComplexTypeError, "Invalid close in type #{type_string}" if paren_stack.negative?
             next
           elsif char == '&' && top_level?(point_stack, curly_stack, paren_stack)
-            conjuncts.push UniqueType.parse(base.strip, subtype_string.strip)
+            conjuncts.push ComplexType.new([UniqueType.parse(base.strip, subtype_string.strip)])
             base.clear
             subtype_string.clear
             next
@@ -591,14 +591,16 @@ module Solargraph
 
       # Wraps a just-parsed unique type together with any pending
       # intersection conjuncts (types seen so far in this segment,
-      # separated by `&`) into a single UniqueType.
+      # separated by `&`) into a single UniqueType. Each conjunct is
+      # a ComplexType (see UniqueType::Intersection), so the final
+      # parsed type is promoted to a single-item ComplexType too.
       #
-      # @param conjuncts [Array<ComplexType::UniqueType>]
+      # @param conjuncts [Array<ComplexType>]
       # @param final_type [ComplexType::UniqueType]
       # @return [ComplexType::UniqueType]
       def close_intersection conjuncts, final_type
         return final_type if conjuncts.empty?
-        UniqueType::Intersection.new(conjuncts + [final_type])
+        UniqueType::Intersection.new(conjuncts + [ComplexType.new([final_type])])
       end
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -538,12 +538,17 @@ module Solargraph
         point_stack = 0
         curly_stack = 0
         paren_stack = 0
+        bracket_stack = 0
         base = String.new
         subtype_string = String.new
         # conjuncts of an intersection type (`A & B`) seen so far in
-        # the segment currently being parsed
+        # the current `|`-disjunct of the segment being parsed
         # @type [Array<ComplexType>]
         conjuncts = []
+        # disjuncts of a union type (`A | B`) seen so far in the
+        # segment currently being parsed
+        # @type [Array<ComplexType, ComplexType::UniqueType>]
+        disjuncts = []
         # @param char [String]
         type_string&.each_char do |char|
           if char == '='
@@ -555,17 +560,8 @@ module Solargraph
               subtype_string += char
             elsif base.end_with?('=')
               raise ComplexTypeError, 'Invalid hash thing' unless key_types.nil?
-              # types.push ComplexType.new([UniqueType.new(base[0..-2].strip)])
-              # @sg-ignore Need to add nil check here
-              types.push close_intersection(conjuncts, UniqueType.parse(base[0..-2].strip, subtype_string))
-              # @todo this should either expand key_type's type
-              #   automatically or complain about not being
-              #   compatible with key_type's type in type checking
-              key_types = types
+              key_types = close_key_types(base, subtype_string, conjuncts, disjuncts, types)
               types = []
-              conjuncts = []
-              base.clear
-              subtype_string.clear
               next
             else
               raise ComplexTypeError, "Invalid close in type #{type_string}" if point_stack.zero?
@@ -576,65 +572,167 @@ module Solargraph
           elsif char == '{'
             curly_stack += 1
           elsif char == '}'
-            curly_stack -= 1
-            subtype_string += char
-            raise ComplexTypeError, "Invalid close in type #{type_string}" if curly_stack.negative?
+            curly_stack = close_bracket(curly_stack, subtype_string, char, type_string)
             next
           elsif char == '('
             paren_stack += 1
           elsif char == ')'
-            paren_stack -= 1
-            subtype_string += char
-            raise ComplexTypeError, "Invalid close in type #{type_string}" if paren_stack.negative?
+            paren_stack = close_bracket(paren_stack, subtype_string, char, type_string)
             next
-          elsif char == '&' && top_level?(point_stack, curly_stack, paren_stack)
-            conjuncts.push ComplexType.new([UniqueType.parse(base.strip, subtype_string.strip)])
+          elsif char == '[' &&
+                (bracket_stack.positive? ||
+                 (base.strip.empty? && point_stack.zero? && curly_stack.zero? && paren_stack.zero?))
+            # Only a fresh atom (blank base, not already nested in
+            # <>/{}/()) can start a `[...]` group - matching
+            # finish_atom's own precondition. Otherwise `[` is just an
+            # ordinary character, e.g. part of a quoted string literal
+            # type like `"[]"`, which has no concept of grouping.
+            bracket_stack += 1
+          elsif char == ']' && bracket_stack.positive?
+            bracket_stack = close_bracket(bracket_stack, subtype_string, char, type_string)
+            next
+          elsif char == '&' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+            conjuncts.push ComplexType.new([finish_atom(base, subtype_string)])
             base.clear
             subtype_string.clear
             next
-          elsif char == ',' && top_level?(point_stack, curly_stack, paren_stack)
-            # types.push ComplexType.new([UniqueType.new(base.strip, subtype_string.strip)])
-            types.push close_intersection(conjuncts, UniqueType.parse(base.strip, subtype_string.strip))
+          elsif char == '|' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+            disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
             conjuncts = []
             base.clear
             subtype_string.clear
             next
+          elsif char == ',' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+            disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
+            types.push close_disjunction(disjuncts)
+            conjuncts = []
+            disjuncts = []
+            base.clear
+            subtype_string.clear
+            next
           end
-          if top_level?(point_stack, curly_stack, paren_stack)
+          if top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
             base.concat char
           else
             subtype_string.concat char
           end
         end
-        if point_stack != 0 || curly_stack != 0 || paren_stack != 0
+        if point_stack != 0 || curly_stack != 0 || paren_stack != 0 || bracket_stack != 0
           raise ComplexTypeError,
                 "Unclosed subtype in #{type_string}"
         end
-        # types.push ComplexType.new([UniqueType.new(base, subtype_string)])
-        types.push close_intersection(conjuncts, UniqueType.parse(base.strip, subtype_string.strip))
+        disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
+        types.push close_disjunction(disjuncts)
         [types, key_types]
+      end
+
+      # Decrements the stack counter for a closing `}`/`)`/`]` and
+      # appends it to the pending subtype substring.
+      #
+      # @param stack [Integer]
+      # @param subtype_string [String]
+      # @param char [String]
+      # @param type_string [String, nil]
+      # @return [Integer] the decremented stack counter
+      def close_bracket stack, subtype_string, char, type_string
+        stack -= 1
+        subtype_string << char
+        raise ComplexTypeError, "Invalid close in type #{type_string}" if stack.negative?
+        stack
+      end
+
+      # Closes the key-list portion of a `Hash{K=>V}` split (the base
+      # ending in `=` marks the boundary) and returns the types parsed
+      # so far to be stashed as the eventual key_types, leaving
+      # conjuncts/disjuncts/base/subtype_string cleared for the value
+      # list that follows.
+      #
+      # @todo this should either expand key_type's type automatically
+      #   or complain about not being compatible with key_type's type
+      #   in type checking
+      #
+      # @param base [String]
+      # @param subtype_string [String]
+      # @param conjuncts [Array<ComplexType>]
+      # @param disjuncts [Array<ComplexType, ComplexType::UniqueType>]
+      # @param types [Array<ComplexType::UniqueType, ComplexType>]
+      # @return [Array<ComplexType::UniqueType, ComplexType>] the key_types
+      def close_key_types base, subtype_string, conjuncts, disjuncts, types
+        # @sg-ignore Need to add nil check here
+        disjuncts.push close_intersection(conjuncts, finish_atom(base[0..-2], subtype_string))
+        types.push close_disjunction(disjuncts)
+        conjuncts.clear
+        disjuncts.clear
+        base.clear
+        subtype_string.clear
+        types
       end
 
       # @param point_stack [Integer]
       # @param curly_stack [Integer]
       # @param paren_stack [Integer]
+      # @param bracket_stack [Integer]
       # @return [Boolean]
-      def top_level? point_stack, curly_stack, paren_stack
-        point_stack.zero? && curly_stack.zero? && paren_stack.zero?
+      def top_level? point_stack, curly_stack, paren_stack, bracket_stack
+        point_stack.zero? && curly_stack.zero? && paren_stack.zero? && bracket_stack.zero?
       end
 
-      # Wraps a just-parsed unique type together with any pending
-      # intersection conjuncts (types seen so far in this segment,
+      # Resolves one type atom - either an ordinary named type (`base`
+      # plus its optional `<...>`/`(...)`/`{...}` parameter substring),
+      # or a standalone `[...]` grouping with no leading name, used to
+      # override the default order of operations (e.g. `[Foo | Bar] &
+      # Baz`, where `[...]` is the only way to mark where the union
+      # ends). A bracket group's content is parsed the same way any
+      # other parameter substring is - recursively, via
+      # ComplexType.parse - and its result substituted directly, since
+      # it can itself be a multi-item union (or an intersection).
+      #
+      # @param base [String]
+      # @param subtype_string [String]
+      # @return [ComplexType::UniqueType, ComplexType]
+      def finish_atom base, subtype_string
+        base = base.strip
+        subtype_string = subtype_string.strip
+        if base.empty? && subtype_string.start_with?('[')
+          raise ComplexTypeError, "Unclosed bracket group in #{subtype_string}" unless subtype_string.end_with?(']')
+          return ComplexType.new(ComplexType.parse(subtype_string[1..-2], partial: true))
+        end
+        UniqueType.parse(base, subtype_string)
+      end
+
+      # Wraps a just-parsed atom together with any pending
+      # intersection conjuncts (types seen so far in this disjunct,
       # separated by `&`) into a single UniqueType. Each conjunct is
       # a ComplexType (see UniqueType::Intersection), so the final
       # parsed type is promoted to a single-item ComplexType too.
       #
       # @param conjuncts [Array<ComplexType>]
-      # @param final_type [ComplexType::UniqueType]
-      # @return [ComplexType::UniqueType]
+      # @param final_type [ComplexType::UniqueType, ComplexType]
+      # @return [ComplexType::UniqueType, ComplexType]
       def close_intersection conjuncts, final_type
         return final_type if conjuncts.empty?
         UniqueType::Intersection.new(conjuncts + [ComplexType.new([final_type])])
+      end
+
+      # Collapses the disjuncts of a union type (`A | B`) seen so far
+      # in the segment currently being parsed into a single value to
+      # push into the enclosing types/subtypes list - a bare type when
+      # there was only one (the common case, `|` never used), or a
+      # real multi-item ComplexType union otherwise. This is also
+      # exactly what a top-level `,` in an already-implicit-union
+      # context (Array<...>, Set<...>, hash key/value lists, the
+      # top-level types list itself) reduces to, since each of those
+      # contexts flattens every comma-separated type into one union
+      # regardless of how it's grouped here - so `,` and `|` land on
+      # the same result there, matching RBS's own tag design.
+      #
+      # @param disjuncts [Array<ComplexType, ComplexType::UniqueType>]
+      # @return [ComplexType::UniqueType, ComplexType]
+      # @sg-ignore #first is only nil for an empty array, and this is
+      #   never called with one
+      def close_disjunction disjuncts
+        return disjuncts.first if disjuncts.length == 1
+        ComplexType.new(disjuncts)
       end
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -279,7 +279,7 @@ module Solargraph
       # A duck-typed conjunct only vouches for the one method its own
       # tag names - it has no namespace to look other methods up on.
       return unique_type.to_s[1..] == quack if unique_type.duck_type?
-      # @sg-ignore Need to add nil check here
+      return false if quack.nil?
       !api_map.get_method_stack(unique_type.namespace, quack, scope: unique_type.scope).empty?
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -525,12 +525,8 @@ module Solargraph
           bracket_stack = 0
           base = String.new
           subtype_string = String.new
-          # conjuncts of an intersection type (`A & B`) seen so far in
-          # the current `|`-disjunct of the segment being parsed
           # @type [Array<ComplexType>]
           conjuncts = []
-          # disjuncts of a union type (`A | B`) seen so far in the
-          # segment currently being parsed
           # @type [Array<ComplexType, ComplexType::UniqueType>]
           disjuncts = []
           # the open quote character of the string literal being read

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -411,17 +411,11 @@ module Solargraph
 
     # Flow-sensitive type narrowing: given a type learned from a
     # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down to
-    # the more specific of each compatible pair between the two
-    # sides. When neither side is already known to be a subtype of
-    # the other but one is positively confirmed to be a mix-in (e.g.
-    # a declared class and an unrelated module), both facts are still
-    # true at once, so the pair is combined into a
-    # ComplexType::UniqueType::Intersection rather than discarded.
-    # Everything else - two different concrete classes (impossible;
-    # an object has exactly one class), or either side being a
-    # namespace we can't positively identify - falls back to the
-    # original behavior of dropping the pair; only if every pair is
-    # either dropped or empty does the result fall back to UNDEFINED.
+    # the more specific of each compatible pair. When neither side
+    # subtypes the other but one is confirmed to be a mix-in, both
+    # facts hold at once, so the pair becomes an Intersection; any
+    # other pair is dropped (see #mixin_pairing?). UNDEFINED results
+    # only when every pair is dropped or empty.
     #
     # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
     #
@@ -473,11 +467,8 @@ module Solargraph
     # pairing is always plausible. Everything else - two different
     # concrete classes (impossible; an object has exactly one class),
     # or a namespace we have no pin for (synthetic names like
-    # `Boolean`, generics, literals, duck types, or simply unresolved)
-    # - defaults to false, preserving the original drop-the-pair
-    # behavior. This is deliberately conservative: it only recognizes
-    # the specific case it was added for rather than guessing about
-    # everything narrow_with might be asked to combine.
+    # `Boolean`, generics, literals, duck types, or unresolved) -
+    # is false, so narrow_with drops the pair.
     #
     # @param api_map [ApiMap]
     # @param declared [ComplexType::UniqueType]
@@ -715,10 +706,9 @@ module Solargraph
       # or a standalone `[...]` grouping with no leading name, used to
       # override the default order of operations (e.g. `[Foo | Bar] &
       # Baz`, where `[...]` is the only way to mark where the union
-      # ends). A bracket group's content is parsed the same way any
-      # other parameter substring is - recursively, via
-      # ComplexType.parse - and its result substituted directly, since
-      # it can itself be a multi-item union (or an intersection).
+      # ends). A bracket group's content is parsed recursively via
+      # ComplexType.parse and substituted directly, since it can
+      # itself be a union or an intersection.
       #
       # @param base [String]
       # @param subtype_string [String]
@@ -748,23 +738,17 @@ module Solargraph
       end
 
       # Collapses the disjuncts of a union type (`A | B`) seen so far
-      # in the segment currently being parsed into a single value to
-      # push into the enclosing types/subtypes list - a bare type when
-      # there was only one (the common case, `|` never used), or a
-      # real multi-item ComplexType union otherwise. This is also
-      # exactly what a top-level `,` in an already-implicit-union
-      # context (Array<...>, Set<...>, hash key/value lists, the
-      # top-level types list itself) reduces to, since each of those
-      # contexts flattens every comma-separated type into one union
-      # regardless of how it's grouped here - so `,` and `|` land on
-      # the same result there, matching RBS's own tag design.
+      # into a single value to push into the enclosing types/subtypes
+      # list - a bare type when `|` was never used, a multi-item
+      # ComplexType union otherwise. A top-level `,` in an
+      # already-implicit-union context (Array<...>, hash key/value
+      # lists, the top-level types list) reduces to the same thing,
+      # since those contexts flatten commas into one union anyway.
       #
       # @param disjuncts [Array<ComplexType, ComplexType::UniqueType>]
       # @return [ComplexType::UniqueType, ComplexType]
-      # @sg-ignore #first is only nil for an empty array, and this is
-      #   never called with one
       def close_disjunction disjuncts
-        return disjuncts.first if disjuncts.length == 1
+        return disjuncts.fetch(0) if disjuncts.length == 1
         ComplexType.new(disjuncts)
       end
     end

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -463,12 +463,10 @@ module Solargraph
 
     # Whether combining these two into an intersection is safe. Only
     # true when at least one side is *positively confirmed* to be a
-    # mix-in: any class can pick up any module, so a class-and-module
-    # pairing is always plausible. Everything else - two different
-    # concrete classes (impossible; an object has exactly one class),
-    # or a namespace we have no pin for (synthetic names like
-    # `Boolean`, generics, literals, duck types, or unresolved) -
-    # is false, so narrow_with drops the pair.
+    # mix-in, since any class can pick up any module. Two concrete
+    # classes are impossible (an object has exactly one class), and a
+    # namespace with no pin is unverifiable, so both are false and
+    # narrow_with drops the pair.
     #
     # @param api_map [ApiMap]
     # @param declared [ComplexType::UniqueType]
@@ -480,7 +478,7 @@ module Solargraph
 
     # @param api_map [ApiMap]
     # @param unique_type [ComplexType::UniqueType]
-    # @return [Symbol, nil] :class, :module, or nil if unknown
+    # @return [:class, :module, nil] nil when the namespace has no pin
     def namespace_kind api_map, unique_type
       # @type [Pin::Namespace, nil]
       pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }
@@ -519,7 +517,120 @@ module Solargraph
         types = []
         key_types = nil
         strings.each do |type_string|
-          types, key_types = parse_type_string(type_string, types, key_types)
+          point_stack = 0
+          curly_stack = 0
+          paren_stack = 0
+          bracket_stack = 0
+          base = String.new
+          subtype_string = String.new
+          # conjuncts of an intersection type (`A & B`) seen so far in
+          # the current `|`-disjunct of the segment being parsed
+          # @type [Array<ComplexType>]
+          conjuncts = []
+          # disjuncts of a union type (`A | B`) seen so far in the
+          # segment currently being parsed
+          # @type [Array<ComplexType, ComplexType::UniqueType>]
+          disjuncts = []
+          # the open quote character of the string literal being read
+          # (e.g. `"Index"`), or nil outside one
+          # @type [String, nil]
+          quote = nil
+          # @param char [String]
+          type_string&.each_char do |char|
+            if quote
+              # inside a string literal every character is content, so
+              # separators and brackets carry no syntactic meaning
+              quote = nil if char == quote
+            elsif char == '"' || char == "'"
+              quote = char
+            elsif char == '='
+              # raise ComplexTypeError, "Invalid = in type #{type_string}" unless curly_stack > 0
+            elsif char == '<'
+              point_stack += 1
+            elsif char == '>'
+              if subtype_string.end_with?('=') && curly_stack.positive?
+                subtype_string += char
+              elsif base.end_with?('=')
+                raise ComplexTypeError, 'Invalid hash thing' unless key_types.nil?
+                # @sg-ignore Need to add nil check here
+                disjuncts.push close_intersection(conjuncts, finish_atom(base[0..-2], subtype_string))
+                types.push close_disjunction(disjuncts)
+                # @todo this should either expand key_type's type
+                #   automatically or complain about not being
+                #   compatible with key_type's type in type checking
+                key_types = types
+                types = []
+                conjuncts = []
+                disjuncts = []
+                base.clear
+                subtype_string.clear
+                next
+              else
+                raise ComplexTypeError, "Invalid close in type #{type_string}" if point_stack.zero?
+                point_stack -= 1
+                subtype_string += char
+              end
+              next
+            elsif char == '{'
+              curly_stack += 1
+            elsif char == '}'
+              curly_stack -= 1
+              subtype_string += char
+              raise ComplexTypeError, "Invalid close in type #{type_string}" if curly_stack.negative?
+              next
+            elsif char == '('
+              paren_stack += 1
+            elsif char == ')'
+              paren_stack -= 1
+              subtype_string += char
+              raise ComplexTypeError, "Invalid close in type #{type_string}" if paren_stack.negative?
+              next
+            elsif char == '[' &&
+                  (bracket_stack.positive? ||
+                   (base.strip.empty? && point_stack.zero? && curly_stack.zero? && paren_stack.zero?))
+              # Only a fresh atom (blank base, not already nested in
+              # <>/{}/()) can start a `[...]` group - matching
+              # finish_atom's own precondition. Otherwise `[` is just an
+              # ordinary character, e.g. part of a literal type like
+              # `"[]"`, which has no concept of grouping.
+              bracket_stack += 1
+            elsif char == ']' && bracket_stack.positive?
+              bracket_stack -= 1
+              subtype_string += char
+              next
+            elsif char == '&' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+              conjuncts.push ComplexType.new([finish_atom(base, subtype_string)])
+              base.clear
+              subtype_string.clear
+              next
+            elsif char == '|' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+              disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
+              conjuncts = []
+              base.clear
+              subtype_string.clear
+              next
+            elsif char == ',' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+              disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
+              types.push close_disjunction(disjuncts)
+              conjuncts = []
+              disjuncts = []
+              base.clear
+              subtype_string.clear
+              next
+            end
+            if top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+              base.concat char
+            else
+              subtype_string.concat char
+            end
+          end
+          raise ComplexTypeError, "Unclosed string literal in #{type_string}" if quote
+          if point_stack != 0 || curly_stack != 0 || paren_stack != 0 || bracket_stack != 0
+            raise ComplexTypeError,
+                  "Unclosed subtype in #{type_string}"
+          end
+          disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
+          types.push close_disjunction(disjuncts)
         end
         unless key_types.nil?
           raise ComplexTypeError, 'Invalid use of key/value parameters' unless partial
@@ -541,156 +652,6 @@ module Solargraph
       end
 
       private
-
-      # Parses a single type string (one comma-separated slot of a
-      # types specifier list) and appends the resulting type(s) to
-      # +types+.
-      #
-      # A top-level `&` (not nested in `<>`, `{}`, or `()`) builds a
-      # ComplexType::UniqueType::Intersection instead of a plain
-      # UniqueType. This applies equally to ordinary YARD type tags
-      # and to RBS-derived tags, since both are parsed here; YARD has
-      # no official intersection syntax yet (see
-      # https://github.com/lsegal/yard/issues/1644), so this is a
-      # Solargraph extension using RBS's `&` convention.
-      #
-      # @param type_string [String, nil]
-      # @param types [Array<ComplexType::UniqueType>]
-      # @param key_types [Array<ComplexType::UniqueType>, nil]
-      # @return [Array(Array<ComplexType::UniqueType>, Array<ComplexType::UniqueType>, nil)]
-      def parse_type_string type_string, types, key_types
-        point_stack = 0
-        curly_stack = 0
-        paren_stack = 0
-        bracket_stack = 0
-        base = String.new
-        subtype_string = String.new
-        # conjuncts of an intersection type (`A & B`) seen so far in
-        # the current `|`-disjunct of the segment being parsed
-        # @type [Array<ComplexType>]
-        conjuncts = []
-        # disjuncts of a union type (`A | B`) seen so far in the
-        # segment currently being parsed
-        # @type [Array<ComplexType, ComplexType::UniqueType>]
-        disjuncts = []
-        # @param char [String]
-        type_string&.each_char do |char|
-          if char == '='
-            # raise ComplexTypeError, "Invalid = in type #{type_string}" unless curly_stack > 0
-          elsif char == '<'
-            point_stack += 1
-          elsif char == '>'
-            if subtype_string.end_with?('=') && curly_stack.positive?
-              subtype_string += char
-            elsif base.end_with?('=')
-              raise ComplexTypeError, 'Invalid hash thing' unless key_types.nil?
-              key_types = close_key_types(base, subtype_string, conjuncts, disjuncts, types)
-              types = []
-              next
-            else
-              raise ComplexTypeError, "Invalid close in type #{type_string}" if point_stack.zero?
-              point_stack -= 1
-              subtype_string += char
-            end
-            next
-          elsif char == '{'
-            curly_stack += 1
-          elsif char == '}'
-            curly_stack = close_bracket(curly_stack, subtype_string, char, type_string)
-            next
-          elsif char == '('
-            paren_stack += 1
-          elsif char == ')'
-            paren_stack = close_bracket(paren_stack, subtype_string, char, type_string)
-            next
-          elsif char == '[' &&
-                (bracket_stack.positive? ||
-                 (base.strip.empty? && point_stack.zero? && curly_stack.zero? && paren_stack.zero?))
-            # Only a fresh atom (blank base, not already nested in
-            # <>/{}/()) can start a `[...]` group - matching
-            # finish_atom's own precondition. Otherwise `[` is just an
-            # ordinary character, e.g. part of a quoted string literal
-            # type like `"[]"`, which has no concept of grouping.
-            bracket_stack += 1
-          elsif char == ']' && bracket_stack.positive?
-            bracket_stack = close_bracket(bracket_stack, subtype_string, char, type_string)
-            next
-          elsif char == '&' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
-            conjuncts.push ComplexType.new([finish_atom(base, subtype_string)])
-            base.clear
-            subtype_string.clear
-            next
-          elsif char == '|' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
-            disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
-            conjuncts = []
-            base.clear
-            subtype_string.clear
-            next
-          elsif char == ',' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
-            disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
-            types.push close_disjunction(disjuncts)
-            conjuncts = []
-            disjuncts = []
-            base.clear
-            subtype_string.clear
-            next
-          end
-          if top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
-            base.concat char
-          else
-            subtype_string.concat char
-          end
-        end
-        if point_stack != 0 || curly_stack != 0 || paren_stack != 0 || bracket_stack != 0
-          raise ComplexTypeError,
-                "Unclosed subtype in #{type_string}"
-        end
-        disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
-        types.push close_disjunction(disjuncts)
-        [types, key_types]
-      end
-
-      # Decrements the stack counter for a closing `}`/`)`/`]` and
-      # appends it to the pending subtype substring.
-      #
-      # @param stack [Integer]
-      # @param subtype_string [String]
-      # @param char [String]
-      # @param type_string [String, nil]
-      # @return [Integer] the decremented stack counter
-      def close_bracket stack, subtype_string, char, type_string
-        stack -= 1
-        subtype_string << char
-        raise ComplexTypeError, "Invalid close in type #{type_string}" if stack.negative?
-        stack
-      end
-
-      # Closes the key-list portion of a `Hash{K=>V}` split (the base
-      # ending in `=` marks the boundary) and returns the types parsed
-      # so far to be stashed as the eventual key_types, leaving
-      # conjuncts/disjuncts/base/subtype_string cleared for the value
-      # list that follows.
-      #
-      # @todo this should either expand key_type's type automatically
-      #   or complain about not being compatible with key_type's type
-      #   in type checking
-      #
-      # @param base [String]
-      # @param subtype_string [String]
-      # @param conjuncts [Array<ComplexType>]
-      # @param disjuncts [Array<ComplexType, ComplexType::UniqueType>]
-      # @param types [Array<ComplexType::UniqueType, ComplexType>]
-      # @return [Array<ComplexType::UniqueType, ComplexType>] the key_types
-      def close_key_types base, subtype_string, conjuncts, disjuncts, types
-        # @sg-ignore Need to add nil check here
-        disjuncts.push close_intersection(conjuncts, finish_atom(base[0..-2], subtype_string))
-        types.push close_disjunction(disjuncts)
-        conjuncts.clear
-        disjuncts.clear
-        base.clear
-        subtype_string.clear
-        types
-      end
 
       # @param point_stack [Integer]
       # @param curly_stack [Integer]

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -480,7 +480,7 @@ module Solargraph
 
     # @param api_map [ApiMap]
     # @param unique_type [ComplexType::UniqueType]
-    # @sg-ignore return type could not be inferred
+    # @sg-ignore flow sensitive typing needs to infer Enumerable#find's block return type from an is_a? check
     # @return [:class, :module, nil] nil when the namespace has no pin
     def namespace_kind api_map, unique_type
       pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -46,6 +46,24 @@ module Solargraph
       ComplexType.new(types).reduce_object
     end
 
+    # Pins for calling +word+ on each alternative of this union
+    # (loose_unions allows leniency).
+    #
+    # @param word [String]
+    # @param api_map [ApiMap]
+    # @yieldparam conjuncts [Array<ComplexType>] the conjuncts of an intersection
+    # @yieldreturn [Array<ComplexType>] the conjuncts to dispatch on
+    # @return [Array<Pin::Base>]
+    def method_stack_pins word, api_map, &narrow_conjuncts
+      pin_groups = @items.map { |item| item.method_stack_pins(word, api_map, &narrow_conjuncts) }
+      return [] if !api_map.loose_unions && pin_groups.any?(&:nil?)
+
+      # Dedup on path *and* return type: alternatives can share a
+      # path (e.g. same generic method on different instantiations).
+      # @param p [Pin::Base]
+      pin_groups.compact.flatten.uniq { |p| [p.path, p.return_type.tag] }
+    end
+
     # @param generics_to_resolve [Enumerable<String>]]
     # @param context_type [ComplexType, ComplexType::UniqueType, nil]
     # @param resolved_generic_values [Hash{String => ComplexType}] Added to as types are encountered or resolved

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -6,8 +6,8 @@ module Solargraph
   class ComplexType
     GENERIC_TAG_NAME = 'generic'
 
-    # the quote characters that open and close a string literal type
     QUOTE_CHARACTERS = ['"', "'"].freeze
+
     # @!parse
     #   include TypeMethods
     include Equality

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -50,7 +50,7 @@ module Solargraph
     # @param gates [Array<String>]
     # @return [ComplexType]
     def unalias_and_qualify api_map, *gates
-      ComplexType.new(map { |t| t.unalias_and_qualify(api_map, *gates) })
+      ComplexType.new(items.map { |t| t.unalias_and_qualify(api_map, *gates) })
     end
 
     # Pins for calling +word+ on each alternative of this union
@@ -102,16 +102,6 @@ module Solargraph
     end
 
     # @yieldparam [UniqueType]
-    # @yieldreturn [UniqueType]
-    # @return [Array<UniqueType>]
-    # @sg-ignore Declared return type
-    #   ::Array<::Solargraph::ComplexType::UniqueType> does not match
-    #   inferred type ::Array<::Proc> for Solargraph::ComplexType#map
-    def map &block
-      @items.map(&block)
-    end
-
-    # @yieldparam [UniqueType]
     # @return [void]
     # @overload each_unique_type()
     #   @return [Enumerator<UniqueType>]
@@ -130,7 +120,7 @@ module Solargraph
     # @param new_subtypes [Array<ComplexType>, nil]
     # @return [self]
     def recreate new_name: nil, make_rooted: nil, new_key_types: nil, new_subtypes: nil
-      ComplexType.new(map do |ut|
+      ComplexType.new(items.map do |ut|
                         ut.recreate(new_name: new_name,
                                     make_rooted: make_rooted,
                                     new_key_types: new_key_types,
@@ -185,12 +175,12 @@ module Solargraph
     end
 
     def to_s
-      map(&:tag).join(', ')
+      items.map(&:tag).join(', ')
     end
 
     # @return [String]
     def tags
-      map(&:tag).join(', ')
+      items.map(&:tag).join(', ')
     end
 
     # @return [String]
@@ -306,7 +296,7 @@ module Solargraph
 
     # @return [String]
     def rooted_tags
-      map(&:rooted_tag).join(', ')
+      items.map(&:rooted_tag).join(', ')
     end
 
     def selfy?
@@ -319,7 +309,7 @@ module Solargraph
 
     # @return [self]
     def simplify_literals
-      ComplexType.new(map(&:simplify_literals))
+      ComplexType.new(items.map(&:simplify_literals))
     end
 
     # @param new_name [String, nil]
@@ -330,13 +320,13 @@ module Solargraph
       if new_name&.start_with?('::')
         raise "Please remove leading :: and set rooted with recreate() instead - #{new_name}"
       end
-      ComplexType.new(map { |ut| ut.transform(new_name, &transform_type) })
+      ComplexType.new(items.map { |ut| ut.transform(new_name, &transform_type) })
     end
 
     # @param named_types [Hash{String => ComplexType}]
     # @return [ComplexType]
     def expand named_types
-      ComplexType.new(map { |ut| ut.expand(named_types) })
+      ComplexType.new(items.map { |ut| ut.expand(named_types) })
     end
 
     # @return [self]

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -39,8 +39,8 @@ module Solargraph
     def qualify api_map, *gates
       red = reduce_object
       types = red.items.map do |t|
-        next t if %w[nil void undefined].include?(t.name)
-        next t if ['::Boolean'].include?(t.rooted_name)
+        next t if %w[nil void undefined].include?(t.rooted_tags)
+        next t if ['::Boolean'].include?(t.rooted_tags)
         api_map.unalias(t.name) || t.qualify(api_map, *gates)
       end
       ComplexType.new(types).reduce_object

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -38,7 +38,7 @@ module Solargraph
     # @return [ComplexType]
     def qualify api_map, *gates
       red = reduce_object
-      types = red.items.map do |t|
+      types = red.unioned_items.map do |t|
         next t if %w[nil void undefined].include?(t.rooted_tags)
         next t if ['::Boolean'].include?(t.rooted_tags)
         t.unalias_and_qualify(api_map, *gates)

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -149,11 +149,6 @@ module Solargraph
                       end)
     end
 
-    # @return [Integer]
-    def length
-      @items.length
-    end
-
     # @return [Array<ComplexType::UniqueType>]
     def unioned_items
       @items

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -173,12 +173,6 @@ module Solargraph
       ComplexType.union(*TypeMethods.combine_members(unioned_items, other.unioned_items, gather, &block))
     end
 
-    # @param index [Integer]
-    # @return [UniqueType]
-    def [] index
-      @items[index]
-    end
-
     # @return [String]
     def namespace
       # cache this attr for high frequency call

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -256,7 +256,7 @@ module Solargraph
                            variance: variance)
         end
       else
-        inferred.all? do |inf|
+        inferred.items.all? do |inf|
           inf.conforms_to?(api_map, expected, situation, rules,
                            variance: variance)
         end
@@ -302,7 +302,7 @@ module Solargraph
     def intersection_conjunct_quacks? api_map, quack, unique_type
       if unique_type.is_a?(UniqueType::Intersection)
         return unique_type.conjuncts.any? do |conjunct|
-          conjunct.all? { |ut| intersection_conjunct_quacks?(api_map, quack, ut) }
+          conjunct.items.all? { |ut| intersection_conjunct_quacks?(api_map, quack, ut) }
         end
       end
       # A duck-typed conjunct only vouches for its own named method.
@@ -313,11 +313,6 @@ module Solargraph
     # @return [String]
     def rooted_tags
       map(&:rooted_tag).join(', ')
-    end
-
-    # @yieldparam [UniqueType]
-    def all? &block
-      @items.all?(&block)
     end
 
     def selfy?
@@ -395,7 +390,7 @@ module Solargraph
     # every type and subtype in this union have been resolved to be
     # fully qualified
     def all_rooted?
-      all?(&:all_rooted?)
+      items.all?(&:all_rooted?)
     end
 
     # @param other [ComplexType, UniqueType]
@@ -408,7 +403,7 @@ module Solargraph
     # every top-level type has resolved to be fully qualified; see
     # #all_rooted? to check their subtypes as well
     def rooted?
-      all?(&:rooted?)
+      items.all?(&:rooted?)
     end
 
     attr_reader :items

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -377,6 +377,8 @@ module Solargraph
       ComplexType.new(map { |ut| ut.transform(new_name, &transform_type) })
     end
 
+    # @param named_types [Hash{String => ComplexType}]
+    # @return [ComplexType]
     def expand named_types
       ComplexType.new(map { |ut| ut.expand(named_types) })
     end

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -159,6 +159,11 @@ module Solargraph
       @items
     end
 
+    # @return [Array<ComplexType::UniqueType>]
+    def unioned_items
+      @items
+    end
+
     # @param index [Integer]
     # @return [UniqueType]
     def [] index

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -84,11 +84,6 @@ module Solargraph
       end)
     end
 
-    # @return [UniqueType]
-    def first
-      @items.first
-    end
-
     # @return [String]
     def to_rbs
       ((@items.length > 1 ? '(' : '') +

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -112,12 +112,6 @@ module Solargraph
     end
 
     # @yieldparam [UniqueType]
-    # @return [Enumerable<UniqueType>]
-    def each &block
-      @items.each(&block)
-    end
-
-    # @yieldparam [UniqueType]
     # @return [void]
     # @overload each_unique_type()
     #   @return [Enumerator<UniqueType>]
@@ -271,7 +265,7 @@ module Solargraph
     def duck_types_match? api_map, expected, inferred, rules = []
       raise ArgumentError, 'Expected type must be duck type' unless expected.duck_type?
       allow_any_match = rules.include?(:allow_any_match)
-      expected.each do |exp|
+      expected.items.each do |exp|
         next unless exp.duck_type?
         quack = exp.to_s[1..] || ''
         matched = allow_any_match ? inferred.items.any? { |inf| duck_type_provides?(api_map, inf, quack) } : inferred.items.all? { |inf| duck_type_provides?(api_map, inf, quack) }
@@ -438,7 +432,7 @@ module Solargraph
       types = []
       # try to find common types via conformance
       items.each do |ut|
-        narrowing_type.each do |candidate|
+        narrowing_type.items.each do |candidate|
           if candidate.conforms_to?(api_map, ut, :assignment)
             types << candidate
           elsif ut.conforms_to?(api_map, candidate, :assignment)

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -673,6 +673,18 @@ module Solargraph
         result
       end
 
+      # Builds a union of the given types, dropping duplicates. A
+      # lone type comes back as itself rather than as a union of one,
+      # so union(A, A) is A.
+      #
+      # @param types [Array<ComplexType, ComplexType::UniqueType>]
+      # @return [ComplexType, ComplexType::UniqueType]
+      def union *types
+        items = types.flat_map(&:items).uniq(&:rooted_tags)
+        return items.fetch(0) if items.length == 1
+        ComplexType.new(items)
+      end
+
       # @param strings [Array<String>]
       # @return [ComplexType]
       def try_parse *strings
@@ -740,8 +752,7 @@ module Solargraph
       # @param disjuncts [Array<ComplexType, ComplexType::UniqueType>]
       # @return [ComplexType::UniqueType, ComplexType]
       def close_disjunction disjuncts
-        return disjuncts.fetch(0) if disjuncts.length == 1
-        ComplexType.new(disjuncts)
+        union(*disjuncts)
       end
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -41,9 +41,16 @@ module Solargraph
       types = red.items.map do |t|
         next t if %w[nil void undefined].include?(t.rooted_tags)
         next t if ['::Boolean'].include?(t.rooted_tags)
-        api_map.unalias(t.name) || t.qualify(api_map, *gates)
+        t.unalias_and_qualify(api_map, *gates)
       end
       ComplexType.new(types).reduce_object
+    end
+
+    # @param api_map [ApiMap]
+    # @param gates [Array<String>]
+    # @return [ComplexType]
+    def unalias_and_qualify api_map, *gates
+      ComplexType.new(map { |t| t.unalias_and_qualify(api_map, *gates) })
     end
 
     # Pins for calling +word+ on each alternative of this union

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -251,7 +251,7 @@ module Solargraph
       return duck_types_match?(api_map, expected, inferred, rules) if expected.duck_type?
 
       if rules.include? :allow_any_match
-        inferred.any? do |inf|
+        inferred.items.any? do |inf|
           inf.conforms_to?(api_map, expected, situation, rules,
                            variance: variance)
         end
@@ -274,7 +274,7 @@ module Solargraph
       expected.each do |exp|
         next unless exp.duck_type?
         quack = exp.to_s[1..] || ''
-        matched = allow_any_match ? inferred.any? { |inf| duck_type_provides?(api_map, inf, quack) } : inferred.all? { |inf| duck_type_provides?(api_map, inf, quack) }
+        matched = allow_any_match ? inferred.items.any? { |inf| duck_type_provides?(api_map, inf, quack) } : inferred.items.all? { |inf| duck_type_provides?(api_map, inf, quack) }
         return false unless matched
       end
       true
@@ -320,19 +320,12 @@ module Solargraph
       @items.all?(&block)
     end
 
-    # @yieldparam [UniqueType]
-    # @yieldreturn [Boolean]
-    # @return [Boolean]
-    def any? &block
-      @items.compact.any?(&block)
-    end
-
     def selfy?
       @items.any?(&:selfy?)
     end
 
     def generic?
-      any?(&:generic?)
+      items.any?(&:generic?)
     end
 
     # @return [self]

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -20,7 +20,7 @@ module Solargraph
     def initialize types = [UniqueType::UNDEFINED]
       # @todo @items here should not need an annotation
       # @type [Array<UniqueType>]
-      items = types.flat_map(&:items).uniq(&:to_s)
+      items = types.flat_map(&:items).uniq(&:rooted_tags)
       if items.any? { |i| i.name == 'false' } && items.any? { |i| i.name == 'true' }
         items.delete_if { |i| %w[false true].include?(i.name) }
         items.unshift(UniqueType::BOOLEAN)

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -179,11 +179,6 @@ module Solargraph
       @items[index]
     end
 
-    # @return [Array<UniqueType>]
-    def select &block
-      @items.select(&block)
-    end
-
     # @return [String]
     def namespace
       # cache this attr for high frequency call

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -154,11 +154,6 @@ module Solargraph
       @items.length
     end
 
-    # @return [Array<UniqueType>]
-    def to_a
-      @items
-    end
-
     # @return [Array<ComplexType::UniqueType>]
     def unioned_items
       @items

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -164,6 +164,20 @@ module Solargraph
       @items
     end
 
+    # Pairs this union up with another type member by member, yields
+    # each pair, and reassembles the results into one union.
+    #
+    # @param other [ComplexType, ComplexType::UniqueType]
+    # @yieldparam mine [ComplexType, ComplexType::UniqueType]
+    # @yieldparam theirs [ComplexType, ComplexType::UniqueType]
+    # @yieldreturn [ComplexType, ComplexType::UniqueType]
+    # @return [ComplexType, ComplexType::UniqueType]
+    def combine_via other, &block
+      # @param members [Array<ComplexType, ComplexType::UniqueType>]
+      gather = ->(members) { ComplexType.union(*members) }
+      ComplexType.union(*TypeMethods.combine_members(unioned_items, other.unioned_items, gather, &block))
+    end
+
     # @param index [Integer]
     # @return [UniqueType]
     def [] index

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -89,8 +89,13 @@ module Solargraph
         # only called when expected.is_a?(UniqueType::Intersection)
         # @type [UniqueType::Intersection]
         intersection = expected
+        # Wrap inferred in a ComplexType (rather than calling
+        # UniqueType#conforms_to? directly) so each conjunct check
+        # gets ComplexType#conforms_to?'s special-case handling (e.g.
+        # duck_type? conjuncts), not just UniqueType's.
+        wrapped_inferred = ComplexType.new([inferred])
         intersection.conjuncts.all? do |conjunct|
-          inferred.conforms_to?(api_map, ComplexType.new([conjunct]), situation, rules, variance: variance)
+          wrapped_inferred.conforms_to?(api_map, ComplexType.new([conjunct]), situation, rules, variance: variance)
         end
       end
 

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -95,7 +95,7 @@ module Solargraph
         # duck_type? conjuncts), not just UniqueType's.
         wrapped_inferred = ComplexType.new([inferred])
         intersection.conjuncts.all? do |conjunct|
-          wrapped_inferred.conforms_to?(api_map, ComplexType.new([conjunct]), situation, rules, variance: variance)
+          wrapped_inferred.conforms_to?(api_map, conjunct, situation, rules, variance: variance)
         end
       end
 

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -41,6 +41,12 @@ module Solargraph
           # :nocov:
         end
 
+        # An expectation of `A & B` can only be satisfied by
+        # something that conforms to every conjunct (A & B <: A and
+        # A & B <: B, so satisfying the intersection requires
+        # satisfying both).
+        return conforms_to_intersection_expectation? if expected.is_a?(UniqueType::Intersection)
+
         return true if ignore_interface?
         return true if conforms_via_reverse_match?
 
@@ -77,6 +83,16 @@ module Solargraph
       end
 
       private
+
+      # @return [Boolean]
+      def conforms_to_intersection_expectation?
+        # only called when expected.is_a?(UniqueType::Intersection)
+        # @type [UniqueType::Intersection]
+        intersection = expected
+        intersection.conjuncts.all? do |conjunct|
+          inferred.conforms_to?(api_map, ComplexType.new([conjunct]), situation, rules, variance: variance)
+        end
+      end
 
       def only_inferred_parameters?
         !expected.parameters? && inferred.parameters?

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -107,7 +107,7 @@ module Solargraph
       end
 
       def ignore_interface?
-        (expected.any?(&:interface?) && rules.include?(:allow_unmatched_interface)) ||
+        (expected.items.any?(&:interface?) && rules.include?(:allow_unmatched_interface)) ||
           (inferred.interface? && rules.include?(:allow_unmatched_interface))
       end
 

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -48,6 +48,7 @@ module Solargraph
         return conforms_to_intersection_expectation? if expected.is_a?(UniqueType::Intersection)
 
         return true if ignore_interface?
+        return true if inferred == expected
         return true if conforms_via_reverse_match?
 
         downcast_inferred = inferred.downcast_to_literal_if_possible
@@ -64,8 +65,6 @@ module Solargraph
         return with_new_types(inferred.erase_parameters, expected).conforms_to_unique_type? if only_inferred_parameters?
 
         return conforms_via_stripped_expected_parameters? if can_strip_expected_parameters?
-
-        return true if inferred == expected
 
         return false unless erased_type_conforms?
 

--- a/lib/solargraph/complex_type/type_methods.rb
+++ b/lib/solargraph/complex_type/type_methods.rb
@@ -27,6 +27,78 @@ module Solargraph
       # @!method can_root_name?(name_to_check = nil)
       #   @param name_to_check [String, nil]
 
+      # Member pairing shared by ComplexType#combine_via and
+      # Intersection#combine_via. ComplexType does not include this
+      # mixin, so these are module methods rather than instance ones.
+      class << self
+        # Pairs two member lists and yields each pair: a lone member
+        # on either side takes on the whole of the other; otherwise
+        # members both sides carry pair off first and the rest zip up.
+        #
+        # @param mine [Array<ComplexType, UniqueType>]
+        # @param theirs [Array<ComplexType, UniqueType>]
+        # @param gather [Proc] gathers several members into one type
+        # @yieldparam mine_member [ComplexType, UniqueType]
+        # @yieldparam theirs_member [ComplexType, UniqueType]
+        # @yieldreturn [ComplexType, UniqueType]
+        # @return [Array<ComplexType, UniqueType>] a result per pair, plus anything left unpaired
+        def combine_members mine, theirs, gather, &block
+          return [block.call(gather.call(mine), gather.call(theirs))] if mine.length == 1 || theirs.length == 1
+
+          mine_rest = mine.dup
+          theirs_rest = theirs.dup
+          matched = pair_identical_members(mine_rest, theirs_rest, &block)
+          zipped = pair_remaining_members(mine_rest, theirs_rest, gather, &block)
+          matched + zipped + mine_rest + theirs_rest
+        end
+
+        # Yields each member both sides carry, matched on rooted tag
+        # and in any order, removing it from both lists.
+        #
+        # @param mine [Array<ComplexType, UniqueType>] matched members are removed
+        # @param theirs [Array<ComplexType, UniqueType>] matched members are removed
+        # @yieldparam mine_member [ComplexType, UniqueType]
+        # @yieldparam theirs_member [ComplexType, UniqueType]
+        # @yieldreturn [ComplexType, UniqueType]
+        # @return [Array<ComplexType, UniqueType>]
+        def pair_identical_members mine, theirs
+          results = []
+          mine.delete_if do |member|
+            index = theirs.index { |other| other.rooted_tags == member.rooted_tags }
+            next false if index.nil?
+
+            results.push(yield(member, theirs.delete_at(index)))
+            true
+          end
+          results
+        end
+
+        # Zips both lists from the front, yielding each pair and
+        # removing it. The shorter side runs out first, so its last
+        # member takes on everything left of the other.
+        #
+        # @param mine [Array<ComplexType, UniqueType>] paired members are removed
+        # @param theirs [Array<ComplexType, UniqueType>] paired members are removed
+        # @param gather [Proc] gathers several members into one type
+        # @yieldparam mine_member [ComplexType, UniqueType]
+        # @yieldparam theirs_member [ComplexType, UniqueType]
+        # @yieldreturn [ComplexType, UniqueType]
+        # @return [Array<ComplexType, UniqueType>]
+        def pair_remaining_members mine, theirs, gather
+          results = []
+          until mine.empty? || theirs.empty?
+            if mine.length == 1 || theirs.length == 1
+              results.push(yield(gather.call(mine.dup), gather.call(theirs.dup)))
+              mine.clear
+              theirs.clear
+            else
+              results.push(yield(mine.shift, theirs.shift))
+            end
+          end
+          results
+        end
+      end
+
       # @return [String]
       attr_reader :name
 

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -212,6 +212,25 @@ module Solargraph
         @non_literal_name ||= determine_non_literal_name
       end
 
+      # Whether every one of this type's key_types is a literal type
+      # (e.g. `Hash{"Index" => Float}`'s key_types is `["Index"]`, a
+      # literal String) - a Hash-like type whose keys are specific
+      # values rather than a general key class.
+      #
+      # @return [Boolean]
+      def literal_keyed?
+        key_types.any? && key_types.all? { |kt| kt.items.all?(&:literal?) }
+      end
+
+      # Whether any of this type's key_types has the given literal tag
+      # (e.g. `'"Index"'`, `':foo'`, `'1'`).
+      #
+      # @param tag [String]
+      # @return [Boolean]
+      def key_type_tag? tag
+        key_types.any? { |kt| kt.tag == tag }
+      end
+
       # @return [self]
       def without_nil
         return UniqueType::UNDEFINED if nil_type?

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -178,7 +178,7 @@ module Solargraph
 
       # @param api_map [ApiMap]
       # @param unique_type [ComplexType::UniqueType]
-      # @return [Symbol, nil] :class, :module, or nil if unknown
+      # @return [:class, :module, nil] nil when the namespace has no pin
       def namespace_kind api_map, unique_type
         # @type [Pin::Namespace, nil]
         pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -13,6 +13,13 @@ module Solargraph
 
       attr_reader :all_params, :subtypes, :key_types
 
+      # @type [Hash{String => String}]
+      ANONYMOUS_NAME_BY_STARTING_TAG = {
+        '{' => 'Hash',
+        '(' => 'Array',
+        '<' => 'Array'
+      }.freeze
+
       # Create a UniqueType with the specified name and an optional substring.
       # The substring is the parameter section of a parametrized type, e.g.,
       # for the type `Array<String>`, the name is `Array` and the substring is
@@ -24,6 +31,11 @@ module Solargraph
       # @return [UniqueType]
       def self.parse name, substring = '', make_rooted: nil
         raise ComplexTypeError, "Illegal prefix: #{name}" if name.start_with?(':::')
+        # Anonymous shorthand - `<A>`, `(A)`, `{A=>B}` - omits the
+        # leading type name, defaulting it to Array or Hash. Resolved
+        # before the rooted/can_root_name? check below so an anonymous
+        # `<A>` behaves exactly like the equivalent `Array<A>`.
+        name = ANONYMOUS_NAME_BY_STARTING_TAG.fetch(substring[0]) if name.empty? && !substring.empty?
         if name.start_with?('::')
           name = name[2..]
           rooted = true

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -158,10 +158,10 @@ module Solargraph
         # try to find common types via conformance
         items.each do |ut|
           narrowing_type.each do |candidate|
-            if ut.conforms_to?(api_map, candidate, :assignment)
-              types << ut
-            elsif candidate.conforms_to?(api_map, ut, :assignment)
+            if candidate.conforms_to?(api_map, ut, :assignment)
               types << candidate
+            elsif ut.conforms_to?(api_map, candidate, :assignment)
+              types << ut
             elsif mixin_pairing?(api_map, ut, candidate)
               types << Intersection.new([ComplexType.new([ut]), ComplexType.new([candidate])])
             end

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -124,9 +124,15 @@ module Solargraph
       # Flow-sensitive type narrowing: given a type learned from a
       # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down
       # to the more specific of each compatible pair between the two
-      # sides. This is a set-refinement over alternatives, not a
-      # real intersection type - see
-      # ComplexType::UniqueType::Intersection for that.
+      # sides. When neither side is already known to be a subtype of
+      # the other but one is positively confirmed to be a mix-in
+      # (e.g. a declared class and an unrelated module), both facts
+      # are still true at once, so the pair is combined into an
+      # Intersection rather than discarded. Everything else - two
+      # different concrete classes (impossible; an object has exactly
+      # one class), or either side being a namespace we can't
+      # positively identify - falls back to the original behavior of
+      # dropping the pair.
       #
       # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
       #
@@ -144,12 +150,41 @@ module Solargraph
               types << ut
             elsif candidate.conforms_to?(api_map, ut, :assignment)
               types << candidate
+            elsif mixin_pairing?(api_map, ut, candidate)
+              types << Intersection.new([ComplexType.new([ut]), ComplexType.new([candidate])])
             end
           end
         end
         types = [ComplexType::UniqueType::UNDEFINED] if types.empty?
         ComplexType.new(types)
       end
+
+      # Whether combining these two into an intersection is safe. Only
+      # true when at least one side is *positively confirmed* to be a
+      # mix-in: any class can pick up any module, so a class-and-module
+      # pairing is always plausible. Everything else - two different
+      # concrete classes, or a namespace we have no pin for (synthetic
+      # names like `Boolean`, generics, literals, duck types, or
+      # simply unresolved) - defaults to false, preserving the
+      # original drop-the-pair behavior.
+      #
+      # @param api_map [ApiMap]
+      # @param declared [ComplexType::UniqueType]
+      # @param candidate [ComplexType::UniqueType]
+      # @return [Boolean]
+      def mixin_pairing? api_map, declared, candidate
+        namespace_kind(api_map, declared) == :module || namespace_kind(api_map, candidate) == :module
+      end
+
+      # @param api_map [ApiMap]
+      # @param unique_type [ComplexType::UniqueType]
+      # @return [Symbol, nil] :class, :module, or nil if unknown
+      def namespace_kind api_map, unique_type
+        # @type [Pin::Namespace, nil]
+        pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }
+        pin&.type
+      end
+      private :mixin_pairing?, :namespace_kind
 
       def simplifyable_literal?
         literal? && name != 'nil'

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -9,6 +9,8 @@ module Solargraph
       include TypeMethods
       include Equality
 
+      autoload :Intersection, 'solargraph/complex_type/unique_type/intersection'
+
       attr_reader :all_params, :subtypes, :key_types
 
       # Create a UniqueType with the specified name and an optional substring.
@@ -262,7 +264,9 @@ module Solargraph
         # match one of their unique types
         expected.any? do |expected_unique_type|
           # :nocov:
-          unless expected_unique_type.instance_of?(UniqueType)
+          unless expected_unique_type.is_a?(UniqueType)
+            # @sg-ignore is_a? doesn't narrow the negated branch as
+            #   precisely as instance_of? did
             raise "Expected type must be a UniqueType, got #{expected_unique_type.class} in #{expected.inspect}"
           end
           # :nocov:

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -133,6 +133,71 @@ module Solargraph
         ComplexType.new(types)
       end
 
+      # Flow-sensitive type narrowing: given a type learned from a
+      # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down
+      # to the more specific of each compatible pair between the two
+      # sides. When neither side is already known to be a subtype of
+      # the other but one is positively confirmed to be a mix-in
+      # (e.g. a declared class and an unrelated module), both facts
+      # are still true at once, so the pair is combined into an
+      # Intersection rather than discarded. Everything else - two
+      # different concrete classes (impossible; an object has exactly
+      # one class), or either side being a namespace we can't
+      # positively identify - falls back to the original behavior of
+      # dropping the pair.
+      #
+      # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
+      #
+      # @param narrowing_type [ComplexType, ComplexType::UniqueType, nil]
+      # @param api_map [ApiMap]
+      # @return [self, ComplexType]
+      def narrow_with narrowing_type, api_map
+        return self if narrowing_type.nil?
+        return narrowing_type if undefined?
+        types = []
+        # try to find common types via conformance
+        items.each do |ut|
+          narrowing_type.each do |candidate|
+            if ut.conforms_to?(api_map, candidate, :assignment)
+              types << ut
+            elsif candidate.conforms_to?(api_map, ut, :assignment)
+              types << candidate
+            elsif mixin_pairing?(api_map, ut, candidate)
+              types << Intersection.new([ComplexType.new([ut]), ComplexType.new([candidate])])
+            end
+          end
+        end
+        types = [ComplexType::UniqueType::UNDEFINED] if types.empty?
+        ComplexType.new(types)
+      end
+
+      # Whether combining these two into an intersection is safe. Only
+      # true when at least one side is *positively confirmed* to be a
+      # mix-in: any class can pick up any module, so a class-and-module
+      # pairing is always plausible. Everything else - two different
+      # concrete classes, or a namespace we have no pin for (synthetic
+      # names like `Boolean`, generics, literals, duck types, or
+      # simply unresolved) - defaults to false, preserving the
+      # original drop-the-pair behavior.
+      #
+      # @param api_map [ApiMap]
+      # @param declared [ComplexType::UniqueType]
+      # @param candidate [ComplexType::UniqueType]
+      # @return [Boolean]
+      def mixin_pairing? api_map, declared, candidate
+        namespace_kind(api_map, declared) == :module || namespace_kind(api_map, candidate) == :module
+      end
+
+      # @param api_map [ApiMap]
+      # @param unique_type [ComplexType::UniqueType]
+      # @return [Symbol, nil] :class, :module, or nil if unknown
+      def namespace_kind api_map, unique_type
+        # @type [Pin::Namespace, nil]
+        pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }
+        pin&.type
+      end
+      private :mixin_pairing?, :namespace_kind
+
       def simplifyable_literal?
         literal? && name != 'nil'
       end

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -211,12 +211,14 @@ module Solargraph
       end
 
       # Whether any of this type's key_types has the given literal tag
-      # (e.g. `'"Index"'`, `':foo'`, `'1'`).
+      # (e.g. `'"Index"'`, `':foo'`, `'1'`). A key_type is itself a
+      # ComplexType, so a union key (`Hash{"A" | "B" => V}`) has more
+      # than one item to check - `kt.tag` alone only sees the first.
       #
       # @param tag [String]
       # @return [Boolean]
       def key_type_tag? tag
-        key_types.any? { |kt| kt.tag == tag }
+        key_types.any? { |kt| kt.items.any? { |item| item.tag == tag } }
       end
 
       # @return [self]

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -121,22 +121,29 @@ module Solargraph
         ComplexType.new(types)
       end
 
-      # @see https://en.wikipedia.org/wiki/Intersection_type
+      # Flow-sensitive type narrowing: given a type learned from a
+      # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down
+      # to the more specific of each compatible pair between the two
+      # sides. This is a set-refinement over alternatives, not a
+      # real intersection type - see
+      # ComplexType::UniqueType::Intersection for that.
       #
-      # @param intersection_type [ComplexType, ComplexType::UniqueType, nil]
+      # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
+      #
+      # @param narrowing_type [ComplexType, ComplexType::UniqueType, nil]
       # @param api_map [ApiMap]
       # @return [self, ComplexType]
-      def intersect_with intersection_type, api_map
-        return self if intersection_type.nil?
-        return intersection_type if undefined?
+      def narrow_with narrowing_type, api_map
+        return self if narrowing_type.nil?
+        return narrowing_type if undefined?
         types = []
         # try to find common types via conformance
         items.each do |ut|
-          intersection_type.each do |int_type|
-            if ut.conforms_to?(api_map, int_type, :assignment)
+          narrowing_type.each do |candidate|
+            if ut.conforms_to?(api_map, candidate, :assignment)
               types << ut
-            elsif int_type.conforms_to?(api_map, ut, :assignment)
-              types << int_type
+            elsif candidate.conforms_to?(api_map, ut, :assignment)
+              types << candidate
             end
           end
         end

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -133,59 +133,6 @@ module Solargraph
         ComplexType.new(types)
       end
 
-      # Flow-sensitive type narrowing: given a type learned from a
-      # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down to
-      # the more specific of each compatible pair. When neither side
-      # subtypes the other but one is confirmed to be a mix-in, both
-      # facts hold at once, so the pair becomes an Intersection; any
-      # other pair is dropped (see #mixin_pairing?).
-      #
-      # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
-      #
-      # @param narrowing_type [ComplexType, ComplexType::UniqueType, nil]
-      # @param api_map [ApiMap]
-      # @return [self, ComplexType]
-      def narrow_with narrowing_type, api_map
-        return self if narrowing_type.nil?
-        return narrowing_type if undefined?
-        types = []
-        # try to find common types via conformance
-        items.each do |ut|
-          narrowing_type.each do |candidate|
-            if ut.conforms_to?(api_map, candidate, :assignment)
-              types << ut
-            elsif candidate.conforms_to?(api_map, ut, :assignment)
-              types << candidate
-            elsif mixin_pairing?(api_map, ut, candidate)
-              types << Intersection.new([ComplexType.new([ut]), ComplexType.new([candidate])])
-            end
-          end
-        end
-        types = [ComplexType::UniqueType::UNDEFINED] if types.empty?
-        ComplexType.new(types)
-      end
-
-      # Whether combining these two into an intersection is safe.
-      #
-      # @see ComplexType#mixin_pairing?
-      # @param api_map [ApiMap]
-      # @param declared [ComplexType::UniqueType]
-      # @param candidate [ComplexType::UniqueType]
-      # @return [Boolean]
-      def mixin_pairing? api_map, declared, candidate
-        namespace_kind(api_map, declared) == :module || namespace_kind(api_map, candidate) == :module
-      end
-
-      # @param api_map [ApiMap]
-      # @param unique_type [ComplexType::UniqueType]
-      # @return [:class, :module, nil] nil when the namespace has no pin
-      def namespace_kind api_map, unique_type
-        # @type [Pin::Namespace, nil]
-        pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }
-        pin&.type
-      end
-      private :mixin_pairing?, :namespace_kind
-
       def simplifyable_literal?
         literal? && name != 'nil'
       end

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -31,10 +31,8 @@ module Solargraph
       # @return [UniqueType]
       def self.parse name, substring = '', make_rooted: nil
         raise ComplexTypeError, "Illegal prefix: #{name}" if name.start_with?(':::')
-        # Anonymous shorthand - `<A>`, `(A)`, `{A=>B}` - omits the
-        # leading type name, defaulting it to Array or Hash. Resolved
-        # before the rooted/can_root_name? check below so an anonymous
-        # `<A>` behaves exactly like the equivalent `Array<A>`.
+        # Anonymous shorthand (`<A>`, `(A)`, `{A=>B}`) defaults the
+        # omitted type name to Array or Hash, before the rooted check below.
         name = ANONYMOUS_NAME_BY_STARTING_TAG.fetch(substring[0]) if name.empty? && !substring.empty?
         if name.start_with?('::')
           name = name[2..]
@@ -133,18 +131,9 @@ module Solargraph
         ComplexType.new(types)
       end
 
-      # Flow-sensitive type narrowing: given a type learned from a
-      # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down
-      # to the more specific of each compatible pair between the two
-      # sides. When neither side is already known to be a subtype of
-      # the other but one is positively confirmed to be a mix-in
-      # (e.g. a declared class and an unrelated module), both facts
-      # are still true at once, so the pair is combined into an
-      # Intersection rather than discarded. Everything else - two
-      # different concrete classes (impossible; an object has exactly
-      # one class), or either side being a namespace we can't
-      # positively identify - falls back to the original behavior of
-      # dropping the pair.
+      # Flow-sensitive narrowing (e.g. via `is_a?`): keeps the more
+      # specific of each compatible pair, or an Intersection when
+      # only a confirmed mix-in relationship holds.
       #
       # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
       #
@@ -171,14 +160,9 @@ module Solargraph
         ComplexType.new(types)
       end
 
-      # Whether combining these two into an intersection is safe. Only
-      # true when at least one side is *positively confirmed* to be a
-      # mix-in: any class can pick up any module, so a class-and-module
-      # pairing is always plausible. Everything else - two different
-      # concrete classes, or a namespace we have no pin for (synthetic
-      # names like `Boolean`, generics, literals, duck types, or
-      # simply unresolved) - defaults to false, preserving the
-      # original drop-the-pair behavior.
+      # Safe to combine into an intersection only when one side is a
+      # confirmed mix-in (any class can pick up any module); two
+      # classes, or an unpinned namespace, stay false.
       #
       # @param api_map [ApiMap]
       # @param declared [ComplexType::UniqueType]
@@ -212,20 +196,16 @@ module Solargraph
         @non_literal_name ||= determine_non_literal_name
       end
 
-      # Whether every one of this type's key_types is a literal type
-      # (e.g. `Hash{"Index" => Float}`'s key_types is `["Index"]`, a
-      # literal String) - a Hash-like type whose keys are specific
-      # values rather than a general key class.
+      # Whether every key_type is a literal, e.g. `Hash{"Index" =>
+      # Float}`'s key is the literal `"Index"`, not a general class.
       #
       # @return [Boolean]
       def literal_keyed?
         key_types.any? && key_types.all? { |kt| kt.items.all?(&:literal?) }
       end
 
-      # Whether any of this type's key_types has the given literal tag
-      # (e.g. `'"Index"'`, `':foo'`, `'1'`). A key_type is itself a
-      # ComplexType, so a union key (`Hash{"A" | "B" => V}`) has more
-      # than one item to check - `kt.tag` alone only sees the first.
+      # Whether any key_type has the given literal tag (e.g.
+      # `'"Index"'`) - checks every item, since a key_type may be a union.
       #
       # @param tag [String]
       # @return [Boolean]

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -174,9 +174,9 @@ module Solargraph
 
       # @param api_map [ApiMap]
       # @param unique_type [ComplexType::UniqueType]
+      # @sg-ignore flow sensitive typing needs to infer Enumerable#find's block return type from an is_a? check
       # @return [Symbol, nil] :class, :module, or nil if unknown
       def namespace_kind api_map, unique_type
-        # @type [Pin::Namespace, nil]
         pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }
         pin&.type
       end

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -134,17 +134,11 @@ module Solargraph
       end
 
       # Flow-sensitive type narrowing: given a type learned from a
-      # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down
-      # to the more specific of each compatible pair between the two
-      # sides. When neither side is already known to be a subtype of
-      # the other but one is positively confirmed to be a mix-in
-      # (e.g. a declared class and an unrelated module), both facts
-      # are still true at once, so the pair is combined into an
-      # Intersection rather than discarded. Everything else - two
-      # different concrete classes (impossible; an object has exactly
-      # one class), or either side being a namespace we can't
-      # positively identify - falls back to the original behavior of
-      # dropping the pair.
+      # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down to
+      # the more specific of each compatible pair. When neither side
+      # subtypes the other but one is confirmed to be a mix-in, both
+      # facts hold at once, so the pair becomes an Intersection; any
+      # other pair is dropped (see #mixin_pairing?).
       #
       # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
       #
@@ -171,15 +165,9 @@ module Solargraph
         ComplexType.new(types)
       end
 
-      # Whether combining these two into an intersection is safe. Only
-      # true when at least one side is *positively confirmed* to be a
-      # mix-in: any class can pick up any module, so a class-and-module
-      # pairing is always plausible. Everything else - two different
-      # concrete classes, or a namespace we have no pin for (synthetic
-      # names like `Boolean`, generics, literals, duck types, or
-      # simply unresolved) - defaults to false, preserving the
-      # original drop-the-pair behavior.
+      # Whether combining these two into an intersection is safe.
       #
+      # @see ComplexType#mixin_pairing?
       # @param api_map [ApiMap]
       # @param declared [ComplexType::UniqueType]
       # @param candidate [ComplexType::UniqueType]
@@ -337,11 +325,7 @@ module Solargraph
         # match one of their unique types
         expected.any? do |expected_unique_type|
           # :nocov:
-          unless expected_unique_type.is_a?(UniqueType)
-            # @sg-ignore is_a? doesn't narrow the negated branch as
-            #   precisely as instance_of? did
-            raise "Expected type must be a UniqueType, got #{expected_unique_type.class} in #{expected.inspect}"
-          end
+          raise "Expected type must be a UniqueType in #{expected.inspect}" unless expected_unique_type.is_a?(UniqueType)
           # :nocov:
           conformance = Conformance.new(api_map, self, expected_unique_type, situation,
                                         rules, variance: variance)

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -664,10 +664,14 @@ module Solargraph
         self.class.can_root_name?(name_to_check)
       end
 
+      # Only a constant path or an RBS interface takes a `::` prefix.
+      # Both start with an uppercase letter, after a leading underscore
+      # for an interface; literals like `:Sym` and `"Index"` do not.
+      ROOTABLE_NAME = /\A_?[A-Z]/
+
       # @param name [String]
       def self.can_root_name? name
-        # name is not lowercase
-        !name.empty? && name != name.downcase
+        name.match?(ROOTABLE_NAME)
       end
 
       UNDEFINED = UniqueType.new('undefined', rooted: false)

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -303,6 +303,18 @@ module Solargraph
         name == other.name && (all_params.empty? || all_params.all?(&:undefined?))
       end
 
+      # The first pin of the method stack for +word+ on this type, or
+      # nil when the method does not resolve.
+      #
+      # @param word [String]
+      # @param api_map [ApiMap]
+      # @return [::Array<Pin::Base>, nil]
+      def method_stack_pins word, api_map
+        ns_tag = namespace == '' ? '' : namespace_type.tag
+        stack = api_map.get_method_stack(ns_tag, word, scope: scope)
+        stack.first.nil? ? nil : [stack.first]
+      end
+
       # @param api_map [ApiMap]
       # @param expected [ComplexType::UniqueType, ComplexType]
       # @param situation [:method_call, :assignment, :return_type]

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -196,23 +196,6 @@ module Solargraph
         @non_literal_name ||= determine_non_literal_name
       end
 
-      # Whether every key_type is a literal, e.g. `Hash{"Index" =>
-      # Float}`'s key is the literal `"Index"`, not a general class.
-      #
-      # @return [Boolean]
-      def literal_keyed?
-        key_types.any? && key_types.all? { |kt| kt.items.all?(&:literal?) }
-      end
-
-      # Whether any key_type has the given literal tag (e.g.
-      # `'"Index"'`) - checks every item, since a key_type may be a union.
-      #
-      # @param tag [String]
-      # @return [Boolean]
-      def key_type_tag? tag
-        key_types.any? { |kt| kt.items.any? { |item| item.tag == tag } }
-      end
-
       # @return [self]
       def without_nil
         return UniqueType::UNDEFINED if nil_type?

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -73,8 +73,8 @@ module Solargraph
               raise ComplexTypeError,
                     "Bad hash type: name=#{name}, substring=#{substring} - must have exactly two parameters"
             end
-            key_types.concat(subs[0].map { |u| ComplexType.new([u]) })
-            subtypes.concat(subs[1].map { |u| ComplexType.new([u]) })
+            key_types.concat(subs[0].items.map { |u| ComplexType.new([u]) })
+            subtypes.concat(subs[1].items.map { |u| ComplexType.new([u]) })
           else
             subtypes.concat subs
           end
@@ -475,7 +475,7 @@ module Solargraph
             context_params = yield context_type if context_type
             if context_params && context_params[i]
               type_arg = context_params[i]
-              type_arg.map do |new_unique_context_type|
+              type_arg.items.map do |new_unique_context_type|
                 ut.resolve_generics_from_context generics_to_resolve, new_unique_context_type,
                                                  resolved_generic_values: resolved_generic_values
               end
@@ -521,13 +521,6 @@ module Solargraph
             t
           end
         end
-      end
-
-      # @yieldparam t [self]
-      # @yieldreturn [self]
-      # @return [Array<self>]
-      def map &block
-        [block.yield(self)]
       end
 
       # @return [Array<ComplexType::UniqueType>]

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -425,11 +425,6 @@ module Solargraph
         nil_type?
       end
 
-      # @yieldreturn [Boolean]
-      def all? &block
-        block.yield self
-      end
-
       # @return [UniqueType]
       def downcast_to_literal_if_possible
         return self

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -540,6 +540,11 @@ module Solargraph
         [self]
       end
 
+      # @return [Array<ComplexType::UniqueType>]
+      def unioned_items
+        [self]
+      end
+
       # @param new_name [String, nil]
       # @param make_rooted [Boolean, nil]
       # @param new_key_types [Array<ComplexType>, nil]

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -11,7 +11,14 @@ module Solargraph
 
       autoload :Intersection, 'solargraph/complex_type/unique_type/intersection'
 
-      attr_reader :all_params, :subtypes, :key_types
+      # @return [Array<UniqueType, Intersection, ComplexType>]
+      attr_reader :all_params
+
+      # @return [Array<UniqueType, Intersection, ComplexType>]
+      attr_reader :subtypes
+
+      # @return [Array<UniqueType, Intersection, ComplexType>]
+      attr_reader :key_types
 
       # @type [Hash{String => String}]
       ANONYMOUS_NAME_BY_STARTING_TAG = {
@@ -77,8 +84,8 @@ module Solargraph
       end
 
       # @param name [String]
-      # @param key_types [Array<ComplexType>]
-      # @param subtypes [Array<ComplexType>]
+      # @param key_types [Array<UniqueType, Intersection, ComplexType>]
+      # @param subtypes [Array<UniqueType, Intersection, ComplexType>]
       # @param rooted [Boolean]
       # @param parameters_type [Symbol, nil]
       def initialize name, key_types = [], subtypes = [], rooted:, parameters_type: nil
@@ -558,9 +565,9 @@ module Solargraph
 
       # @param new_name [String, nil]
       # @param make_rooted [Boolean, nil]
-      # @param new_key_types [Array<ComplexType>, nil]
+      # @param new_key_types [Array<UniqueType, Intersection, ComplexType>, nil]
       # @param make_rooted [Boolean, nil]
-      # @param new_subtypes [Array<ComplexType>, nil]
+      # @param new_subtypes [Array<UniqueType, Intersection, ComplexType>, nil]
       # @return [self]
       def recreate new_name: nil, make_rooted: nil, new_key_types: nil, new_subtypes: nil
         raise "Please remove leading :: and set rooted instead - #{new_name}" if new_name&.start_with?('::')

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -545,6 +545,17 @@ module Solargraph
         [self]
       end
 
+      # A lone type has one member, so there is one pair to make.
+      #
+      # @param other [ComplexType, UniqueType]
+      # @yieldparam mine [self]
+      # @yieldparam theirs [ComplexType, UniqueType]
+      # @yieldreturn [ComplexType, UniqueType]
+      # @return [ComplexType, UniqueType]
+      def combine_via other
+        yield self, other
+      end
+
       # @param new_name [String, nil]
       # @param make_rooted [Boolean, nil]
       # @param new_key_types [Array<ComplexType>, nil]

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -319,7 +319,7 @@ module Solargraph
 
         # complex types as expectations are unions - we only need to
         # match one of their unique types
-        expected.any? do |expected_unique_type|
+        expected.items.any? do |expected_unique_type|
           # :nocov:
           raise "Expected type must be a UniqueType in #{expected.inspect}" unless expected_unique_type.is_a?(UniqueType)
           # :nocov:
@@ -662,11 +662,6 @@ module Solargraph
           next t if t.name != 'self'
           object_type_dst
         end
-      end
-
-      # @yieldreturn [Boolean]
-      def any? &block
-        block.yield self
       end
 
       # @return [ComplexType]

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -542,11 +542,6 @@ module Solargraph
         [self].each(&)
       end
 
-      # @return [Array<UniqueType>]
-      def to_a
-        [self]
-      end
-
       # @return [Array<ComplexType::UniqueType>]
       def unioned_items
         [self]

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -660,7 +660,7 @@ module Solargraph
       end
 
       # @param dst [ComplexType]
-      # @return [self]
+      # @return [ComplexType, self]
       def self_to_type dst
         object_type_dst = dst.reduce_class_type
         transform do |t|

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -620,6 +620,15 @@ module Solargraph
         end
       end
 
+      # Expand this type if it names a type alias; otherwise qualify it.
+      #
+      # @param api_map [ApiMap]
+      # @param gates [Array<String>]
+      # @return [ComplexType, UniqueType]
+      def unalias_and_qualify api_map, *gates
+        api_map.unalias(name) || qualify(api_map, *gates)
+      end
+
       def selfy?
         @name == 'self' || @key_types.any?(&:selfy?) || @subtypes.any?(&:selfy?)
       end

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -566,7 +566,6 @@ module Solargraph
       # @param new_name [String, nil]
       # @param make_rooted [Boolean, nil]
       # @param new_key_types [Array<UniqueType, Intersection, ComplexType>, nil]
-      # @param make_rooted [Boolean, nil]
       # @param new_subtypes [Array<UniqueType, Intersection, ComplexType>, nil]
       # @return [self]
       def recreate new_name: nil, make_rooted: nil, new_key_types: nil, new_subtypes: nil
@@ -620,6 +619,10 @@ module Solargraph
         yield new_type
       end
 
+      # Substitutes a named type for this one when the name is bound.
+      #
+      # @param named_types [Hash{String => ComplexType}]
+      # @return [ComplexType, self]
       def expand named_types
         named_types[name] || self
       end

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -153,7 +153,7 @@ module Solargraph
         types = []
         # try to find common types via conformance
         items.each do |ut|
-          narrowing_type.each do |candidate|
+          narrowing_type.items.each do |candidate|
             if candidate.conforms_to?(api_map, ut, :assignment)
               types << candidate
             elsif ut.conforms_to?(api_map, candidate, :assignment)
@@ -528,13 +528,6 @@ module Solargraph
       # @return [Array<self>]
       def map &block
         [block.yield(self)]
-      end
-
-      # @yieldparam t [self]
-      # @yieldreturn [self]
-      # @return [Enumerable<self>]
-      def each(&)
-        [self].each(&)
       end
 
       # @return [Array<ComplexType::UniqueType>]

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -149,12 +149,20 @@ module Solargraph
         # Applies the transformation to each conjunct independently
         # and rebuilds the intersection from the results.
         #
-        # @param new_name [String, nil]
+        # new_name is not passed down to the conjuncts. An
+        # intersection's own `name` is the synthetic `"A & B"` string
+        # built in #initialize, not a namespace; giving that to each
+        # conjunct renames `Hash{"a" => Float}` to
+        # `Hash{"a" => Float} & Hash{"b" => Float}{"a" => Float}`,
+        # which no longer parses. Each conjunct keeps its own name,
+        # which is the only rename that means anything here.
+        #
+        # @param _new_name [String, nil] ignored - see above
         # @yieldparam t [UniqueType]
         # @yieldreturn [UniqueType]
         # @return [self]
-        def transform new_name = nil, &transform_type
-          Intersection.new(conjuncts.map { |conjunct| conjunct.transform(new_name, &transform_type) })
+        def transform _new_name = nil, &transform_type
+          Intersection.new(conjuncts.map { |conjunct| conjunct.transform(&transform_type) })
         end
 
         # @return [self]

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -9,8 +9,9 @@ module Solargraph
       # Unlike ComplexType's comma-separated items (a union, where any
       # one member describes the value), every conjunct must describe
       # the value independently, so the subtyping rules are a union's
-      # mirror image: A & B <: A and A & B <: B, but a value satisfies
-      # A & B only if it satisfies every conjunct.
+      # mirror image: A & B <: A and A & B <: B (<: means "is a
+      # subtype of"), but a value satisfies A & B only if it satisfies
+      # every conjunct.
       #
       # Each conjunct is a full ComplexType, not a plain UniqueType, as
       # RBS allows a union as one member of an intersection
@@ -130,17 +131,9 @@ module Solargraph
           end
         end
 
-        # Every conjunct describes the same value, so each is resolved
-        # against the same context type, and a generic bound by one
-        # conjunct is visible to the rest through the shared
-        # resolved_generic_values hash. UniqueType's implementation
-        # looks for generics in #subtypes and #key_types, which an
-        # intersection does not use - its type parameters live inside
-        # the conjuncts - so `Class<generic<T>> & #new` never bound T.
-        #
-        # Conjuncts resolve left to right, so a generic that only
-        # becomes bindable through a later conjunct stays unresolved in
-        # an earlier one's output.
+        # Every conjunct resolves against the same context, sharing
+        # resolved_generic_values - resolved left to right, so an
+        # earlier conjunct won't see a generic only a later one binds.
         #
         # @param generics_to_resolve [Enumerable<String>]
         # @param context_type [ComplexType, UniqueType, nil]
@@ -171,11 +164,8 @@ module Solargraph
 
         private
 
-        # Renders the conjuncts as a tag, bracketing any conjunct that
-        # holds more than one type. `&` binds tighter than the `,`/`|`
-        # of a union, so without the brackets `[A | B] & C` would
-        # render as `A, B & C` and parse back as `A | (B & C)` - a
-        # different type.
+        # Renders conjuncts as a tag, bracketing multi-item ones since
+        # `&` binds tighter than `,`/`|` (`[A|B] & C`, not `A, B & C`).
         #
         # @param tags_method [:tags, :rooted_tags]
         # @return [String]
@@ -186,13 +176,6 @@ module Solargraph
           end.join(' & ')
         end
 
-        # Returns expected itself when it's a bare Intersection, or
-        # its one item when it's a ComplexType consisting of nothing
-        # but a single Intersection. A union with an intersection as
-        # one of several alternatives returns nil; #conforms_to? has
-        # already tried each alternative on its own by then, so what
-        # reaches here is the fallback "any conjunct" path.
-        #
         # True when expected is a union and this intersection conforms
         # to one of its alternatives taken on its own.
         #
@@ -210,6 +193,8 @@ module Solargraph
           end
         end
 
+        # Returns expected itself (or its one item) when it's an Intersection, else nil.
+        #
         # @param expected [ComplexType, ComplexType::UniqueType]
         # @return [Intersection, nil]
         def sole_intersection expected

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Solargraph
+  class ComplexType
+    class UniqueType
+      # A single unique type representing the intersection of two or
+      # more conjunct types, e.g., the RBS type `A & B`.
+      #
+      # Unlike ComplexType's comma-separated items (a union, where any
+      # one member describes the value), every conjunct of an
+      # Intersection must independently describe the value. That
+      # means the subtyping rules are the mirror image of a union's:
+      #
+      #   A & B <: A
+      #   A & B <: B
+      #
+      # i.e., a value typed as the intersection can be used wherever
+      # *any* conjunct is expected, but a value can only be used
+      # where the intersection itself is expected if it satisfies
+      # *every* conjunct.
+      #
+      # `A & B` is parsed the same way from plain YARD type tags
+      # (`@param`, `@return`, `@type`, etc.) as it is from inline RBS
+      # signatures, since both funnel through ComplexType.parse. YARD
+      # itself has no official intersection type syntax yet; `&` is
+      # Solargraph's extension pending upstream guidance.
+      #
+      # @see https://en.wikipedia.org/wiki/Intersection_type
+      # @see https://github.com/ruby/rbs/blob/master/docs/syntax.md#intersection-type
+      # @see https://github.com/lsegal/yard/issues/1644
+      class Intersection < UniqueType
+        # @return [Array<UniqueType>]
+        attr_reader :conjuncts
+
+        # @param conjuncts [Array<UniqueType>]
+        def initialize conjuncts
+          @conjuncts = conjuncts
+          super(conjuncts.map(&:tag).join(' & '), rooted: true)
+        end
+
+        # @return [String]
+        def tag
+          @tag ||= conjuncts.map(&:tag).join(' & ')
+        end
+
+        # @return [String]
+        def rooted_tag
+          @rooted_tag ||= conjuncts.map(&:rooted_tag).join(' & ')
+        end
+
+        # @return [String]
+        def to_rbs
+          conjuncts.map(&:to_rbs).join(' & ')
+        end
+
+        # @return [String]
+        def namespace
+          conjuncts.fetch(0).namespace
+        end
+
+        # @return [::Symbol]
+        def scope
+          conjuncts.fetch(0).scope
+        end
+
+        def generic?
+          conjuncts.any?(&:generic?)
+        end
+
+        def rooted?
+          conjuncts.all?(&:rooted?)
+        end
+
+        def all_rooted?
+          conjuncts.all?(&:all_rooted?)
+        end
+
+        def duck_type?
+          false
+        end
+
+        def interface?
+          false
+        end
+
+        # @yieldparam [UniqueType]
+        # @return [void]
+        # @overload each_unique_type()
+        #   @return [Enumerator<UniqueType>]
+        def each_unique_type &block
+          return enum_for(__method__) unless block_given?
+          conjuncts.each { |conjunct| conjunct.each_unique_type(&block) }
+        end
+
+        # An intersection can be assigned wherever any one of its
+        # conjuncts would be accepted (A & B <: A, A & B <: B).
+        #
+        # @param api_map [ApiMap]
+        # @param expected [ComplexType, ComplexType::UniqueType]
+        # @param situation [:method_call, :assignment, :return_type]
+        # @param rules [Array<:allow_subtype_skew, :allow_empty_params, :allow_reverse_match, :allow_any_match, :allow_undefined, :allow_unresolved_generic>]
+        # @param variance [:invariant, :covariant, :contravariant]
+        # @return [Boolean]
+        def conforms_to? api_map, expected, situation, rules = [],
+                         variance: erased_variance(situation)
+          conjuncts.any? do |conjunct|
+            conjunct.conforms_to?(api_map, expected, situation, rules, variance: variance)
+          end
+        end
+
+        # Applies the transformation to each conjunct independently
+        # and rebuilds the intersection from the results.
+        #
+        # @param new_name [String, nil]
+        # @yieldparam t [UniqueType]
+        # @yieldreturn [UniqueType]
+        # @return [self]
+        def transform new_name = nil, &transform_type
+          Intersection.new(conjuncts.map { |conjunct| conjunct.transform(new_name, &transform_type) })
+        end
+
+        # @return [self]
+        def erase_parameters
+          self
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -32,17 +32,17 @@ module Solargraph
         # @param conjuncts [Array<ComplexType>]
         def initialize conjuncts
           @conjuncts = conjuncts
-          super(conjuncts.map(&:tags).join(' & '), rooted: true)
+          super(intersection_tag(:tags), rooted: true)
         end
 
         # @return [String]
         def tag
-          @tag ||= conjuncts.map(&:tags).join(' & ')
+          @tag ||= intersection_tag(:tags)
         end
 
         # @return [String]
         def rooted_tag
-          @rooted_tag ||= conjuncts.map(&:rooted_tags).join(' & ')
+          @rooted_tag ||= intersection_tag(:rooted_tags)
         end
 
         # @return [String]
@@ -138,6 +138,21 @@ module Solargraph
         end
 
         private
+
+        # Renders the conjuncts as a tag, bracketing any conjunct that
+        # holds more than one type. `&` binds tighter than the `,`/`|`
+        # of a union, so without the brackets `[A | B] & C` would
+        # render as `A, B & C` and parse back as `A | (B & C)` - a
+        # different type.
+        #
+        # @param tags_method [:tags, :rooted_tags]
+        # @return [String]
+        def intersection_tag tags_method
+          conjuncts.map do |conjunct|
+            tags = conjunct.send(tags_method)
+            conjunct.items.length > 1 ? "[#{tags}]" : tags
+          end.join(' & ')
+        end
 
         # Returns expected itself when it's a bare Intersection, or
         # its one item when it's a ComplexType consisting of nothing

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -121,6 +121,29 @@ module Solargraph
           end
         end
 
+        # Every conjunct describes the same value, so each is resolved
+        # against the same context type, and a generic bound by one
+        # conjunct is visible to the rest through the shared
+        # resolved_generic_values hash. UniqueType's implementation
+        # looks for generics in #subtypes and #key_types, which an
+        # intersection does not use - its type parameters live inside
+        # the conjuncts - so `Class<generic<T>> & #new` never bound T.
+        #
+        # Conjuncts resolve left to right, so a generic that only
+        # becomes bindable through a later conjunct stays unresolved in
+        # an earlier one's output.
+        #
+        # @param generics_to_resolve [Enumerable<String>]
+        # @param context_type [ComplexType, UniqueType, nil]
+        # @param resolved_generic_values [Hash{String => ComplexType, UniqueType}]
+        # @return [Intersection]
+        def resolve_generics_from_context generics_to_resolve, context_type, resolved_generic_values: {}
+          Intersection.new(conjuncts.map do |conjunct|
+            conjunct.resolve_generics_from_context(generics_to_resolve, context_type,
+                                                   resolved_generic_values: resolved_generic_values)
+          end)
+        end
+
         # Applies the transformation to each conjunct independently
         # and rebuilds the intersection from the results.
         #

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -19,6 +19,16 @@ module Solargraph
       # where the intersection itself is expected if it satisfies
       # *every* conjunct.
       #
+      # Each conjunct is a full ComplexType, not a plain UniqueType -
+      # the same way UniqueType#subtypes and #key_types already hold
+      # ComplexTypes rather than UniqueTypes. RBS itself allows a
+      # union as one member of an intersection (`(A | B) & C`), so a
+      # conjunct needs to be able to represent more than one
+      # alternative; a single type is just the common case of a
+      # one-item ComplexType. This also means a conjunct can itself be
+      # (or contain) another Intersection, since Intersection is a
+      # UniqueType and ComplexType already holds UniqueTypes.
+      #
       # `A & B` is parsed the same way from plain YARD type tags
       # (`@param`, `@return`, `@type`, etc.) as it is from inline RBS
       # signatures, since both funnel through ComplexType.parse. YARD
@@ -29,23 +39,23 @@ module Solargraph
       # @see https://github.com/ruby/rbs/blob/master/docs/syntax.md#intersection-type
       # @see https://github.com/lsegal/yard/issues/1644
       class Intersection < UniqueType
-        # @return [Array<UniqueType>]
+        # @return [Array<ComplexType>]
         attr_reader :conjuncts
 
-        # @param conjuncts [Array<UniqueType>]
+        # @param conjuncts [Array<ComplexType>]
         def initialize conjuncts
           @conjuncts = conjuncts
-          super(conjuncts.map(&:tag).join(' & '), rooted: true)
+          super(conjuncts.map(&:tags).join(' & '), rooted: true)
         end
 
         # @return [String]
         def tag
-          @tag ||= conjuncts.map(&:tag).join(' & ')
+          @tag ||= conjuncts.map(&:tags).join(' & ')
         end
 
         # @return [String]
         def rooted_tag
-          @rooted_tag ||= conjuncts.map(&:rooted_tag).join(' & ')
+          @rooted_tag ||= conjuncts.map(&:rooted_tags).join(' & ')
         end
 
         # @return [String]
@@ -93,7 +103,10 @@ module Solargraph
         end
 
         # An intersection can be assigned wherever any one of its
-        # conjuncts would be accepted (A & B <: A, A & B <: B).
+        # conjuncts would be accepted (A & B <: A, A & B <: B). Each
+        # conjunct is checked as a full ComplexType, so a conjunct
+        # that's itself a union (from `(A | B) & C`) gets real union
+        # semantics (every member of that union must conform).
         #
         # @param api_map [ApiMap]
         # @param expected [ComplexType, ComplexType::UniqueType]

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -100,6 +100,13 @@ module Solargraph
         # *some* conjunct of this one, not necessarily the same one each
         # time - handled separately below.
         #
+        # A union on the expected side is tried one alternative at a
+        # time first, so that an intersection buried in a union is
+        # still compared as an intersection. Checking the conjuncts
+        # against the whole union instead asks a single conjunct to
+        # carry the match on its own, which `A & false` cannot do
+        # against a union that contains `A & false` itself.
+        #
         # @param api_map [ApiMap]
         # @param expected [ComplexType, ComplexType::UniqueType]
         # @param situation [:method_call, :assignment, :return_type]
@@ -108,6 +115,8 @@ module Solargraph
         # @return [Boolean]
         def conforms_to? api_map, expected, situation, rules = [],
                          variance: erased_variance(situation)
+          return true if any_union_alternative_conforms?(api_map, expected, situation, rules, variance)
+
           expected_intersection = sole_intersection(expected)
           if expected_intersection
             return expected_intersection.conjuncts.all? do |expected_conjunct|
@@ -179,12 +188,28 @@ module Solargraph
 
         # Returns expected itself when it's a bare Intersection, or
         # its one item when it's a ComplexType consisting of nothing
-        # but a single Intersection. Anything else - including a
-        # union with an intersection as just one of several
-        # alternatives - returns nil, leaving that (rarer, untested)
-        # case on the simpler existing "any conjunct" path rather
-        # than guessing at its semantics here.
+        # but a single Intersection. A union with an intersection as
+        # one of several alternatives returns nil; #conforms_to? has
+        # already tried each alternative on its own by then, so what
+        # reaches here is the fallback "any conjunct" path.
         #
+        # True when expected is a union and this intersection conforms
+        # to one of its alternatives taken on its own.
+        #
+        # @param api_map [ApiMap]
+        # @param expected [ComplexType, ComplexType::UniqueType]
+        # @param situation [:method_call, :assignment, :return_type]
+        # @param rules [Array<Symbol>]
+        # @param variance [:invariant, :covariant, :contravariant]
+        # @return [Boolean]
+        def any_union_alternative_conforms? api_map, expected, situation, rules, variance
+          return false unless expected.is_a?(ComplexType) && expected.length > 1
+
+          expected.items.any? do |item|
+            conforms_to?(api_map, ComplexType.new([item]), situation, rules, variance: variance)
+          end
+        end
+
         # @param expected [ComplexType, ComplexType::UniqueType]
         # @return [Intersection, nil]
         def sole_intersection expected

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -7,33 +7,20 @@ module Solargraph
       # more conjunct types, e.g., the RBS type `A & B`.
       #
       # Unlike ComplexType's comma-separated items (a union, where any
-      # one member describes the value), every conjunct of an
-      # Intersection must independently describe the value. That
-      # means the subtyping rules are the mirror image of a union's:
+      # one member describes the value), every conjunct must describe
+      # the value independently, so the subtyping rules are a union's
+      # mirror image: A & B <: A and A & B <: B, but a value satisfies
+      # A & B only if it satisfies every conjunct.
       #
-      #   A & B <: A
-      #   A & B <: B
+      # Each conjunct is a full ComplexType, not a plain UniqueType, as
+      # RBS allows a union as one member of an intersection
+      # (`(A | B) & C`) - and so a conjunct may itself be an
+      # Intersection.
       #
-      # i.e., a value typed as the intersection can be used wherever
-      # *any* conjunct is expected, but a value can only be used
-      # where the intersection itself is expected if it satisfies
-      # *every* conjunct.
-      #
-      # Each conjunct is a full ComplexType, not a plain UniqueType -
-      # the same way UniqueType#subtypes and #key_types already hold
-      # ComplexTypes rather than UniqueTypes. RBS itself allows a
-      # union as one member of an intersection (`(A | B) & C`), so a
-      # conjunct needs to be able to represent more than one
-      # alternative; a single type is just the common case of a
-      # one-item ComplexType. This also means a conjunct can itself be
-      # (or contain) another Intersection, since Intersection is a
-      # UniqueType and ComplexType already holds UniqueTypes.
-      #
-      # `A & B` is parsed the same way from plain YARD type tags
-      # (`@param`, `@return`, `@type`, etc.) as it is from inline RBS
-      # signatures, since both funnel through ComplexType.parse. YARD
-      # itself has no official intersection type syntax yet; `&` is
-      # Solargraph's extension pending upstream guidance.
+      # `A & B` parses the same from plain YARD type tags as from
+      # inline RBS signatures, since both funnel through
+      # ComplexType.parse. YARD has no official intersection syntax
+      # yet; `&` is Solargraph's extension pending upstream guidance.
       #
       # @see https://en.wikipedia.org/wiki/Intersection_type
       # @see https://github.com/ruby/rbs/blob/master/docs/syntax.md#intersection-type
@@ -108,16 +95,10 @@ module Solargraph
         # that's itself a union (from `(A | B) & C`) gets real union
         # semantics (every member of that union must conform).
         #
-        # When expected is *also* an intersection, that simple "any
-        # one conjunct" rule breaks down: a single one of our
-        # conjuncts, checked alone, would have to satisfy every
-        # conjunct expected of it - which fails whenever our conjuncts
-        # don't already relate to each other, even when checking an
-        # intersection against an identical copy of itself. The
-        # correct rule for A & B <: C & D is that every conjunct of
-        # the expected side must be satisfied by *some* conjunct of
-        # this one (not necessarily the same one each time), so that
-        # case is handled separately below.
+        # When expected is *also* an intersection, the rule instead is
+        # that every conjunct of the expected side must be satisfied by
+        # *some* conjunct of this one, not necessarily the same one each
+        # time - handled separately below.
         #
         # @param api_map [ApiMap]
         # @param expected [ComplexType, ComplexType::UniqueType]

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -108,6 +108,17 @@ module Solargraph
         # that's itself a union (from `(A | B) & C`) gets real union
         # semantics (every member of that union must conform).
         #
+        # When expected is *also* an intersection, that simple "any
+        # one conjunct" rule breaks down: a single one of our
+        # conjuncts, checked alone, would have to satisfy every
+        # conjunct expected of it - which fails whenever our conjuncts
+        # don't already relate to each other, even when checking an
+        # intersection against an identical copy of itself. The
+        # correct rule for A & B <: C & D is that every conjunct of
+        # the expected side must be satisfied by *some* conjunct of
+        # this one (not necessarily the same one each time), so that
+        # case is handled separately below.
+        #
         # @param api_map [ApiMap]
         # @param expected [ComplexType, ComplexType::UniqueType]
         # @param situation [:method_call, :assignment, :return_type]
@@ -116,6 +127,14 @@ module Solargraph
         # @return [Boolean]
         def conforms_to? api_map, expected, situation, rules = [],
                          variance: erased_variance(situation)
+          expected_intersection = sole_intersection(expected)
+          if expected_intersection
+            return expected_intersection.conjuncts.all? do |expected_conjunct|
+              conjuncts.any? do |conjunct|
+                conjunct.conforms_to?(api_map, expected_conjunct, situation, rules, variance: variance)
+              end
+            end
+          end
           conjuncts.any? do |conjunct|
             conjunct.conforms_to?(api_map, expected, situation, rules, variance: variance)
           end
@@ -135,6 +154,24 @@ module Solargraph
         # @return [self]
         def erase_parameters
           self
+        end
+
+        private
+
+        # Returns expected itself when it's a bare Intersection, or
+        # its one item when it's a ComplexType consisting of nothing
+        # but a single Intersection. Anything else - including a
+        # union with an intersection as just one of several
+        # alternatives - returns nil, leaving that (rarer, untested)
+        # case on the simpler existing "any conjunct" path rather
+        # than guessing at its semantics here.
+        #
+        # @param expected [ComplexType, ComplexType::UniqueType]
+        # @return [Intersection, nil]
+        def sole_intersection expected
+          return expected if expected.is_a?(Intersection)
+          return expected.first if expected.is_a?(ComplexType) && expected.length == 1 && expected.first.is_a?(Intersection)
+          nil
         end
       end
     end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -61,6 +61,26 @@ module Solargraph
           conjuncts.fetch(0).scope
         end
 
+        # Pins from the conjuncts defining the method - one is enough -
+        # narrowed by the block to those the caller can dispatch to.
+        #
+        # @param word [String]
+        # @param api_map [ApiMap]
+        # @yieldparam conjuncts [::Array<ComplexType>]
+        # @yieldreturn [::Array<ComplexType>]
+        # @return [::Array<Pin::Base>, nil] nil when no conjunct defines it
+        def method_stack_pins word, api_map, &narrow_conjuncts
+          candidates = block_given? ? yield(conjuncts) : conjuncts
+          resolved = candidates.filter_map do |conjunct|
+            pins = conjunct.method_stack_pins(word, api_map, &narrow_conjuncts)
+            pins.empty? ? nil : pins
+          end
+          return nil if resolved.empty?
+
+          # @param p [Pin::Base]
+          resolved.flatten.uniq { |p| [p.path, p.return_type.tag] }
+        end
+
         def generic?
           conjuncts.any?(&:generic?)
         end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -249,6 +249,11 @@ module Solargraph
           self
         end
 
+        # @return [Array<ComplexType::UniqueType>]
+        def unioned_items
+          [self]
+        end
+
         # Unanswerable for an intersection: each would report from @name
         # (the whole compound tag) or from subtype and parameter state an
         # intersection never populates.

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -443,11 +443,6 @@ module Solargraph
         end
 
         # @sg-ignore https://github.com/castwide/solargraph/pull/1277
-        def map(*, **, &)
-          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
-        end
-
-        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def desc(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -121,6 +121,16 @@ module Solargraph
           conjuncts.all?(&:void?)
         end
 
+        # @return [Boolean]
+        def undefined?
+          conjuncts.all?(&:undefined?)
+        end
+
+        # @return [Boolean]
+        def defined?
+          conjuncts.any?(&:defined?)
+        end
+
         # @param other [Object]
         # @return [Boolean]
         def eql? other

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -542,7 +542,7 @@ module Solargraph
         # @param variance [:invariant, :covariant, :contravariant]
         # @return [Boolean]
         def any_union_alternative_conforms? api_map, expected, situation, rules, variance
-          return false unless expected.is_a?(ComplexType) && expected.length > 1
+          return false unless expected.is_a?(ComplexType) && expected.items.length > 1
 
           expected.items.any? do |item|
             conforms_to?(api_map, ComplexType.new([item]), situation, rules, variance: variance)
@@ -555,7 +555,7 @@ module Solargraph
         # @return [Intersection, nil]
         def sole_intersection expected
           return expected if expected.is_a?(Intersection)
-          return expected.first if expected.is_a?(ComplexType) && expected.length == 1 && expected.first.is_a?(Intersection)
+          return expected.first if expected.is_a?(ComplexType) && expected.items.length == 1 && expected.first.is_a?(Intersection)
           nil
         end
       end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -190,7 +190,196 @@ module Solargraph
           self
         end
 
+        # Unanswerable for an intersection: each would report from @name
+        # (the whole compound tag) or from subtype and parameter state an
+        # intersection never populates.
+        def rooted_namespace(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def namespace_type(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def recreate(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def erased_version_of?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def value_types(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def parameters?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def list_parameters?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def fixed_parameters?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def hash_parameters?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def substring(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def rooted_substring(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def generate_substring_from(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def parameters_as_rbs(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def resolve_param_generics_from_context(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def rbs_name(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def non_literal_name(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def determine_non_literal_name(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def nullable?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def selfy?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def expand(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def without_nil(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def narrow_with(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def resolve_generics(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def erase_generics(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def simplify_literals(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def force_rooted(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def self_to_type(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def exclude(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def reduce_class_type(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def to_a(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def each(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def map(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def all?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def any?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def rooted_tags(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def desc(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def erased_variance(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def parameter_variance(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def literal?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def simplifyable_literal?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def tuple?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def downcast_to_literal_if_possible(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def rbs_union(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        protected
+
+        def equality_fields(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
         private
+
+        def mixin_pairing?(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        def namespace_kind(*, **, &)
+          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
 
         # Renders conjuncts as a tag, bracketing multi-item ones since
         # `&` binds tighter than `,`/`|` (`[A|B] & C`, not `A, B & C`).

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -254,6 +254,24 @@ module Solargraph
           [self]
         end
 
+        # Pairs conjunct by conjunct with another intersection and
+        # rebuilds one from the results. Any other type has no
+        # conjuncts to line up with, so it pairs with the whole.
+        #
+        # @param other [ComplexType, ComplexType::UniqueType]
+        # @yieldparam mine [ComplexType, ComplexType::UniqueType]
+        # @yieldparam theirs [ComplexType, ComplexType::UniqueType]
+        # @yieldreturn [ComplexType, ComplexType::UniqueType]
+        # @return [ComplexType, ComplexType::UniqueType]
+        def combine_via other, &block
+          return block.call(self, other) unless other.is_a?(Intersection)
+
+          # @param members [Array<ComplexType>]
+          gather = ->(members) { members.length == 1 ? members.fetch(0) : Intersection.new(members) }
+          results = TypeMethods.combine_members(conjuncts, other.conjuncts, gather, &block)
+          Intersection.new(results.map { |type| ComplexType.new([type]) })
+        end
+
         # Unanswerable for an intersection: each would report from @name
         # (the whole compound tag) or from subtype and parameter state an
         # intersection never populates.

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -139,6 +139,7 @@ module Solargraph
         # @param other [Object]
         # @return [Boolean]
         def eql? other
+          # @sg-ignore flow sensitive typing should support .class == .class
           self.class == other.class && sorted_conjuncts == other.sorted_conjuncts
         end
 

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -136,6 +136,11 @@ module Solargraph
           conjuncts.all?(&:nil_type?)
         end
 
+        # @return [Boolean]
+        def selfy?
+          conjuncts.any?(&:selfy?)
+        end
+
         # @param other [Object]
         # @return [Boolean]
         def eql? other
@@ -316,10 +321,6 @@ module Solargraph
         end
 
         def nullable?(*, **, &)
-          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
-        end
-
-        def selfy?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -443,11 +443,6 @@ module Solargraph
         end
 
         # @sg-ignore https://github.com/castwide/solargraph/pull/1277
-        def to_a(*, **, &)
-          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
-        end
-
-        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def each(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -27,10 +27,10 @@ module Solargraph
       # @see https://github.com/ruby/rbs/blob/master/docs/syntax.md#intersection-type
       # @see https://github.com/lsegal/yard/issues/1644
       class Intersection < UniqueType
-        # @return [Array<ComplexType>]
+        # @return [Array<UniqueType, Intersection, ComplexType>]
         attr_reader :conjuncts
 
-        # @param conjuncts [Array<ComplexType>]
+        # @param conjuncts [Array<UniqueType, Intersection, ComplexType>]
         def initialize conjuncts
           @conjuncts = conjuncts
           super(intersection_tag(:tags), rooted: conjuncts.all?(&:rooted?))

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -397,6 +397,7 @@ module Solargraph
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def expand(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -555,7 +555,7 @@ module Solargraph
         # @return [Intersection, nil]
         def sole_intersection expected
           return expected if expected.is_a?(Intersection)
-          return expected.first if expected.is_a?(ComplexType) && expected.items.length == 1 && expected.first.is_a?(Intersection)
+          return expected.items.first if expected.is_a?(ComplexType) && expected.items.length == 1 && expected.items.first.is_a?(Intersection)
           nil
         end
       end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -131,6 +131,11 @@ module Solargraph
           conjuncts.any?(&:defined?)
         end
 
+        # @return [Boolean]
+        def nil_type?
+          conjuncts.all?(&:nil_type?)
+        end
+
         # @param other [Object]
         # @return [Boolean]
         def eql? other

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -443,11 +443,6 @@ module Solargraph
         end
 
         # @sg-ignore https://github.com/castwide/solargraph/pull/1277
-        def each(*, **, &)
-          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
-        end
-
-        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def map(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -458,11 +458,6 @@ module Solargraph
         end
 
         # @sg-ignore https://github.com/castwide/solargraph/pull/1277
-        def any?(*, **, &)
-          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
-        end
-
-        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def desc(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -66,11 +66,13 @@ module Solargraph
           conjuncts.map(&:to_rbs).join(' & ')
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         # @return [String]
         def namespace
           raise NotImplementedError, "Intersection #{tag} has no single namespace - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         # @return [::Symbol]
         def scope
           raise NotImplementedError, "Intersection #{tag} has no single scope - resolve each conjunct instead"
@@ -305,74 +307,92 @@ module Solargraph
         # Unanswerable for an intersection: each would report from @name
         # (the whole compound tag) or from subtype and parameter state an
         # intersection never populates.
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def rooted_namespace(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def namespace_type(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def recreate(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def erased_version_of?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def value_types(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def parameters?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def list_parameters?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def fixed_parameters?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def hash_parameters?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def substring(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def rooted_substring(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def generate_substring_from(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def parameters_as_rbs(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def resolve_param_generics_from_context(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def rbs_name(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def non_literal_name(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def determine_non_literal_name(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def nullable?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
@@ -381,84 +401,104 @@ module Solargraph
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def without_nil(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def narrow_with(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def erase_generics(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def simplify_literals(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def force_rooted(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def self_to_type(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def exclude(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def reduce_class_type(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def to_a(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def each(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def map(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def all?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def any?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def desc(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def parameter_variance(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def simplifyable_literal?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def tuple?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def downcast_to_literal_if_possible(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def rbs_union(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
         protected
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def equality_fields(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
@@ -474,10 +514,12 @@ module Solargraph
 
         private
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def mixin_pairing?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def namespace_kind(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -453,11 +453,6 @@ module Solargraph
         end
 
         # @sg-ignore https://github.com/castwide/solargraph/pull/1277
-        def all?(*, **, &)
-          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
-        end
-
-        # @sg-ignore https://github.com/castwide/solargraph/pull/1277
         def desc(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -121,6 +121,17 @@ module Solargraph
           conjuncts.all?(&:void?)
         end
 
+        # @param other [Object]
+        # @return [Boolean]
+        def eql? other
+          self.class == other.class && sorted_conjuncts == other.sorted_conjuncts
+        end
+
+        # @return [Integer]
+        def hash
+          [self.class, sorted_conjuncts].hash
+        end
+
         # @yieldparam [UniqueType]
         # @return [void]
         # @overload each_unique_type()
@@ -385,6 +396,15 @@ module Solargraph
 
         def equality_fields(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
+        end
+
+        # Conjunct order is not part of the type. rooted_tags keys the
+        # sort rather than tag, which reports only a union conjunct's
+        # first member and drops the :: from a rooted one.
+        #
+        # @return [Array<ComplexType>]
+        def sorted_conjuncts
+          conjuncts.sort_by(&:rooted_tags)
         end
 
         private

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -53,12 +53,12 @@ module Solargraph
 
         # @return [String]
         def namespace
-          conjuncts.fetch(0).namespace
+          raise NotImplementedError, "Intersection #{tag} has no single namespace - resolve each conjunct instead"
         end
 
         # @return [::Symbol]
         def scope
-          conjuncts.fetch(0).scope
+          raise NotImplementedError, "Intersection #{tag} has no single scope - resolve each conjunct instead"
         end
 
         # Pins from the conjuncts defining the method - one is enough -

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -116,6 +116,11 @@ module Solargraph
           false
         end
 
+        # @return [Boolean]
+        def void?
+          conjuncts.all?(&:void?)
+        end
+
         # @yieldparam [UniqueType]
         # @return [void]
         # @overload each_unique_type()

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -232,6 +232,13 @@ module Solargraph
           Intersection.new(conjuncts.map { |conjunct| conjunct.transform(&transform_type) })
         end
 
+        # @param api_map [ApiMap]
+        # @param gates [Array<String>]
+        # @return [Intersection]
+        def unalias_and_qualify api_map, *gates
+          Intersection.new(conjuncts.map { |conjunct| conjunct.unalias_and_qualify(api_map, *gates) })
+        end
+
         # @return [self]
         def erase_parameters
           self

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -141,6 +141,14 @@ module Solargraph
           conjuncts.any?(&:selfy?)
         end
 
+        # A value of the intersection satisfies every conjunct, so one
+        # literal conjunct fixes it to that literal value.
+        #
+        # @return [Boolean]
+        def literal?
+          conjuncts.any?(&:literal?)
+        end
+
         # @param other [Object]
         # @return [Boolean]
         def eql? other
@@ -160,6 +168,18 @@ module Solargraph
         def each_unique_type &block
           return enum_for(__method__) unless block_given?
           conjuncts.each { |conjunct| conjunct.each_unique_type(&block) }
+        end
+
+        # Substituting one type for another where this one is expected
+        # is safe only where it is safe for every conjunct, so the
+        # variance is whatever the conjuncts agree on - and invariant
+        # when they disagree, since no one direction then holds for all.
+        #
+        # @param situation [:method_call, :return_type, :assignment]
+        # @return [:invariant, :covariant, :contravariant]
+        def erased_variance situation = :method_call
+          variances = conjuncts.map { |conjunct| conjunct.erased_variance(situation) }.uniq
+          variances.length == 1 ? variances.fetch(0) : :invariant
         end
 
         # An intersection can be assigned wherever any one of its
@@ -216,6 +236,16 @@ module Solargraph
             conjunct.resolve_generics_from_context(generics_to_resolve, context_type,
                                                    resolved_generic_values: resolved_generic_values)
           end)
+        end
+
+        # Each conjunct probes the same definitions and receiver, as in
+        # #resolve_generics_from_context above.
+        #
+        # @param definitions [Pin::Namespace, Pin::Method] The module/class/method which uses generic types
+        # @param context_type [ComplexType] The receiver type
+        # @return [Intersection]
+        def resolve_generics definitions, context_type
+          Intersection.new(conjuncts.map { |conjunct| conjunct.resolve_generics(definitions, context_type) })
         end
 
         # Applies the transformation to each conjunct independently
@@ -359,10 +389,6 @@ module Solargraph
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
-        def resolve_generics(*, **, &)
-          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
-        end
-
         def erase_generics(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
@@ -411,15 +437,7 @@ module Solargraph
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 
-        def erased_variance(*, **, &)
-          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
-        end
-
         def parameter_variance(*, **, &)
-          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
-        end
-
-        def literal?(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -33,7 +33,7 @@ module Solargraph
         # @param conjuncts [Array<ComplexType>]
         def initialize conjuncts
           @conjuncts = conjuncts
-          super(intersection_tag(:tags), rooted: true)
+          super(intersection_tag(:tags), rooted: conjuncts.all?(&:rooted?))
         end
 
         # @return [String]

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -47,6 +47,21 @@ module Solargraph
         end
 
         # @return [String]
+        def tags
+          tag
+        end
+
+        # @return [String]
+        def rooted_tags
+          rooted_tag
+        end
+
+        # @return [String]
+        def to_s
+          tags
+        end
+
+        # @return [String]
         def to_rbs
           conjuncts.map(&:to_rbs).join(' & ')
         end
@@ -326,10 +341,6 @@ module Solargraph
         end
 
         def any?(*, **, &)
-          raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
-        end
-
-        def rooted_tags(*, **, &)
           raise NotImplementedError, "Intersection #{tag} cannot answer ##{__method__} - resolve each conjunct instead"
         end
 

--- a/lib/solargraph/language_server/message/base.rb
+++ b/lib/solargraph/language_server/message/base.rb
@@ -88,6 +88,7 @@ module Solargraph
             # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#cancelRequest
             # cancel should send response RequestCancelled
             Solargraph::Logging.logger.info "Cancelled response to ##{id} #{method}"
+            # @sg-ignore https://github.com/castwide/solargraph/pull/1223
             set_result nil
             set_error ErrorCodes::REQUEST_CANCELLED, 'Cancelled by client'
           else

--- a/lib/solargraph/language_server/message/base.rb
+++ b/lib/solargraph/language_server/message/base.rb
@@ -63,11 +63,14 @@ module Solargraph
           return if id.nil?
 
           accept_or_cancel
+          # @type [Hash{Symbol => String, Integer, Hash, Array, nil}]
           response = {
             jsonrpc: '2.0',
             id: id
           }
+          # @sg-ignore https://github.com/castwide/solargraph/pull/1223
           response[:result] = result unless result.nil?
+          # @sg-ignore https://github.com/castwide/solargraph/pull/1223
           response[:error] = error unless error.nil?
           response[:result] = nil if result.nil? && error.nil?
           json = response.to_json

--- a/lib/solargraph/language_server/message/initialize.rb
+++ b/lib/solargraph/language_server/message/initialize.rb
@@ -14,6 +14,7 @@ module Solargraph
           else
             host.prepare params['rootPath']
           end
+          # @type [Hash{:capabilities => Hash{:textDocumentSync => Integer} & Hash{:workspace => Hash} & Hash{:positionEncoding => String}}]
           result = {
             capabilities: {
               textDocumentSync: 2, # @todo What should this be?
@@ -26,27 +27,27 @@ module Solargraph
             }
           }
           # FIXME: lsp default is utf-16, may have different position
-          result[:capabilities][:positionEncoding] = 'utf-32' if params.dig('capabilities', 'general',
-                                                                            'positionEncodings')&.include?('utf-32')
-          result[:capabilities].merge! static_completion unless dynamic_registration_for?('textDocument', 'completion')
-          result[:capabilities].merge! static_signature_help unless dynamic_registration_for?('textDocument',
-                                                                                              'signatureHelp')
+          result.fetch(:capabilities)[:positionEncoding] = 'utf-32' if params.dig('capabilities', 'general',
+                                                                                  'positionEncodings')&.include?('utf-32')
+          result.fetch(:capabilities).merge! static_completion unless dynamic_registration_for?('textDocument', 'completion')
+          result.fetch(:capabilities).merge! static_signature_help unless dynamic_registration_for?('textDocument',
+                                                                                                    'signatureHelp')
           # result[:capabilities].merge! static_on_type_formatting unless dynamic_registration_for?('textDocument', 'onTypeFormatting')
-          result[:capabilities].merge! static_hover unless dynamic_registration_for?('textDocument', 'hover')
-          result[:capabilities].merge! static_document_formatting unless dynamic_registration_for?('textDocument',
-                                                                                                   'formatting')
-          result[:capabilities].merge! static_document_symbols unless dynamic_registration_for?('textDocument',
-                                                                                                'documentSymbol')
-          result[:capabilities].merge! static_definitions unless dynamic_registration_for?('textDocument', 'definition')
-          result[:capabilities].merge! static_type_definitions unless dynamic_registration_for?('textDocument',
-                                                                                                'typeDefinition')
-          result[:capabilities].merge! static_rename unless dynamic_registration_for?('textDocument', 'rename')
-          result[:capabilities].merge! static_references unless dynamic_registration_for?('textDocument', 'references')
-          result[:capabilities].merge! static_workspace_symbols unless dynamic_registration_for?('workspace', 'symbol')
-          result[:capabilities].merge! static_folding_range unless dynamic_registration_for?('textDocument',
-                                                                                             'foldingRange')
-          result[:capabilities].merge! static_highlights unless dynamic_registration_for?('textDocument',
-                                                                                          'documentHighlight')
+          result.fetch(:capabilities).merge! static_hover unless dynamic_registration_for?('textDocument', 'hover')
+          result.fetch(:capabilities).merge! static_document_formatting unless dynamic_registration_for?('textDocument',
+                                                                                                         'formatting')
+          result.fetch(:capabilities).merge! static_document_symbols unless dynamic_registration_for?('textDocument',
+                                                                                                      'documentSymbol')
+          result.fetch(:capabilities).merge! static_definitions unless dynamic_registration_for?('textDocument', 'definition')
+          result.fetch(:capabilities).merge! static_type_definitions unless dynamic_registration_for?('textDocument',
+                                                                                                      'typeDefinition')
+          result.fetch(:capabilities).merge! static_rename unless dynamic_registration_for?('textDocument', 'rename')
+          result.fetch(:capabilities).merge! static_references unless dynamic_registration_for?('textDocument', 'references')
+          result.fetch(:capabilities).merge! static_workspace_symbols unless dynamic_registration_for?('workspace', 'symbol')
+          result.fetch(:capabilities).merge! static_folding_range unless dynamic_registration_for?('textDocument',
+                                                                                                   'foldingRange')
+          result.fetch(:capabilities).merge! static_highlights unless dynamic_registration_for?('textDocument',
+                                                                                                'documentHighlight')
           # @todo Temporarily disabled
           # result[:capabilities].merge! static_code_action unless dynamic_registration_for?('textDocument', 'codeAction')
           set_result result

--- a/lib/solargraph/language_server/message/initialize.rb
+++ b/lib/solargraph/language_server/message/initialize.rb
@@ -14,6 +14,7 @@ module Solargraph
           else
             host.prepare params['rootPath']
           end
+          # @type [Hash{Symbol => Hash{Symbol => Boolean, Integer, String, Hash}}]
           result = {
             capabilities: {
               textDocumentSync: 2, # @todo What should this be?
@@ -26,29 +27,29 @@ module Solargraph
             }
           }
           # FIXME: lsp default is utf-16, may have different position
-          result[:capabilities][:positionEncoding] = 'utf-32' if params.dig('capabilities', 'general',
-                                                                            'positionEncodings')&.include?('utf-32')
-          result[:capabilities].merge! static_completion unless dynamic_registration_for?('textDocument', 'completion')
-          result[:capabilities].merge! static_signature_help unless dynamic_registration_for?('textDocument',
-                                                                                              'signatureHelp')
-          # result[:capabilities].merge! static_on_type_formatting unless dynamic_registration_for?('textDocument', 'onTypeFormatting')
-          result[:capabilities].merge! static_hover unless dynamic_registration_for?('textDocument', 'hover')
-          result[:capabilities].merge! static_document_formatting unless dynamic_registration_for?('textDocument',
-                                                                                                   'formatting')
-          result[:capabilities].merge! static_document_symbols unless dynamic_registration_for?('textDocument',
-                                                                                                'documentSymbol')
-          result[:capabilities].merge! static_definitions unless dynamic_registration_for?('textDocument', 'definition')
-          result[:capabilities].merge! static_type_definitions unless dynamic_registration_for?('textDocument',
-                                                                                                'typeDefinition')
-          result[:capabilities].merge! static_rename unless dynamic_registration_for?('textDocument', 'rename')
-          result[:capabilities].merge! static_references unless dynamic_registration_for?('textDocument', 'references')
-          result[:capabilities].merge! static_workspace_symbols unless dynamic_registration_for?('workspace', 'symbol')
-          result[:capabilities].merge! static_folding_range unless dynamic_registration_for?('textDocument',
-                                                                                             'foldingRange')
-          result[:capabilities].merge! static_highlights unless dynamic_registration_for?('textDocument',
-                                                                                          'documentHighlight')
+          result.fetch(:capabilities)[:positionEncoding] = 'utf-32' if params.dig('capabilities', 'general',
+                                                                                  'positionEncodings')&.include?('utf-32')
+          result.fetch(:capabilities).merge! static_completion unless dynamic_registration_for?('textDocument', 'completion')
+          result.fetch(:capabilities).merge! static_signature_help unless dynamic_registration_for?('textDocument',
+                                                                                                    'signatureHelp')
+          # result.fetch(:capabilities).merge! static_on_type_formatting unless dynamic_registration_for?('textDocument', 'onTypeFormatting')
+          result.fetch(:capabilities).merge! static_hover unless dynamic_registration_for?('textDocument', 'hover')
+          result.fetch(:capabilities).merge! static_document_formatting unless dynamic_registration_for?('textDocument',
+                                                                                                         'formatting')
+          result.fetch(:capabilities).merge! static_document_symbols unless dynamic_registration_for?('textDocument',
+                                                                                                      'documentSymbol')
+          result.fetch(:capabilities).merge! static_definitions unless dynamic_registration_for?('textDocument', 'definition')
+          result.fetch(:capabilities).merge! static_type_definitions unless dynamic_registration_for?('textDocument',
+                                                                                                      'typeDefinition')
+          result.fetch(:capabilities).merge! static_rename unless dynamic_registration_for?('textDocument', 'rename')
+          result.fetch(:capabilities).merge! static_references unless dynamic_registration_for?('textDocument', 'references')
+          result.fetch(:capabilities).merge! static_workspace_symbols unless dynamic_registration_for?('workspace', 'symbol')
+          result.fetch(:capabilities).merge! static_folding_range unless dynamic_registration_for?('textDocument',
+                                                                                                   'foldingRange')
+          result.fetch(:capabilities).merge! static_highlights unless dynamic_registration_for?('textDocument',
+                                                                                                'documentHighlight')
           # @todo Temporarily disabled
-          # result[:capabilities].merge! static_code_action unless dynamic_registration_for?('textDocument', 'codeAction')
+          # result.fetch(:capabilities).merge! static_code_action unless dynamic_registration_for?('textDocument', 'codeAction')
           set_result result
         end
 

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -265,11 +265,11 @@ module Solargraph
           referenced&.path == pin.path
         end
         if pin.path == 'Class#new'
-          caller = cursor.chain.base.infer(api_map, clip.send(:closure), clip.locals).first
+          caller = cursor.chain.base.infer(api_map, clip.send(:closure), clip.locals).items.first
           if caller.defined?
             found.select! do |loc|
               clip = api_map.clip_at(loc.filename, loc.range.start)
-              other = clip.send(:cursor).chain.base.infer(api_map, clip.send(:closure), clip.locals).first
+              other = clip.send(:cursor).chain.base.infer(api_map, clip.send(:closure), clip.locals).items.first
               caller == other
             end
           else

--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -206,7 +206,7 @@ module Solargraph
       # @return [void]
       def add_downcast_var pin, presence:, downcast_type:, downcast_not_type:
         new_pin = pin.downcast(exclude_return_type: downcast_not_type,
-                               intersection_return_type: downcast_type,
+                               narrowed_return_type: downcast_type,
                                source: :flow_sensitive_typing,
                                presence: presence)
         if pin.is_a?(Pin::LocalVariable)

--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -146,7 +146,7 @@ module Solargraph
               result.push Chain::BlockVariable.new("&#{block_variable_name_node.children[0]}")
             end
           elsif n.type == :hash
-            result.push Chain::Hash.new('::Hash', n, hash_is_splatted?(n))
+            result.push Chain::Hash.new('::Hash', n, hash_is_splatted?(n), hash_pairs(n))
           elsif n.type == :array
             chained_children = n.children.map { |c| NodeChainer.chain(c) }
             result.push Source::Chain::Array.new(chained_children, n)
@@ -166,6 +166,27 @@ module Solargraph
             return false
           end
           true
+        end
+
+        # Chains each key/value pair of a literal hash so Chain::Hash
+        # can infer Hash{K => V} from its actual contents, the same
+        # way Chain::Array infers Array<T> from its elements. Returns
+        # nil (falling back to a bare, unparameterized Hash) when any
+        # entry isn't a plain `key => value` pair - a `**splat` entry
+        # contributes key/value types we have no node to chain.
+        #
+        # @param node [Parser::AST::Node]
+        # @return [::Array<::Array(Chain, Chain)>, nil]
+        def hash_pairs node
+          return nil unless Parser.is_ast_node?(node) && node.type == :hash
+          # @sg-ignore https://github.com/castwide/solargraph/pull/1223
+          return nil unless node.children.all? { |pair| Parser.is_ast_node?(pair) && pair.type == :pair }
+
+          node.children.map do |pair|
+            # @sg-ignore https://github.com/castwide/solargraph/pull/1223
+            key_node, value_node = pair.children
+            [NodeChainer.chain(key_node, @filename, pair), NodeChainer.chain(value_node, @filename, pair)]
+          end
         end
 
         # @param node [Parser::AST::Node]

--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -168,12 +168,9 @@ module Solargraph
           true
         end
 
-        # Chains each key/value pair of a literal hash so Chain::Hash
-        # can infer Hash{K => V} from its actual contents, the same
-        # way Chain::Array infers Array<T> from its elements. Returns
-        # nil (falling back to a bare, unparameterized Hash) when any
-        # entry isn't a plain `key => value` pair - a `**splat` entry
-        # contributes key/value types we have no node to chain.
+        # Chains each key/value pair so Chain::Hash can infer
+        # Hash{K => V}, mirroring how Chain::Array infers Array<T>.
+        # Returns nil for a `**splat` entry, which has no node to chain.
         #
         # @param node [Parser::AST::Node]
         # @return [::Array<::Array(Chain, Chain)>, nil]

--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -176,11 +176,9 @@ module Solargraph
         # @return [::Array<::Array(Chain, Chain)>, nil]
         def hash_pairs node
           return nil unless Parser.is_ast_node?(node) && node.type == :hash
-          # @sg-ignore https://github.com/castwide/solargraph/pull/1223
           return nil unless node.children.all? { |pair| Parser.is_ast_node?(pair) && pair.type == :pair }
 
           node.children.map do |pair|
-            # @sg-ignore https://github.com/castwide/solargraph/pull/1223
             key_node, value_node = pair.children
             [NodeChainer.chain(key_node, @filename, pair), NodeChainer.chain(value_node, @filename, pair)]
           end

--- a/lib/solargraph/parser/parser_gem/node_processors/send_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/send_node.rb
@@ -122,7 +122,7 @@ module Solargraph
                                                             source: :parser)
               if method_pin.return_type.defined?
                 pins.last.docstring.add_tag YARD::Tags::Tag.new(:param, '',
-                                                                pins.last.return_type.items.map(&:rooted_tags), 'value')
+                                                                pins.last.return_type.unioned_items.map(&:rooted_tags), 'value')
               end
             end
           end

--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -196,7 +196,7 @@ module Solargraph
       end
 
       # @param other [self]
-      # @return [ComplexType]
+      # @return [ComplexType, ComplexType::UniqueType]
       def combine_return_type other
         if return_type.undefined?
           other.return_type
@@ -211,14 +211,19 @@ module Solargraph
         elsif other.dodgy_return_type_source? && !dodgy_return_type_source?
           return_type
         else
-          all_items = return_type.items + other.return_type.items
-          if all_items.any?(&:selfy?) && all_items.any? do |item|
-            item.rooted_tag == context.reduce_class_type.rooted_tag
+          self_tags = context.reduce_class_type.rooted_tags
+          return_type.combine_via(other.return_type) do |mine, theirs|
+            # a declaration naming both self and the enclosing class meant self
+            if mine.rooted_tags == theirs.rooted_tags
+              mine
+            elsif mine.selfy? && theirs.rooted_tags == self_tags
+              mine
+            elsif theirs.selfy? && mine.rooted_tags == self_tags
+              theirs
+            else
+              ComplexType.union(mine, theirs)
+            end
           end
-            # assume this was a declaration that should have said 'self'
-            all_items.delete_if { |item| item.rooted_tag == context.reduce_class_type.rooted_tag }
-          end
-          ComplexType.new(all_items)
         end
       end
 

--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -31,46 +31,48 @@ module Solargraph
       #   Example: If a return type is 'Float | Integer | nil' and the
       #   exclude_return_type is 'Integer', the resulting return
       #   type will be 'Float | nil' because Integer is excluded.
-      # @param intersection_return_type [ComplexType, nil] Ensure each unique
+      # @param narrowed_return_type [ComplexType, nil] Ensure each unique
       #   return type is compatible with at least one element of this
       #   complex type.  If a ComplexType used as a return type is an
-      #   union type - we can return any of these - these are
-      #   intersection types - everything we return needs to meet at least
-      #   one of these unique types.
+      #   union type - we can return any of these - this is a
+      #   flow-sensitive narrowing (e.g. from an `is_a?` guard), not a
+      #   real intersection type (see
+      #   ComplexType::UniqueType::Intersection for that) - everything
+      #   we return needs to meet at least one of these unique types.
       #
       #   Example: If a return type is 'Numeric | nil' and the
-      #   intersection_return_type is 'Float | nil', the resulting return
+      #   narrowed_return_type is 'Float | nil', the resulting return
       #   type will be 'Float | nil' because Float is compatible
       #   with Numeric and nil is compatible with nil.
       # @see https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types
-      # @see https://en.wikipedia.org/wiki/Intersection_type#TypeScript_example
+      # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
       # @param presence [Range, nil]
       # @param [Hash{Symbol => Object}] splat
       def initialize assignment: nil, assignments: [], mass_assignment: nil,
                      presence: nil, return_type: nil,
-                     intersection_return_type: nil, exclude_return_type: nil,
+                     narrowed_return_type: nil, exclude_return_type: nil,
                      **splat
         super(**splat)
         @assignments = (assignment.nil? ? [] : [assignment]) + assignments
         # @type [nil, ::Array(Parser::AST::Node, Integer)]
         @mass_assignment = mass_assignment
         @return_type = return_type
-        @intersection_return_type = intersection_return_type
+        @narrowed_return_type = narrowed_return_type
         @exclude_return_type = exclude_return_type
         @presence = presence
       end
 
       # @param presence [Range]
       # @param exclude_return_type [ComplexType, nil]
-      # @param intersection_return_type [ComplexType, nil]
+      # @param narrowed_return_type [ComplexType, nil]
       # @param source [::Symbol]
       #
       # @return [self]
-      def downcast presence:, exclude_return_type: nil, intersection_return_type: nil,
+      def downcast presence:, exclude_return_type: nil, narrowed_return_type: nil,
                    source: self.source
         result = dup
         result.exclude_return_type = exclude_return_type
-        result.intersection_return_type = intersection_return_type
+        result.narrowed_return_type = narrowed_return_type
         result.source = source
         result.presence = presence
         result.reset_generated!
@@ -93,7 +95,7 @@ module Solargraph
                                   assignments: new_assignments,
                                   mass_assignment: combine_mass_assignment(other),
                                   return_type: combine_return_type(other),
-                                  intersection_return_type: combine_types(other, :intersection_return_type),
+                                  narrowed_return_type: combine_types(other, :narrowed_return_type),
                                   exclude_return_type: combine_types(other, :exclude_return_type),
                                   presence: combine_presence(other)
                                 })
@@ -123,7 +125,7 @@ module Solargraph
 
       def inner_desc
         super + ", presence=#{presence.inspect}, assignments=#{assignments}, " \
-                "intersection_return_type=#{intersection_return_type&.rooted_tags.inspect}, " \
+                "narrowed_return_type=#{narrowed_return_type&.rooted_tags.inspect}, " \
                 "exclude_return_type=#{exclude_return_type&.rooted_tags.inspect}"
       end
 
@@ -214,7 +216,7 @@ module Solargraph
 
       # @return [ComplexType, nil]
       def return_type
-        generate_complex_type || @return_type || intersection_return_type || ComplexType::UNDEFINED
+        generate_complex_type || @return_type || narrowed_return_type || ComplexType::UNDEFINED
       end
 
       def typify api_map
@@ -225,7 +227,7 @@ module Solargraph
 
       # @sg-ignore need boolish support for ? methods
       def presence_certain?
-        exclude_return_type || intersection_return_type
+        exclude_return_type || narrowed_return_type
       end
 
       # @param other_loc [Location]
@@ -288,7 +290,7 @@ module Solargraph
 
       protected
 
-      attr_accessor :exclude_return_type, :intersection_return_type
+      attr_accessor :exclude_return_type, :narrowed_return_type
 
       # @return [Range]
       attr_writer :presence
@@ -302,8 +304,8 @@ module Solargraph
       def adjust_type api_map, raw_return_type
         qualified_exclude = exclude_return_type&.qualify(api_map, *(closure&.gates || ['']))
         minus_exclusions = raw_return_type.exclude qualified_exclude, api_map
-        qualified_intersection = intersection_return_type&.qualify(api_map, *(closure&.gates || ['']))
-        minus_exclusions.intersect_with qualified_intersection, api_map
+        qualified_narrowing = narrowed_return_type&.qualify(api_map, *(closure&.gates || ['']))
+        minus_exclusions.narrow_with qualified_narrowing, api_map
       end
 
       # See if this variable is visible within 'viewing_closure'

--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -354,8 +354,7 @@ module Solargraph
         # @type [ComplexType, nil]
         type2 = other.send(attr)
         if type1 && type2
-          types = (type1.items + type2.items).uniq
-          ComplexType.new(types)
+          ComplexType.new([type1, type2])
         else
           type1 || type2
         end

--- a/lib/solargraph/pin/callable.rb
+++ b/lib/solargraph/pin/callable.rb
@@ -124,7 +124,7 @@ module Solargraph
       # @return [Array<Array, String, nil>]
       def full_type_arity
         # @sg-ignore flow sensitive typing needs to handle attrs
-        [return_type ? return_type.items.count.to_s : nil] + type_arity
+        [return_type ? return_type.unioned_items.count.to_s : nil] + type_arity
       end
 
       # @param generics_to_resolve [Enumerable<String>]

--- a/lib/solargraph/pin/namespace.rb
+++ b/lib/solargraph/pin/namespace.rb
@@ -8,7 +8,7 @@ module Solargraph
       # @return [::Symbol] :public or :private
       attr_reader :visibility
 
-      # @return [::Symbol] :class or :module
+      # @return [:class, :module]
       attr_reader :type
 
       # does not assert like super, as a namespace without a closure
@@ -16,7 +16,7 @@ module Solargraph
       # qualified
       attr_reader :closure
 
-      # @param type [::Symbol] :class or :module
+      # @param type [:class, :module]
       # @param visibility [::Symbol] :public or :private
       # @param gates [::Array<String>]
       # @param name [String]

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -227,10 +227,18 @@ module Solargraph
         ptype = typify api_map
         return true if ptype.undefined?
 
+        # :allow_unmatched_interface is included so that an
+        # RBS-interface-typed parameter (e.g. Hash#fetch's `_Key`) doesn't
+        # reject every argument that isn't nominally included in that
+        # interface via CoreFills::INCLUDES. Without it, no overload of a
+        # method like Hash#fetch ever matches a plain argument, and
+        # Pin::Method#return_type falls back to unioning every overload's
+        # return type together - including unbound generics from
+        # overloads that were never actually selected.
         return true if atype.conforms_to?(api_map,
                                           ptype,
                                           :method_call,
-                                          %i[allow_empty_params allow_undefined])
+                                          %i[allow_empty_params allow_undefined allow_unmatched_interface])
         ptype.generic?
       end
 

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -227,14 +227,9 @@ module Solargraph
         ptype = typify api_map
         return true if ptype.undefined?
 
-        # :allow_unmatched_interface is included so that an
-        # RBS-interface-typed parameter (e.g. Hash#fetch's `_Key`) doesn't
-        # reject every argument that isn't nominally included in that
-        # interface via CoreFills::INCLUDES. Without it, no overload of a
-        # method like Hash#fetch ever matches a plain argument, and
-        # Pin::Method#return_type falls back to unioning every overload's
-        # return type together - including unbound generics from
-        # overloads that were never actually selected.
+        # :allow_unmatched_interface lets an RBS-interface-typed
+        # parameter (e.g. Hash#fetch's `_Key`) accept an argument not
+        # nominally included in that interface via CoreFills::INCLUDES.
         return true if atype.conforms_to?(api_map,
                                           ptype,
                                           :method_call,

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -95,7 +95,7 @@ module Solargraph
 
       # @return [String]
       def type_arity_decl
-        arity_decl + return_type.items.count.to_s
+        arity_decl + return_type.unioned_items.count.to_s
       end
 
       def arg?

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -227,13 +227,10 @@ module Solargraph
         ptype = typify api_map
         return true if ptype.undefined?
 
-        # :allow_unmatched_interface lets an RBS-interface-typed
-        # parameter (e.g. Hash#fetch's `_Key`) accept an argument not
-        # nominally included in that interface via CoreFills::INCLUDES.
         return true if atype.conforms_to?(api_map,
                                           ptype,
                                           :method_call,
-                                          %i[allow_empty_params allow_undefined allow_unmatched_interface])
+                                          %i[allow_empty_params allow_undefined])
         ptype.generic?
       end
 

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -60,31 +60,22 @@ module Solargraph
         out
       end
 
-      # The index of the first parameter acting as a Hash-like lookup
-      # key for this class's own `K` (e.g. `Hash#fetch`'s first
-      # parameter), or nil if no parameter has that shape.
+      # The index of the first parameter typed as the receiver's own
+      # key (e.g. `Hash#fetch`'s first parameter), or nil if none is.
       #
-      # RBS's `core/hash.rbs` declares that parameter two ways, so both
-      # are recognized: `(_Key key)` from RBS 4.1.0 on (matched by the
-      # interface's literal name, so only RBS's own `Hash::_Key`), and
-      # `(K arg0)` before it, where `K` has already been resolved
-      # against the receiver - for a literal-keyed receiver that makes
-      # it the literal key type `key_tags` matches against.
+      # The parameter is declared `K`, which by this point has been
+      # resolved against the receiver - for a literal-keyed receiver
+      # that makes it the literal key type `key_tags` matches against.
+      # RBS >= 4.1 declares it as the structural interface `Hash::_Key`
+      # instead; RbsTranslator stubs that back to `K` on the way in
+      # (see RBS_INTERFACE_TO_GENERIC), so only this one shape is left
+      # to recognize here.
       #
-      # @todo Match `_Key` structurally rather than by name once
-      #   castwide/solargraph#1266 lands with ApiMap#get_own_methods -
-      #   https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
-      #
-      # @param namespace [String]
       # @param api_map [ApiMap]
       # @param key_tags [::Array<String>] the receiver's own resolved
-      #   `key_types` tags, used to recognize the pre-4.1 `K`-typed
-      #   shape. Empty disables that fallback.
+      #   `key_types` tags. Empty means there is nothing to match.
       # @return [Integer, nil]
-      def hash_key_param_index namespace, api_map, key_tags = []
-        key_tag = "#{namespace}::_Key"
-        index = parameters.find_index { |p| p.typify(api_map).tag == key_tag }
-        return index unless index.nil?
+      def hash_key_param_index api_map, key_tags
         return nil if key_tags.empty?
 
         parameters.find_index { |p| key_tags.include?(p.typify(api_map).tag) }

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -59,20 +59,6 @@ module Solargraph
         logger.debug { "Signature#typify(self=#{self}) => #{out}" }
         out
       end
-
-      # The index of the first parameter typed as the receiver's own
-      # key (e.g. `Hash#fetch`'s), or nil if none. RBS >= 4.1's
-      # `Hash::_Key` is stubbed back to `K` by RbsTranslator first.
-      #
-      # @param api_map [ApiMap]
-      # @param key_tags [::Array<String>] the receiver's own resolved
-      #   `key_types` tags. Empty means there is nothing to match.
-      # @return [Integer, nil]
-      def hash_key_param_index api_map, key_tags
-        return nil if key_tags.empty?
-
-        parameters.find_index { |p| key_tags.include?(p.typify(api_map).tag) }
-      end
     end
   end
 end

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -60,14 +60,24 @@ module Solargraph
         out
       end
 
-      # The index of the first parameter typed exactly
-      # `<namespace>::_Key` - the position RBS uses to mark "this
-      # parameter is a lookup key for this class's own K" (e.g.
-      # `Hash#fetch: (Hash::_Key key) -> V`) - or nil if none of this
-      # signature's parameters have that shape.
+      # The index of the first parameter acting as a lookup key for
+      # this class's own `K` (e.g. `Hash#fetch`'s first parameter), or
+      # nil if none of this signature's parameters have that shape.
       #
-      # This matches by the interface's literal name, so it only
-      # recognizes RBS's own `Hash::_Key` - a user-defined generic
+      # Two shapes are recognized, because RBS's own `core/hash.rbs`
+      # changed how it declares them in 4.1.0:
+      #
+      # - RBS >= 4.1.0 declares `def fetch: (_Key key) -> V` (also
+      #   `#[]`, `#dig`, `#delete`), so the parameter is typed exactly
+      #   `<namespace>::_Key`.
+      # - RBS < 4.1.0 declares `def fetch: (K arg0) -> V`, so the
+      #   parameter is typed as the class's own generic `K`, which by
+      #   this point has already been resolved against the receiver -
+      #   for a literal-keyed receiver that makes it the literal key
+      #   type itself, which is what `key_types` matches against.
+      #
+      # The `_Key` shape matches by the interface's literal name, so it
+      # only recognizes RBS's own `Hash::_Key` - a user-defined generic
       # class using the same "marker interface for a lookup key"
       # pattern under a different name/namespace won't be detected.
       #
@@ -76,28 +86,35 @@ module Solargraph
       # ApiMap#get_own_methods (a namespace's directly-declared
       # methods, excluding inherited ones), extracted from
       # Conformance#required_interface_methods for exactly this reuse.
-      # Replace the literal name comparison below with a structural
-      # one: a parameter is key-shaped if its type is an interface
-      # whose own declared method names equal
-      # `Hash::_Key`'s (`hash`/`eql?`), regardless of the interface's
-      # actual name -
+      # Replace the `_Key` name comparison below with a structural one:
+      # a parameter is key-shaped if its type is an interface whose own
+      # declared method names equal `Hash::_Key`'s (`hash`/`eql?`),
+      # regardless of the interface's actual name -
       # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
       #
-      #   def key_param_index namespace, api_map
-      #     key_interface_methods = api_map.get_own_methods("#{namespace}::_Key").map(&:name).to_set
-      #     parameters.find_index do |p|
-      #       type = p.typify(api_map)
-      #       next false unless type.interface?
-      #       api_map.get_own_methods(type.tag).map(&:name).to_set == key_interface_methods
-      #     end
+      #   key_interface_methods = api_map.get_own_methods("#{namespace}::_Key").map(&:name).to_set
+      #   index = parameters.find_index do |p|
+      #     type = p.typify(api_map)
+      #     next false unless type.interface?
+      #     api_map.get_own_methods(type.tag).map(&:name).to_set == key_interface_methods
       #   end
+      #
+      # That only replaces the first branch - the `key_tags` fallback is
+      # still needed for RBS < 4.1, which has no interface there at all.
       #
       # @param namespace [String]
       # @param api_map [ApiMap]
+      # @param key_tags [::Array<String>] the receiver's own resolved
+      #   `key_types` tags, used to recognize the pre-4.1 `K`-typed
+      #   shape. Empty disables that fallback.
       # @return [Integer, nil]
-      def key_param_index namespace, api_map
+      def key_param_index namespace, api_map, key_tags = []
         key_tag = "#{namespace}::_Key"
-        parameters.find_index { |p| p.typify(api_map).tag == key_tag }
+        index = parameters.find_index { |p| p.typify(api_map).tag == key_tag }
+        return index unless index.nil?
+        return nil if key_tags.empty?
+
+        parameters.find_index { |p| key_tags.include?(p.typify(api_map).tag) }
       end
     end
   end

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -66,6 +66,32 @@ module Solargraph
       # `Hash#fetch: (Hash::_Key key) -> V`) - or nil if none of this
       # signature's parameters have that shape.
       #
+      # This matches by the interface's literal name, so it only
+      # recognizes RBS's own `Hash::_Key` - a user-defined generic
+      # class using the same "marker interface for a lookup key"
+      # pattern under a different name/namespace won't be detected.
+      #
+      # TODO once castwide/solargraph#1266 (structurally verify RBS
+      # interface-typed expectations) lands - it lands with
+      # ApiMap#get_own_methods (a namespace's directly-declared
+      # methods, excluding inherited ones), extracted from
+      # Conformance#required_interface_methods for exactly this reuse.
+      # Replace the literal name comparison below with a structural
+      # one: a parameter is key-shaped if its type is an interface
+      # whose own declared method names equal
+      # `Hash::_Key`'s (`hash`/`eql?`), regardless of the interface's
+      # actual name -
+      # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
+      #
+      #   def key_param_index namespace, api_map
+      #     key_interface_methods = api_map.get_own_methods("#{namespace}::_Key").map(&:name).to_set
+      #     parameters.find_index do |p|
+      #       type = p.typify(api_map)
+      #       next false unless type.interface?
+      #       api_map.get_own_methods(type.tag).map(&:name).to_set == key_interface_methods
+      #     end
+      #   end
+      #
       # @param namespace [String]
       # @param api_map [ApiMap]
       # @return [Integer, nil]

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -59,6 +59,20 @@ module Solargraph
         logger.debug { "Signature#typify(self=#{self}) => #{out}" }
         out
       end
+
+      # The index of the first parameter typed exactly
+      # `<namespace>::_Key` - the position RBS uses to mark "this
+      # parameter is a lookup key for this class's own K" (e.g.
+      # `Hash#fetch: (Hash::_Key key) -> V`) - or nil if none of this
+      # signature's parameters have that shape.
+      #
+      # @param namespace [String]
+      # @param api_map [ApiMap]
+      # @return [Integer, nil]
+      def key_param_index namespace, api_map
+        key_tag = "#{namespace}::_Key"
+        parameters.find_index { |p| p.typify(api_map).tag == key_tag }
+      end
     end
   end
 end

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -61,15 +61,8 @@ module Solargraph
       end
 
       # The index of the first parameter typed as the receiver's own
-      # key (e.g. `Hash#fetch`'s first parameter), or nil if none is.
-      #
-      # The parameter is declared `K`, which by this point has been
-      # resolved against the receiver - for a literal-keyed receiver
-      # that makes it the literal key type `key_tags` matches against.
-      # RBS >= 4.1 declares it as the structural interface `Hash::_Key`
-      # instead; RbsTranslator stubs that back to `K` on the way in
-      # (see RBS_INTERFACE_TO_GENERIC), so only this one shape is left
-      # to recognize here.
+      # key (e.g. `Hash#fetch`'s), or nil if none. RBS >= 4.1's
+      # `Hash::_Key` is stubbed back to `K` by RbsTranslator first.
       #
       # @param api_map [ApiMap]
       # @param key_tags [::Array<String>] the receiver's own resolved

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -60,47 +60,20 @@ module Solargraph
         out
       end
 
-      # The index of the first parameter acting as a lookup key for
-      # this class's own `K` (e.g. `Hash#fetch`'s first parameter), or
-      # nil if none of this signature's parameters have that shape.
+      # The index of the first parameter acting as a Hash-like lookup
+      # key for this class's own `K` (e.g. `Hash#fetch`'s first
+      # parameter), or nil if no parameter has that shape.
       #
-      # Two shapes are recognized, because RBS's own `core/hash.rbs`
-      # changed how it declares them in 4.1.0:
+      # RBS's `core/hash.rbs` declares that parameter two ways, so both
+      # are recognized: `(_Key key)` from RBS 4.1.0 on (matched by the
+      # interface's literal name, so only RBS's own `Hash::_Key`), and
+      # `(K arg0)` before it, where `K` has already been resolved
+      # against the receiver - for a literal-keyed receiver that makes
+      # it the literal key type `key_tags` matches against.
       #
-      # - RBS >= 4.1.0 declares `def fetch: (_Key key) -> V` (also
-      #   `#[]`, `#dig`, `#delete`), so the parameter is typed exactly
-      #   `<namespace>::_Key`.
-      # - RBS < 4.1.0 declares `def fetch: (K arg0) -> V`, so the
-      #   parameter is typed as the class's own generic `K`, which by
-      #   this point has already been resolved against the receiver -
-      #   for a literal-keyed receiver that makes it the literal key
-      #   type itself, which is what `key_types` matches against.
-      #
-      # The `_Key` shape matches by the interface's literal name, so it
-      # only recognizes RBS's own `Hash::_Key` - a user-defined generic
-      # class using the same "marker interface for a lookup key"
-      # pattern under a different name/namespace won't be detected.
-      #
-      # TODO once castwide/solargraph#1266 (structurally verify RBS
-      # interface-typed expectations) lands - it lands with
-      # ApiMap#get_own_methods (a namespace's directly-declared
-      # methods, excluding inherited ones), extracted from
-      # Conformance#required_interface_methods for exactly this reuse.
-      # Replace the `_Key` name comparison below with a structural one:
-      # a parameter is key-shaped if its type is an interface whose own
-      # declared method names equal `Hash::_Key`'s (`hash`/`eql?`),
-      # regardless of the interface's actual name -
-      # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
-      #
-      #   key_interface_methods = api_map.get_own_methods("#{namespace}::_Key").map(&:name).to_set
-      #   index = parameters.find_index do |p|
-      #     type = p.typify(api_map)
-      #     next false unless type.interface?
-      #     api_map.get_own_methods(type.tag).map(&:name).to_set == key_interface_methods
-      #   end
-      #
-      # That only replaces the first branch - the `key_tags` fallback is
-      # still needed for RBS < 4.1, which has no interface there at all.
+      # @todo Match `_Key` structurally rather than by name once
+      #   castwide/solargraph#1266 lands with ApiMap#get_own_methods -
+      #   https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
       #
       # @param namespace [String]
       # @param api_map [ApiMap]
@@ -108,7 +81,7 @@ module Solargraph
       #   `key_types` tags, used to recognize the pre-4.1 `K`-typed
       #   shape. Empty disables that fallback.
       # @return [Integer, nil]
-      def key_param_index namespace, api_map, key_tags = []
+      def hash_key_param_index namespace, api_map, key_tags = []
         key_tag = "#{namespace}::_Key"
         index = parameters.find_index { |p| p.typify(api_map).tag == key_tag }
         return index unless index.nil?

--- a/lib/solargraph/position.rb
+++ b/lib/solargraph/position.rb
@@ -121,6 +121,7 @@ module Solargraph
     # @return [Position]
     def self.normalize object
       return object if object.is_a?(Position)
+      # @sg-ignore https://github.com/castwide/solargraph/pull/1223
       return Position.new(object[0], object[1]) if object.is_a?(Array)
       raise ArgumentError, "Unable to convert #{object.class} to Position"
     end

--- a/lib/solargraph/position.rb
+++ b/lib/solargraph/position.rb
@@ -34,7 +34,7 @@ module Solargraph
     # Get a hash of the position. This representation is suitable for use in
     # the language server protocol.
     #
-    # @return [Hash]
+    # @return [Hash{Symbol => Integer}]
     def to_hash
       {
         line: line,

--- a/lib/solargraph/range.rb
+++ b/lib/solargraph/range.rb
@@ -32,7 +32,7 @@ module Solargraph
     # Get a hash of the range. This representation is suitable for use in
     # the language server protocol.
     #
-    # @return [Hash{Symbol => Position}]
+    # @return [Hash{Symbol => Hash{Symbol => Integer}}]
     def to_hash
       {
         start: start.to_hash,

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -763,7 +763,7 @@ module Solargraph
       # @return [ComplexType]
       def extract_method_type_return_type type, implicit_nil
         return_type = RbsTranslator.to_complex_type(type.type.return_type)
-        return ComplexType.new(return_type.items + [ComplexType::UniqueType::NIL]) if return_type && implicit_nil
+        return ComplexType.parse("#{return_type.rooted_tags}, nil") if return_type && implicit_nil
 
         return_type
       end

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -759,11 +759,13 @@ module Solargraph
       # This method will convert type aliases to concrete types.
       #
       # @param type [RBS::MethodType]
+      # @param implicit_nil [Boolean]
       # @return [ComplexType]
       def extract_method_type_return_type type, implicit_nil
-          tag = RbsTranslator.to_complex_type(type.type.return_type)
-          return ComplexType.parse("#{tag}, nil") if tag && implicit_nil
-          tag
+        return_type = RbsTranslator.to_complex_type(type.type.return_type)
+        return ComplexType.new(return_type.items + [ComplexType::UniqueType::NIL]) if return_type && implicit_nil
+
+        return_type
       end
 
       # @param type_name [RBS::TypeName]

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -852,15 +852,6 @@ module Solargraph
         )
       end
 
-      RBS_TO_YARD_TYPE = {
-        'bool' => 'Boolean',
-        'string' => 'String',
-        'int' => 'Integer',
-        'untyped' => '',
-        'NilClass' => 'nil'
-      }
-      private_constant :RBS_TO_YARD_TYPE
-
       # Extract a ComplexType from a MethodType's return type.
       #
       # This method will convert type aliases to concrete types.
@@ -877,13 +868,7 @@ module Solargraph
       # @param type_args [Enumerable<RBS::Types::Bases::Base>]
       # @return [ComplexType::UniqueType]
       def build_type(type_name, type_args = [])
-        base = RBS_TO_YARD_TYPE[type_name.relative!.to_s] || type_name.relative!.to_s
-        params = type_args.map { |arg| RbsTranslator.to_complex_type(arg).force_rooted }
-        if base == 'Hash' && params.length == 2
-          ComplexType::UniqueType.new(base, [params.first], [params.last], rooted: true, parameters_type: :hash)
-        else
-          ComplexType::UniqueType.new(base, [], params.reject(&:undefined?), rooted: true, parameters_type: :list)
-        end
+        RbsTranslator.build_unique_type(type_name, type_args)
       end
 
       # @param decl [RBS::AST::Declarations::Class, RBS::AST::Declarations::Module]

--- a/lib/solargraph/rbs_map/core_map.rb
+++ b/lib/solargraph/rbs_map/core_map.rb
@@ -13,6 +13,11 @@ module Solargraph
 
       FILLS_DIRECTORY = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'rbs', 'fills'))
 
+      # Like FILLS_DIRECTORY, but a declaration here *replaces* the core
+      # definition of the same method path rather than adding an overload
+      # alongside it.
+      OVERRIDES_DIRECTORY = File.expand_path(File.join(File.dirname(__FILE__), '..', '..', '..', 'rbs', 'overrides'))
+
       def initialize; end
 
       # @param out [IO, nil] output stream for logging
@@ -25,6 +30,7 @@ module Solargraph
       # @param out [StringIO, IO, nil] output stream for logging
       # @return [Array<Pin::Base>]
       def cache_core out: $stderr
+        # @type [Array<Pin::Base>]
         new_pins = []
         cache = PinCache.deserialize_core
         return cache if cache
@@ -36,6 +42,15 @@ module Solargraph
         out&.puts 'Caching RBS pins for Ruby core'
         fill_conversions = Conversions.new(loader: fill_loader)
         new_pins.concat fill_conversions.pins
+
+        override_loader = RBS::EnvironmentLoader.new(core_root: nil, repository: RBS::Repository.new(no_stdlib: false))
+        override_loader.add(path: Pathname(OVERRIDES_DIRECTORY))
+        override_pins = Conversions.new(loader: override_loader).pins
+        # An override replaces what core declared for that path.
+        overridden = override_pins.grep(Pin::Method).to_set(&:path)
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1266
+        new_pins.reject! { |pin| pin.is_a?(Pin::Method) && overridden.include?(pin.path) }
+        new_pins.concat override_pins
 
         # add some overrides
         new_pins.concat RbsMap::CoreFills::ALL

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -12,10 +12,9 @@ module Solargraph
       'NilClass' => 'nil'
     }
 
-    # RBS 4.1 types the key lookups on Hash (`#[]`, `#fetch`, `#dig`,
-    # `#delete`) as the structural interface `Hash::_Key`. Solargraph
-    # resolves interfaces by name, so stub the name to the type
-    # parameter it stands in for until structural support lands.
+    # Solargraph resolves interfaces by name, so Hash's `_Key` lookups
+    # (`#[]`, `#fetch`, `#dig`, `#delete`) are stubbed to the type
+    # parameter they stand in for.
     #
     # https://github.com/castwide/solargraph/pull/1266
     #

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -12,16 +12,12 @@ module Solargraph
       'NilClass' => 'nil'
     }
 
-    # From 4.1.0, RBS types Hash's own key lookups (`#[]`, `#fetch`,
-    # `#dig`, `#delete`) as the structural interface `Hash::_Key` -
-    # anything answering `hash`/`eql?` - rather than the class's own
-    # `K`, which is how it declared them before. Solargraph resolves
-    # interfaces by name rather than structurally, so the well-known
-    # name is stubbed to the type parameter it stands in for, the same
-    # way `bool`/`string`/`int` are stubbed above.
+    # RBS 4.1 types the key lookups on Hash (`#[]`, `#fetch`, `#dig`,
+    # `#delete`) as the structural interface `Hash::_Key`. Solargraph
+    # resolves interfaces by name, so stub the name to the type
+    # parameter it stands in for until structural support lands.
     #
-    # This is a stand-in, not a translation: it reads as `K`, which is
-    # narrower than the `hash`/`eql?` that RBS actually accepts.
+    # https://github.com/castwide/solargraph/pull/1266
     #
     # @type [Hash{String => String}]
     RBS_INTERFACE_TO_GENERIC = {
@@ -182,6 +178,8 @@ module Solargraph
           #
           # @sg-ignore flow sensitive typing ought to be able to handle 'when ClassName'
           type.types.map { |member| intersection_conjunct_tag(member) }.join(' & ')
+        when RBS::Types::Proc
+          'Proc'
         when RBS::Types::ClassInstance, RBS::Types::Alias, RBS::Types::Interface
           # `Alias` is a top-level type alias, e.g., 'bool' in "type bool = true | false"
           # @todo ensure these get resolved after processing all aliases
@@ -196,8 +194,6 @@ module Solargraph
           # e.g., singleton(String)
           # @sg-ignore flow sensitive typing ought to be able to handle 'when ClassName'
           build_unique_type(type.name).tags
-        when RBS::Types::Proc
-          'Proc'
         when RBS::Types::Bases::Any, RBS::Types::Bases::Bottom
           # `Bottom`` is used in contexts where nothing will ever return
           # - e.g., it could be the return type of 'exit()' or 'raise'

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -12,16 +12,30 @@ module Solargraph
       'NilClass' => 'nil'
     }
 
+    # From 4.1.0, RBS types Hash's own key lookups (`#[]`, `#fetch`,
+    # `#dig`, `#delete`) as the structural interface `Hash::_Key` -
+    # anything answering `hash`/`eql?` - rather than the class's own
+    # `K`, which is how it declared them before. Solargraph resolves
+    # interfaces by name rather than structurally, so the well-known
+    # name is stubbed to the type parameter it stands in for, the same
+    # way `bool`/`string`/`int` are stubbed above.
+    #
+    # This is a stand-in, not a translation: it reads as `K`, which is
+    # narrower than the `hash`/`eql?` that RBS actually accepts.
+    #
+    # @type [Hash{String => String}]
+    RBS_INTERFACE_TO_GENERIC = {
+      'Hash::_Key' => 'K'
+    }.freeze
+
     # Translates an RBS type into a ComplexType.
     #
     # Every RBS node that can *contain* another type - intersections,
     # unions, optionals, tuples, and generic type arguments - is built
     # directly as a ComplexType/UniqueType object graph by recursing
-    # through this method, rather than by rendering a tag string and
-    # re-parsing it. A joined string can't represent grouping that
-    # Solargraph's own tag grammar has no syntax for (e.g. a union
-    # nested inside an intersection, `(A | B) & C`), so round-tripping
-    # through one silently produces the wrong structure. Only leaf
+    # through this method, continuing the move away from tag strings
+    # begun in castwide/solargraph#870 so that `rooted?` is carried
+    # through unchanged rather than re-derived by a parse. Only leaf
     # types that can't contain a nested type (literals, `bool`, `nil`,
     # `void`, generic type variables, `self`/`instance`, `Proc`, etc.)
     # go through the tag-string fallback in type_to_tag.
@@ -130,14 +144,20 @@ module Solargraph
       Pin::Signature.new(generics: generics, parameters: parameters, return_type: return_type, block: block, source: :rbs, type_location: closure.location, closure: closure)
     end
 
+    # Builds a named type (with its generic arguments, if any) directly
+    # as an object rather than via a tag string, so `rooted?` survives -
+    # see castwide/solargraph#870.
+    #
     # @param type_name [RBS::TypeName]
     # @param type_args [Enumerable<RBS::Types::Bases::Base>]
     # @return [ComplexType::UniqueType]
     def self.build_unique_type(type_name, type_args = [])
-      base = RBS_TO_YARD_TYPE[type_name.relative!.to_s] || type_name.relative!.to_s
-      params = type_args.map do |a|
-        RbsTranslator.to_complex_type(a)
-      end
+      name = type_name.relative!.to_s
+      generic = RBS_INTERFACE_TO_GENERIC[name]
+      return ComplexType.parse("#{ComplexType::GENERIC_TAG_NAME}<#{generic}>").first if generic
+
+      base = RBS_TO_YARD_TYPE[name] || name
+      params = type_args.map { |arg| RbsTranslator.to_complex_type(arg).force_rooted }
       if base == 'Hash' && params.length == 2
         ComplexType::UniqueType.new(base, [params.first], [params.last], rooted: true, parameters_type: :hash)
       else

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -15,6 +15,7 @@ module Solargraph
     # @param type [RBS::Types::Bases::Base]
     # @return [ComplexType]
     def self.to_complex_type(type)
+      return intersection_complex_type(type) if type.is_a?(RBS::Types::Intersection)
       tag = type_to_tag(type)
       ComplexType.try_parse(tag).force_rooted
     end
@@ -122,6 +123,22 @@ module Solargraph
 
     class << self
       private
+
+      # Builds an Intersection directly from each member's own
+      # translated ComplexType, rather than flattening through
+      # type_to_tag's string-based join. RBS allows a union as one
+      # member of an intersection (e.g. `(A | B) & C`); going through
+      # a joined string would lose that structure (`type_to_tag`
+      # would render the union member as a plain comma list, which
+      # ComplexType.parse would then read back as a top-level union
+      # of the whole expression rather than a nested one).
+      #
+      # @param type [RBS::Types::Intersection]
+      # @return [ComplexType]
+      def intersection_complex_type type
+        conjuncts = type.types.map { |member| RbsTranslator.to_complex_type(member) }
+        ComplexType.new([ComplexType::UniqueType::Intersection.new(conjuncts)]).force_rooted
+      end
 
       # @param type [RBS::Types::Bases::Base]
       # @return [String]

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -152,7 +152,7 @@ module Solargraph
           # `Top` is the most super superclass
           'BasicObject'
         when RBS::Types::Intersection
-          type.types.map { |member| type_to_tag(member) }.join(', ')
+          type.types.map { |member| type_to_tag(member) }.join(' & ')
         when RBS::Types::Proc
           'Proc'
         when RBS::Types::ClassInstance, RBS::Types::Alias, RBS::Types::Interface

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -145,8 +145,8 @@ module Solargraph
     end
 
     # Builds a named type (with its generic arguments, if any) directly
-    # as an object rather than via a tag string, so `rooted?` survives -
-    # see castwide/solargraph#870.
+    # as an object rather than via a tag string, so `rooted?` survives.
+    # https://github.com/castwide/solargraph/pull/870
     #
     # @param type_name [RBS::TypeName]
     # @param type_args [Enumerable<RBS::Types::Bases::Base>]

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -28,45 +28,11 @@ module Solargraph
       'Hash::_Key' => 'K'
     }.freeze
 
-    # Translates an RBS type into a ComplexType.
-    #
-    # Every RBS node that can *contain* another type - intersections,
-    # unions, optionals, tuples, and generic type arguments - is built
-    # directly as a ComplexType/UniqueType object graph by recursing
-    # through this method, continuing the move away from tag strings
-    # begun in castwide/solargraph#870 so that `rooted?` is carried
-    # through unchanged rather than re-derived by a parse. Only leaf
-    # types that can't contain a nested type (literals, `bool`, `nil`,
-    # `void`, generic type variables, `self`/`instance`, `Proc`, etc.)
-    # go through the tag-string fallback in type_to_tag.
-    #
     # @param type [RBS::Types::Bases::Base]
     # @return [ComplexType]
     def self.to_complex_type(type)
-      case type
-      when RBS::Types::Intersection
-        intersection_complex_type(type)
-      when RBS::Types::Optional
-        optional_complex_type(type)
-      when RBS::Types::Union
-        union_complex_type(type)
-      when RBS::Types::Tuple
-        tuple_complex_type(type)
-      when RBS::Types::ClassInstance, RBS::Types::Alias, RBS::Types::Interface
-        # `Alias` is a top-level type alias, e.g., 'bool' in "type bool = true | false"
-        # @todo ensure these get resolved after processing all aliases
-        # @todo handle recursive aliases
-        #
-        # `Interface` represents a mix-in module which can be considered a
-        # subtype of a consumer of it
-        ComplexType.new([build_unique_type(type.name, type.args)]).force_rooted
-      when RBS::Types::ClassSingleton
-        # e.g., singleton(String)
-        ComplexType.new([build_unique_type(type.name)]).force_rooted
-      else
-        tag = type_to_tag(type)
-        ComplexType.try_parse(tag).force_rooted
-      end
+      tag = type_to_tag(type)
+      ComplexType.try_parse(tag).force_rooted
     end
 
     # @param param_type [RBS::Types::Function::Param]
@@ -179,45 +145,23 @@ module Solargraph
     class << self
       private
 
-      # @param type [RBS::Types::Intersection]
-      # @return [ComplexType]
-      def intersection_complex_type type
-        conjuncts = type.types.map { |member| RbsTranslator.to_complex_type(member) }
-        ComplexType.new([ComplexType::UniqueType::Intersection.new(conjuncts)]).force_rooted
-      end
-
-      # @param type [RBS::Types::Optional]
-      # @return [ComplexType]
-      def optional_complex_type type
-        inner = RbsTranslator.to_complex_type(type.type)
-        ComplexType.new(inner.items + [ComplexType::UniqueType::NIL]).force_rooted
-      end
-
-      # @param type [RBS::Types::Union]
-      # @return [ComplexType]
-      def union_complex_type type
-        ComplexType.new(type.types.flat_map { |t| RbsTranslator.to_complex_type(t).items }).force_rooted
-      end
-
-      # @param type [RBS::Types::Tuple]
-      # @return [ComplexType]
-      def tuple_complex_type type
-        subtypes = type.types.map { |t| RbsTranslator.to_complex_type(t) }
-        ComplexType.new([ComplexType::UniqueType.new('Array', [], subtypes, rooted: true, parameters_type: :fixed)]).force_rooted
-      end
-
-      # Renders a leaf RBS type (one that can't contain another type)
-      # as a tag string. Composite/recursive types are handled
-      # directly in to_complex_type instead - see its comment.
-      #
       # @param type [RBS::Types::Bases::Base]
       # @return [String]
       def type_to_tag type
         case type
+        when RBS::Types::Optional
+          # @sg-ignore flow sensitive typing ought to be able to handle 'when ClassName'
+          "#{type_to_tag(type.type)}, nil"
         when RBS::Types::Bases::Bool
           'Boolean'
+        when RBS::Types::Tuple
+          # @sg-ignore flow sensitive typing ought to be able to handle 'when ClassName'
+          "Array(#{type.types.map { |t| type_to_tag(t) }.join(', ')})"
         when RBS::Types::Literal
           type.literal.inspect
+        when RBS::Types::Union
+          # @sg-ignore flow sensitive typing ought to be able to handle 'when ClassName'
+          type.types.map { |t| type_to_tag(t) }.join(', ')
         when RBS::Types::Record
           # @todo Better record support
           'Hash'
@@ -232,6 +176,26 @@ module Solargraph
         when RBS::Types::Bases::Top
           # `Top` is the most super superclass
           'BasicObject'
+        when RBS::Types::Intersection
+          # `&` binds tighter than `,`/`|`, so bracket a conjunct that
+          # renders as more than one type (Union, Optional).
+          #
+          # @sg-ignore flow sensitive typing ought to be able to handle 'when ClassName'
+          type.types.map { |member| intersection_conjunct_tag(member) }.join(' & ')
+        when RBS::Types::ClassInstance, RBS::Types::Alias, RBS::Types::Interface
+          # `Alias` is a top-level type alias, e.g., 'bool' in "type bool = true | false"
+          # @todo ensure these get resolved after processing all aliases
+          # @todo handle recursive aliases
+          #
+          # `Interface` represents a mix-in module which can be considered a
+          # subtype of a consumer of it
+          #
+          # @sg-ignore flow sensitive typing ought to be able to handle 'when ClassName'
+          build_unique_type(type.name, type.args).tags
+        when RBS::Types::ClassSingleton
+          # e.g., singleton(String)
+          # @sg-ignore flow sensitive typing ought to be able to handle 'when ClassName'
+          build_unique_type(type.name).tags
         when RBS::Types::Proc
           'Proc'
         when RBS::Types::Bases::Any, RBS::Types::Bases::Bottom
@@ -245,6 +209,13 @@ module Solargraph
           Solargraph.logger.warn "Unrecognized RBS type: #{type.class} at #{type.location}"
           'undefined'
         end
+      end
+
+      # @param member [RBS::Types::Bases::Base]
+      # @return [String]
+      def intersection_conjunct_tag member
+        tag = type_to_tag(member)
+        member.is_a?(RBS::Types::Union) || member.is_a?(RBS::Types::Optional) ? "[#{tag}]" : tag
       end
     end
   end

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -12,12 +12,47 @@ module Solargraph
       'NilClass' => 'nil'
     }
 
+    # Translates an RBS type into a ComplexType.
+    #
+    # Every RBS node that can *contain* another type - intersections,
+    # unions, optionals, tuples, and generic type arguments - is built
+    # directly as a ComplexType/UniqueType object graph by recursing
+    # through this method, rather than by rendering a tag string and
+    # re-parsing it. A joined string can't represent grouping that
+    # Solargraph's own tag grammar has no syntax for (e.g. a union
+    # nested inside an intersection, `(A | B) & C`), so round-tripping
+    # through one silently produces the wrong structure. Only leaf
+    # types that can't contain a nested type (literals, `bool`, `nil`,
+    # `void`, generic type variables, `self`/`instance`, `Proc`, etc.)
+    # go through the tag-string fallback in type_to_tag.
+    #
     # @param type [RBS::Types::Bases::Base]
     # @return [ComplexType]
     def self.to_complex_type(type)
-      return intersection_complex_type(type) if type.is_a?(RBS::Types::Intersection)
-      tag = type_to_tag(type)
-      ComplexType.try_parse(tag).force_rooted
+      case type
+      when RBS::Types::Intersection
+        intersection_complex_type(type)
+      when RBS::Types::Optional
+        optional_complex_type(type)
+      when RBS::Types::Union
+        union_complex_type(type)
+      when RBS::Types::Tuple
+        tuple_complex_type(type)
+      when RBS::Types::ClassInstance, RBS::Types::Alias, RBS::Types::Interface
+        # `Alias` is a top-level type alias, e.g., 'bool' in "type bool = true | false"
+        # @todo ensure these get resolved after processing all aliases
+        # @todo handle recursive aliases
+        #
+        # `Interface` represents a mix-in module which can be considered a
+        # subtype of a consumer of it
+        ComplexType.new([build_unique_type(type.name, type.args)]).force_rooted
+      when RBS::Types::ClassSingleton
+        # e.g., singleton(String)
+        ComplexType.new([build_unique_type(type.name)]).force_rooted
+      else
+        tag = type_to_tag(type)
+        ComplexType.try_parse(tag).force_rooted
+      end
     end
 
     # @param param_type [RBS::Types::Function::Param]
@@ -124,15 +159,6 @@ module Solargraph
     class << self
       private
 
-      # Builds an Intersection directly from each member's own
-      # translated ComplexType, rather than flattening through
-      # type_to_tag's string-based join. RBS allows a union as one
-      # member of an intersection (e.g. `(A | B) & C`); going through
-      # a joined string would lose that structure (`type_to_tag`
-      # would render the union member as a plain comma list, which
-      # ComplexType.parse would then read back as a top-level union
-      # of the whole expression rather than a nested one).
-      #
       # @param type [RBS::Types::Intersection]
       # @return [ComplexType]
       def intersection_complex_type type
@@ -140,20 +166,38 @@ module Solargraph
         ComplexType.new([ComplexType::UniqueType::Intersection.new(conjuncts)]).force_rooted
       end
 
+      # @param type [RBS::Types::Optional]
+      # @return [ComplexType]
+      def optional_complex_type type
+        inner = RbsTranslator.to_complex_type(type.type)
+        ComplexType.new(inner.items + [ComplexType::UniqueType::NIL]).force_rooted
+      end
+
+      # @param type [RBS::Types::Union]
+      # @return [ComplexType]
+      def union_complex_type type
+        ComplexType.new(type.types.flat_map { |t| RbsTranslator.to_complex_type(t).items }).force_rooted
+      end
+
+      # @param type [RBS::Types::Tuple]
+      # @return [ComplexType]
+      def tuple_complex_type type
+        subtypes = type.types.map { |t| RbsTranslator.to_complex_type(t) }
+        ComplexType.new([ComplexType::UniqueType.new('Array', [], subtypes, rooted: true, parameters_type: :fixed)]).force_rooted
+      end
+
+      # Renders a leaf RBS type (one that can't contain another type)
+      # as a tag string. Composite/recursive types are handled
+      # directly in to_complex_type instead - see its comment.
+      #
       # @param type [RBS::Types::Bases::Base]
       # @return [String]
       def type_to_tag type
         case type
-        when RBS::Types::Optional
-          "#{type_to_tag(type.type)}, nil"
         when RBS::Types::Bases::Bool
           'Boolean'
-        when RBS::Types::Tuple
-          "Array(#{type.types.map { |t| type_to_tag(t) }.join(', ')})"
         when RBS::Types::Literal
           type.literal.inspect
-        when RBS::Types::Union
-          type.types.map { |t| type_to_tag(t) }.join(', ')
         when RBS::Types::Record
           # @todo Better record support
           'Hash'
@@ -168,22 +212,8 @@ module Solargraph
         when RBS::Types::Bases::Top
           # `Top` is the most super superclass
           'BasicObject'
-        when RBS::Types::Intersection
-          type.types.map { |member| type_to_tag(member) }.join(' & ')
         when RBS::Types::Proc
           'Proc'
-        when RBS::Types::ClassInstance, RBS::Types::Alias, RBS::Types::Interface
-          # `Alias` is a top-level type alias, e.g., 'bool' in "type bool = true | false"
-          # @todo ensure these get resolved after processing all aliases
-          # @todo handle recursive aliases
-          #
-          # `Interface represents a mix-in module which can be considered a
-          # subtype of a consumer of it
-          #
-          type_tag(type.name, type.args)
-        when RBS::Types::ClassSingleton
-          # e.g., singleton(String)
-          type_tag(type.name)
         when RBS::Types::Bases::Any, RBS::Types::Bases::Bottom
           # `Bottom`` is used in contexts where nothing will ever return
           # - e.g., it could be the return type of 'exit()' or 'raise'
@@ -194,28 +224,6 @@ module Solargraph
         else
           Solargraph.logger.warn "Unrecognized RBS type: #{type.class} at #{type.location}"
           'undefined'
-        end
-      end
-
-      # @param type_name [RBS::TypeName]
-      # @param type_args [Enumerable<RBS::Types::Bases::Base>]
-      # @return [String]
-      def type_tag(type_name, type_args = [])
-        build_type(type_name, type_args).tags
-      end
-
-      # @param type_name [RBS::TypeName]
-      # @param type_args [Enumerable<RBS::Types::Bases::Base>]
-      # @return [ComplexType::UniqueType]
-      def build_type(type_name, type_args = [])
-        base = RBS_TO_YARD_TYPE[type_name.relative!.to_s] || type_name.relative!.to_s
-        params = type_args.map { |a| type_to_tag(a) }.map do |t|
-          ComplexType.try_parse(t)
-        end
-        if base == 'Hash' && params.length == 2
-          ComplexType::UniqueType.new(base, [params.first], [params.last], rooted: true, parameters_type: :hash)
-        else
-          ComplexType::UniqueType.new(base, [], params.reject(&:undefined?), rooted: true, parameters_type: :list)
         end
       end
     end

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -188,11 +188,11 @@ module Solargraph
           # subtype of a consumer of it
           #
           # @sg-ignore flow sensitive typing ought to be able to handle 'when ClassName'
-          build_unique_type(type.name, type.args).tags
+          build_unique_type(type.name, type.args).rooted_tags
         when RBS::Types::ClassSingleton
           # e.g., singleton(String)
           # @sg-ignore flow sensitive typing ought to be able to handle 'when ClassName'
-          build_unique_type(type.name).tags
+          build_unique_type(type.name).rooted_tags
         when RBS::Types::Bases::Any, RBS::Types::Bases::Bottom
           # `Bottom`` is used in contexts where nothing will ever return
           # - e.g., it could be the return type of 'exit()' or 'raise'

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -115,7 +115,7 @@ module Solargraph
     def self.build_unique_type(type_name, type_args = [])
       name = type_name.relative!.to_s
       generic = RBS_INTERFACE_TO_GENERIC[name]
-      return ComplexType.parse("#{ComplexType::GENERIC_TAG_NAME}<#{generic}>").first if generic
+      return ComplexType.parse("#{ComplexType::GENERIC_TAG_NAME}<#{generic}>").items.first if generic
 
       base = RBS_TO_YARD_TYPE[name] || name
       params = type_args.map { |arg| RbsTranslator.to_complex_type(arg).force_rooted }

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -535,7 +535,7 @@ module Solargraph
           next unless pin.return_type.undefined?
           type = pin.typify(api_map)
           type = pin.probe(api_map) if type.undefined?
-          pin.docstring.add_tag YARD::Tags::Tag.new('return', nil, type.items.map(&:rooted_tags))
+          pin.docstring.add_tag YARD::Tags::Tag.new('return', nil, type.unioned_items.map(&:rooted_tags))
           pin.instance_variable_set(:@return_type, type)
         end
       end

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -535,7 +535,7 @@ module Solargraph
           next unless pin.return_type.undefined?
           type = pin.typify(api_map)
           type = pin.probe(api_map) if type.undefined?
-          pin.docstring.add_tag YARD::Tags::Tag.new('return', nil, type.items.map(&:to_s))
+          pin.docstring.add_tag YARD::Tags::Tag.new('return', nil, type.items.map(&:rooted_tags))
           pin.instance_variable_set(:@return_type, type)
         end
       end

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -321,7 +321,7 @@ module Solargraph
       def maybe_nil type, api_map
         return type if type.undefined? || type.void? || type.nullable?
         return type unless nullable?(api_map)
-        ComplexType.new(type.items + [ComplexType::NIL])
+        ComplexType.new([type, ComplexType::NIL])
       end
 
       protected

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -107,11 +107,9 @@ module Solargraph
           end
         end
 
-        # Narrows conjuncts to the ones with at least one signature the
-        # call's actual arguments conform to - the same per-signature
-        # overload matching #match_overload_type does, applied per
-        # conjunct instead of per signature. Unfiltered if any verdict
-        # is unknown (conjunct's method pin/signatures don't resolve).
+        # Narrows conjuncts to the ones with at least one signature
+        # the call arguments conform to. Left unfiltered when any
+        # conjunct resolves no signature to judge against.
         #
         # @param conjuncts [::Array<ComplexType>]
         # @param api_map [ApiMap]
@@ -121,23 +119,22 @@ module Solargraph
         def argument_verified_conjuncts conjuncts, api_map, name_pin, locals
           return conjuncts if arguments.empty?
 
-          verdicts = conjuncts.map { |c| conjunct_argument_verdict(c, api_map, name_pin, locals) }
-          return conjuncts if verdicts.any?(&:nil?)
+          accepts = conjuncts.map { |c| conjunct_matches_arguments?(c, api_map, name_pin, locals) }
+          return conjuncts if accepts.any?(&:nil?)
 
-          matching = conjuncts.zip(verdicts).select { |(_c, matched)| matched }.map(&:first)
+          matching = conjuncts.zip(accepts).select { |(_c, matched)| matched }.map(&:first)
           matching.empty? ? conjuncts : matching
         end
 
-        # Whether any of this conjunct's resolved method signatures
-        # match the call's actual arguments, or nil if the conjunct's
-        # method pin/signatures don't resolve at all.
+        # Whether any signature of the method this conjunct resolves
+        # accepts the call arguments; nil when none resolves.
         #
         # @param conjunct [ComplexType]
         # @param api_map [ApiMap]
         # @param name_pin [Pin::Base]
         # @param locals [::Array<Pin::LocalVariable, Pin::Parameter>]
         # @return [Boolean, nil]
-        def conjunct_argument_verdict conjunct, api_map, name_pin, locals
+        def conjunct_matches_arguments? conjunct, api_map, name_pin, locals
           pins = method_pins_for_binder(conjunct, api_map, name_pin, locals)
           return nil if pins.empty?
 
@@ -151,7 +148,7 @@ module Solargraph
         # type accept the call's actual arguments. Used both for
         # regular overload resolution and, per conjunct, to narrow an
         # Intersection's conjuncts to the ones a call can actually
-        # dispatch to (see #conjunct_argument_verdict) - the same
+        # dispatch to (see #conjunct_matches_arguments?) - the same
         # question either way: does this signature accept these
         # arguments.
         #

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -100,7 +100,7 @@ module Solargraph
         # @return [::Array<Pin::Base>, nil] nil when unresolved
         def method_stack_pins unique_type, api_map
           if unique_type.is_a?(ComplexType::UniqueType::Intersection)
-            resolved = unique_type.conjuncts.filter_map do |conjunct|
+            resolved = key_verified_conjuncts(unique_type.conjuncts, api_map).filter_map do |conjunct|
               pins = method_pins_for_binder(conjunct, api_map)
               pins.empty? ? nil : pins
             end
@@ -112,6 +112,99 @@ module Solargraph
             stack = api_map.get_method_stack(ns_tag, word, scope: unique_type.scope)
             return nil if stack.first.nil?
             [stack.first]
+          end
+        end
+
+        # Narrows a same-class-generic intersection's conjuncts to
+        # whichever ones we can positively verify match this call's own
+        # literal argument against a `_Key`-shaped parameter (e.g.
+        # `Hash#fetch: (Hash::_Key key) -> V`, `Hash#[]`), e.g. resolving
+        # `(Hash{"Index" => Float} & Hash{"Triggers" => Array<...>})#fetch("Index")`
+        # to just the "Index" conjunct instead of a union of both.
+        #
+        # RBS's own `_Key`-shaped signatures can't do this narrowing
+        # themselves - `_Key` is a structural hash/eql? interface, not
+        # literally `K`, so the key argument's type is never connected to
+        # the return type by ordinary overload resolution. This has to be
+        # done here, ahead of generic resolution, by matching the call's
+        # own literal argument directly against each conjunct's own
+        # `key_types` - which generalizes to any `_Key`-shaped method
+        # (`#fetch`, `#[]`, `#dig`, `#delete`, ...) without naming them.
+        #
+        # Conservative by construction: a conjunct is only ever narrowed
+        # away when *every* conjunct produced a positive verdict (matched
+        # or didn't). If we can't determine a verdict for even one
+        # conjunct - its method isn't `_Key`-shaped there, the argument
+        # isn't a literal, or it has no literal `key_types` to compare
+        # against - we don't have enough evidence to safely exclude
+        # anything, so every conjunct passes through unfiltered, same as
+        # before this method existed.
+        #
+        # @param conjuncts [::Array<ComplexType>]
+        # @param api_map [ApiMap]
+        # @return [::Array<ComplexType>]
+        def key_verified_conjuncts conjuncts, api_map
+          return conjuncts if arguments.empty?
+
+          verdicts = conjuncts.map { |c| conjunct_key_verdict(c, api_map) }
+          return conjuncts if verdicts.any?(&:nil?)
+
+          matching = conjuncts.zip(verdicts).select { |(_c, matched)| matched }.map(&:first)
+          matching.empty? ? conjuncts : matching
+        end
+
+        # Whether this conjunct's own literal `key_types` positively match
+        # the call's own literal argument at the `_Key`-typed parameter's
+        # position, or nil if that can't be determined (no `_Key`-shaped
+        # parameter here, non-literal argument, or no literal `key_types`
+        # to compare against).
+        #
+        # @param conjunct [ComplexType]
+        # @param api_map [ApiMap]
+        # @return [Boolean, nil]
+        def conjunct_key_verdict conjunct, api_map
+          verdicts = conjunct.items.map { |unique_type| unique_type_key_verdict(unique_type, api_map) }
+          return nil if verdicts.any?(&:nil?)
+
+          verdicts.all?
+        end
+
+        # @param unique_type [ComplexType::UniqueType]
+        # @param api_map [ApiMap]
+        # @return [Boolean, nil]
+        def unique_type_key_verdict unique_type, api_map
+          return nil unless unique_type.literal_keyed?
+
+          ns_tag = unique_type.namespace == '' ? '' : unique_type.namespace_type.tag
+          pin = api_map.get_method_stack(ns_tag, word, scope: unique_type.scope).first
+          return nil if pin.nil?
+
+          index = pin.signatures.filter_map { |s| s.key_param_index(unique_type.namespace, api_map) }.first
+          return nil if index.nil? || index >= arguments.length
+
+          key_tag = literal_node_tag(arguments[index]&.node)
+          return nil if key_tag.nil?
+
+          unique_type.key_type_tag?(key_tag)
+        end
+
+        # The literal tag (e.g. `"Index"`, `:index`, `1`) a `UniqueType`
+        # built from this argument node's literal value would have, or nil
+        # if the node isn't a literal Hash-key-shaped value.
+        #
+        # @param node [Parser::AST::Node, Object]
+        # @return [String, nil]
+        def literal_node_tag node
+          return nil unless Parser.is_ast_node?(node)
+
+          # @sg-ignore Translate to something flow sensitive typing understands
+          case node.type
+          # @sg-ignore Translate to something flow sensitive typing understands
+          when :str then node.children.first.inspect
+          # @sg-ignore Translate to something flow sensitive typing understands
+          when :sym then ":#{node.children.first}"
+          # @sg-ignore Translate to something flow sensitive typing understands
+          when :int then node.children.first.to_s
           end
         end
 

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -57,19 +57,55 @@ module Solargraph
 
           # @sg-ignore Need to handle duck-typed method calls on union types
           binder = binder.without_nil if nullable?
-          # @sg-ignore Need to handle duck-typed method calls on union types
-          pin_groups = binder.each_unique_type.map do |context|
-            ns_tag = context.namespace == '' ? '' : context.namespace_type.tag
-            stack = api_map.get_method_stack(ns_tag, word, scope: context.scope)
-            [stack.first].compact
-          end
-          pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:empty?)
-          pins = pin_groups.flatten.uniq(&:path)
+          pins = method_pins_for_binder(binder, api_map)
           return [] if pins.empty?
           inferred_pins(pins, api_map, name_pin, locals)
         end
 
         private
+
+        # Resolves the pins for calling `word` on every top-level
+        # alternative of a (possibly union) binder type. Each
+        # alternative must define the method unless
+        # api_map.loose_unions allows duck-typed leniency.
+        #
+        # @param binder_type [ComplexType, ComplexType::UniqueType]
+        # @param api_map [ApiMap]
+        # @return [::Array<Pin::Base>]
+        def method_pins_for_binder binder_type, api_map
+          top_level_types = binder_type.is_a?(ComplexType) ? binder_type.to_a : [binder_type]
+          pin_groups = top_level_types.map { |unique_type| method_stack_pins(unique_type, api_map) }
+          pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:nil?)
+          pin_groups.compact.flatten.uniq(&:path)
+        end
+
+        # Resolves the method stack's first pin for a single
+        # top-level unique type. An Intersection conjunct only needs
+        # *one* of its conjuncts to define the method (A & B <: A,
+        # A & B <: B) - the opposite of a union, where every
+        # alternative needs it - so it recurses through
+        # #method_pins_for_binder per conjunct (a conjunct is a full
+        # ComplexType, since RBS allows e.g. `(A | B) & C`) and
+        # accepts whichever conjuncts resolve.
+        #
+        # @param unique_type [ComplexType::UniqueType]
+        # @param api_map [ApiMap]
+        # @return [::Array<Pin::Base>, nil] nil when unresolved
+        def method_stack_pins unique_type, api_map
+          if unique_type.is_a?(ComplexType::UniqueType::Intersection)
+            resolved = unique_type.conjuncts.filter_map do |conjunct|
+              pins = method_pins_for_binder(conjunct, api_map)
+              pins.empty? ? nil : pins
+            end
+            return nil if resolved.empty?
+            resolved.flatten.uniq(&:path)
+          else
+            ns_tag = unique_type.namespace == '' ? '' : unique_type.namespace_type.tag
+            stack = api_map.get_method_stack(ns_tag, word, scope: unique_type.scope)
+            return nil if stack.first.nil?
+            [stack.first]
+          end
+        end
 
         # @param pins [::Enumerable<Pin::Base>]
         # @param api_map [ApiMap]

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -119,7 +119,7 @@ module Solargraph
         def argument_verified_conjuncts conjuncts, api_map, name_pin, locals
           return conjuncts if arguments.empty?
 
-          accepts = conjuncts.map { |c| conjunct_matches_arguments?(c, api_map, name_pin, locals) }
+          accepts = conjuncts.map { |c| conjunct_accepts_arguments(c, api_map, name_pin, locals) }
           return conjuncts if accepts.any?(&:nil?)
 
           matching = conjuncts.zip(accepts).select { |(_c, matched)| matched }.map(&:first)
@@ -134,7 +134,7 @@ module Solargraph
         # @param name_pin [Pin::Base]
         # @param locals [::Array<Pin::LocalVariable, Pin::Parameter>]
         # @return [Boolean, nil]
-        def conjunct_matches_arguments? conjunct, api_map, name_pin, locals
+        def conjunct_accepts_arguments conjunct, api_map, name_pin, locals
           pins = method_pins_for_binder(conjunct, api_map, name_pin, locals)
           return nil if pins.empty?
 
@@ -148,7 +148,7 @@ module Solargraph
         # type accept the call's actual arguments. Used both for
         # regular overload resolution and, per conjunct, to narrow an
         # Intersection's conjuncts to the ones a call can actually
-        # dispatch to (see #conjunct_matches_arguments?) - the same
+        # dispatch to (see #conjunct_accepts_arguments) - the same
         # question either way: does this signature accept these
         # arguments.
         #

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -182,13 +182,13 @@ module Solargraph
         def literal_node_tag node
           return nil unless Parser.is_ast_node?(node)
 
-          # @sg-ignore Translate to something flow sensitive typing understands
+          # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
           case node.type
-          # @sg-ignore Translate to something flow sensitive typing understands
+          # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
           when :str then node.children.first.inspect
-          # @sg-ignore Translate to something flow sensitive typing understands
+          # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
           when :sym then ":#{node.children.first}"
-          # @sg-ignore Translate to something flow sensitive typing understands
+          # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
           when :int then node.children.first.to_s
           end
         end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -65,9 +65,7 @@ module Solargraph
         private
 
         # Resolves the pins for calling `word` on every top-level
-        # alternative of a (possibly union) binder type. Each
-        # alternative must define the method unless
-        # api_map.loose_unions allows duck-typed leniency.
+        # alternative of a binder type (loose_unions allows leniency).
         #
         # @param binder_type [ComplexType, ComplexType::UniqueType]
         # @param api_map [ApiMap]
@@ -76,20 +74,14 @@ module Solargraph
           top_level_types = binder_type.is_a?(ComplexType) ? binder_type.to_a : [binder_type]
           pin_groups = top_level_types.map { |unique_type| method_stack_pins(unique_type, api_map) }
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:nil?)
-          # Alternatives can share a pin path (e.g. the same generic
-          # method against `Box<Integer>` and `Box<String>`) while
-          # already resolving to different return types, so dedup on
-          # both rather than losing every alternative but the first.
+          # Dedup on path *and* return type: alternatives can share a
+          # path (e.g. same generic method on different instantiations).
           # @param p [Pin::Base]
           pin_groups.compact.flatten.uniq { |p| [p.path, p.return_type.tag] }
         end
 
-        # Resolves the method stack's first pin for a single top-level
-        # unique type. An Intersection needs only *one* of its conjuncts
-        # to define the method (A & B <: A, A & B <: B) - the opposite of
-        # a union - so it recurses per conjunct and accepts whichever
-        # ones resolve. A conjunct is a full ComplexType, since RBS
-        # allows e.g. `(A | B) & C`.
+        # Resolves the method stack's first pin for one top-level type.
+        # An Intersection needs only one conjunct to define the method.
         #
         # @param unique_type [ComplexType::UniqueType]
         # @param api_map [ApiMap]
@@ -111,18 +103,8 @@ module Solargraph
           end
         end
 
-        # Narrows an intersection's conjuncts to the ones whose own
-        # `key_types` match this call's literal argument at a Hash-like
-        # key parameter, so
-        # `(Hash{"Index" => Float} & Hash{"Triggers" => Array<...>})#fetch("Index")`
-        # resolves to the "Index" conjunct rather than a union of both.
-        # Overload resolution can't do this on its own: it runs per
-        # conjunct, and both conjuncts produce a pin with the same path,
-        # so nothing downstream knows which one the argument selected.
-        #
-        # A conjunct is only narrowed away when *every* conjunct yields a
-        # positive verdict (matched or didn't); if even one is
-        # undeterminable, every conjunct passes through unfiltered.
+        # Narrows conjuncts to the ones whose `key_types` match the
+        # call's literal argument; unfiltered if any verdict is unknown.
         #
         # @param conjuncts [::Array<ComplexType>]
         # @param api_map [ApiMap]
@@ -137,11 +119,8 @@ module Solargraph
           matching.empty? ? conjuncts : matching
         end
 
-        # Whether this conjunct's own literal `key_types` positively match
-        # the call's own literal argument at the key parameter's position
-        # (see Pin::Signature#hash_key_param_index), or nil if that can't be
-        # determined (no key-shaped parameter here, non-literal argument,
-        # or no literal `key_types` to compare against).
+        # Whether this conjunct's key_types match the call's literal
+        # argument (see Signature#hash_key_param_index), or nil if unknown.
         #
         # @param conjunct [ComplexType]
         # @param api_map [ApiMap]
@@ -182,13 +161,13 @@ module Solargraph
         def literal_node_tag node
           return nil unless Parser.is_ast_node?(node)
 
-          # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
+          # @sg-ignore flow sensitive typing needs to narrow through a predicate wrapper like Parser.is_ast_node?
           case node.type
-          # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
+          # @sg-ignore flow sensitive typing needs to narrow through a predicate wrapper like Parser.is_ast_node?
           when :str then node.children.first.inspect
-          # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
+          # @sg-ignore flow sensitive typing needs to narrow through a predicate wrapper like Parser.is_ast_node?
           when :sym then ":#{node.children.first}"
-          # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
+          # @sg-ignore flow sensitive typing needs to narrow through a predicate wrapper like Parser.is_ast_node?
           when :int then node.children.first.to_s
           end
         end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -164,7 +164,7 @@ module Solargraph
           return nil if pin.nil?
 
           key_tags = unique_type.key_types.map(&:tag)
-          index = pin.signatures.filter_map { |s| s.hash_key_param_index(unique_type.namespace, api_map, key_tags) }.first
+          index = pin.signatures.filter_map { |s| s.hash_key_param_index(api_map, key_tags) }.first
           return nil if index.nil? || index >= arguments.length
 
           key_tag = literal_node_tag(arguments[index]&.node)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -76,7 +76,14 @@ module Solargraph
           top_level_types = binder_type.is_a?(ComplexType) ? binder_type.to_a : [binder_type]
           pin_groups = top_level_types.map { |unique_type| method_stack_pins(unique_type, api_map) }
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:nil?)
-          pin_groups.compact.flatten.uniq(&:path)
+          # Different alternatives can resolve to pins that share a
+          # path (e.g. the same generic method looked up against
+          # `Box<Integer>` and `Box<String>`) but that have already
+          # been resolved to different return types for their
+          # respective context - dedup on both so a real union
+          # doesn't silently lose every alternative but the first.
+          # @param p [Pin::Base]
+          pin_groups.compact.flatten.uniq { |p| [p.path, p.return_type.tag] }
         end
 
         # Resolves the method stack's first pin for a single
@@ -98,7 +105,8 @@ module Solargraph
               pins.empty? ? nil : pins
             end
             return nil if resolved.empty?
-            resolved.flatten.uniq(&:path)
+            # @param p [Pin::Base]
+            resolved.flatten.uniq { |p| [p.path, p.return_type.tag] }
           else
             ns_tag = unique_type.namespace == '' ? '' : unique_type.namespace_type.tag
             stack = api_map.get_method_stack(ns_tag, word, scope: unique_type.scope)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -116,9 +116,9 @@ module Solargraph
         # key parameter, so
         # `(Hash{"Index" => Float} & Hash{"Triggers" => Array<...>})#fetch("Index")`
         # resolves to the "Index" conjunct rather than a union of both.
-        # RBS can't do this itself - `Hash#fetch: (_Key key) -> V` types
-        # the key as a structural hash/eql? interface, not `K`, so
-        # overload resolution never connects it to the return type.
+        # Overload resolution can't do this on its own: it runs per
+        # conjunct, and both conjuncts produce a pin with the same path,
+        # so nothing downstream knows which one the argument selected.
         #
         # A conjunct is only narrowed away when *every* conjunct yields a
         # positive verdict (matched or didn't); if even one is

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -76,24 +76,20 @@ module Solargraph
           top_level_types = binder_type.is_a?(ComplexType) ? binder_type.to_a : [binder_type]
           pin_groups = top_level_types.map { |unique_type| method_stack_pins(unique_type, api_map) }
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:nil?)
-          # Different alternatives can resolve to pins that share a
-          # path (e.g. the same generic method looked up against
-          # `Box<Integer>` and `Box<String>`) but that have already
-          # been resolved to different return types for their
-          # respective context - dedup on both so a real union
-          # doesn't silently lose every alternative but the first.
+          # Alternatives can share a pin path (e.g. the same generic
+          # method against `Box<Integer>` and `Box<String>`) while
+          # already resolving to different return types, so dedup on
+          # both rather than losing every alternative but the first.
           # @param p [Pin::Base]
           pin_groups.compact.flatten.uniq { |p| [p.path, p.return_type.tag] }
         end
 
-        # Resolves the method stack's first pin for a single
-        # top-level unique type. An Intersection conjunct only needs
-        # *one* of its conjuncts to define the method (A & B <: A,
-        # A & B <: B) - the opposite of a union, where every
-        # alternative needs it - so it recurses through
-        # #method_pins_for_binder per conjunct (a conjunct is a full
-        # ComplexType, since RBS allows e.g. `(A | B) & C`) and
-        # accepts whichever conjuncts resolve.
+        # Resolves the method stack's first pin for a single top-level
+        # unique type. An Intersection needs only *one* of its conjuncts
+        # to define the method (A & B <: A, A & B <: B) - the opposite of
+        # a union - so it recurses per conjunct and accepts whichever
+        # ones resolve. A conjunct is a full ComplexType, since RBS
+        # allows e.g. `(A | B) & C`.
         #
         # @param unique_type [ComplexType::UniqueType]
         # @param api_map [ApiMap]
@@ -115,30 +111,18 @@ module Solargraph
           end
         end
 
-        # Narrows a same-class-generic intersection's conjuncts to
-        # whichever ones we can positively verify match this call's own
-        # literal argument against a `_Key`-shaped parameter (e.g.
-        # `Hash#fetch: (Hash::_Key key) -> V`, `Hash#[]`), e.g. resolving
+        # Narrows an intersection's conjuncts to the ones whose own
+        # `key_types` match this call's literal argument at a Hash-like
+        # key parameter, so
         # `(Hash{"Index" => Float} & Hash{"Triggers" => Array<...>})#fetch("Index")`
-        # to just the "Index" conjunct instead of a union of both.
+        # resolves to the "Index" conjunct rather than a union of both.
+        # RBS can't do this itself - `Hash#fetch: (_Key key) -> V` types
+        # the key as a structural hash/eql? interface, not `K`, so
+        # overload resolution never connects it to the return type.
         #
-        # RBS's own `_Key`-shaped signatures can't do this narrowing
-        # themselves - `_Key` is a structural hash/eql? interface, not
-        # literally `K`, so the key argument's type is never connected to
-        # the return type by ordinary overload resolution. This has to be
-        # done here, ahead of generic resolution, by matching the call's
-        # own literal argument directly against each conjunct's own
-        # `key_types` - which generalizes to any `_Key`-shaped method
-        # (`#fetch`, `#[]`, `#dig`, `#delete`, ...) without naming them.
-        #
-        # Conservative by construction: a conjunct is only ever narrowed
-        # away when *every* conjunct produced a positive verdict (matched
-        # or didn't). If we can't determine a verdict for even one
-        # conjunct - its method isn't `_Key`-shaped there, the argument
-        # isn't a literal, or it has no literal `key_types` to compare
-        # against - we don't have enough evidence to safely exclude
-        # anything, so every conjunct passes through unfiltered, same as
-        # before this method existed.
+        # A conjunct is only narrowed away when *every* conjunct yields a
+        # positive verdict (matched or didn't); if even one is
+        # undeterminable, every conjunct passes through unfiltered.
         #
         # @param conjuncts [::Array<ComplexType>]
         # @param api_map [ApiMap]
@@ -155,7 +139,7 @@ module Solargraph
 
         # Whether this conjunct's own literal `key_types` positively match
         # the call's own literal argument at the key parameter's position
-        # (see Pin::Signature#key_param_index), or nil if that can't be
+        # (see Pin::Signature#hash_key_param_index), or nil if that can't be
         # determined (no key-shaped parameter here, non-literal argument,
         # or no literal `key_types` to compare against).
         #
@@ -180,7 +164,7 @@ module Solargraph
           return nil if pin.nil?
 
           key_tags = unique_type.key_types.map(&:tag)
-          index = pin.signatures.filter_map { |s| s.key_param_index(unique_type.namespace, api_map, key_tags) }.first
+          index = pin.signatures.filter_map { |s| s.hash_key_param_index(unique_type.namespace, api_map, key_tags) }.first
           return nil if index.nil? || index >= arguments.length
 
           key_tag = literal_node_tag(arguments[index]&.node)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -163,6 +163,7 @@ module Solargraph
         def matching_arg_types overload, api_map, name_pin, locals
           return nil unless overload.arity_matches?(arguments, with_block?)
 
+          # @type [::Array<ComplexType>]
           atypes = []
           arguments.each_with_index do |arg, idx|
             param = overload.parameters[idx]

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -57,7 +57,7 @@ module Solargraph
 
           # @sg-ignore Need to handle duck-typed method calls on union types
           binder = binder.without_nil if nullable?
-          pins = method_pins_for_binder(binder, api_map)
+          pins = method_pins_for_binder(binder, api_map, name_pin, locals)
           return [] if pins.empty?
           inferred_pins(pins, api_map, name_pin, locals)
         end
@@ -69,10 +69,12 @@ module Solargraph
         #
         # @param binder_type [ComplexType, ComplexType::UniqueType]
         # @param api_map [ApiMap]
+        # @param name_pin [Pin::Base]
+        # @param locals [::Array<Pin::LocalVariable, Pin::Parameter>]
         # @return [::Array<Pin::Base>]
-        def method_pins_for_binder binder_type, api_map
+        def method_pins_for_binder binder_type, api_map, name_pin, locals
           top_level_types = binder_type.is_a?(ComplexType) ? binder_type.to_a : [binder_type]
-          pin_groups = top_level_types.map { |unique_type| method_stack_pins(unique_type, api_map) }
+          pin_groups = top_level_types.map { |unique_type| method_stack_pins(unique_type, api_map, name_pin, locals) }
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:nil?)
           # Dedup on path *and* return type: alternatives can share a
           # path (e.g. same generic method on different instantiations).
@@ -85,11 +87,13 @@ module Solargraph
         #
         # @param unique_type [ComplexType::UniqueType]
         # @param api_map [ApiMap]
+        # @param name_pin [Pin::Base]
+        # @param locals [::Array<Pin::LocalVariable, Pin::Parameter>]
         # @return [::Array<Pin::Base>, nil] nil when unresolved
-        def method_stack_pins unique_type, api_map
+        def method_stack_pins unique_type, api_map, name_pin, locals
           if unique_type.is_a?(ComplexType::UniqueType::Intersection)
-            resolved = key_verified_conjuncts(unique_type.conjuncts, api_map).filter_map do |conjunct|
-              pins = method_pins_for_binder(conjunct, api_map)
+            resolved = argument_verified_conjuncts(unique_type.conjuncts, api_map, name_pin, locals).filter_map do |conjunct|
+              pins = method_pins_for_binder(conjunct, api_map, name_pin, locals)
               pins.empty? ? nil : pins
             end
             return nil if resolved.empty?
@@ -103,73 +107,78 @@ module Solargraph
           end
         end
 
-        # Narrows conjuncts to the ones whose `key_types` match the
-        # call's literal argument; unfiltered if any verdict is unknown.
+        # Narrows conjuncts to the ones with at least one signature the
+        # call's actual arguments conform to - the same per-signature
+        # overload matching #match_overload_type does, applied per
+        # conjunct instead of per signature. Unfiltered if any verdict
+        # is unknown (conjunct's method pin/signatures don't resolve).
         #
         # @param conjuncts [::Array<ComplexType>]
         # @param api_map [ApiMap]
+        # @param name_pin [Pin::Base]
+        # @param locals [::Array<Pin::LocalVariable, Pin::Parameter>]
         # @return [::Array<ComplexType>]
-        def key_verified_conjuncts conjuncts, api_map
+        def argument_verified_conjuncts conjuncts, api_map, name_pin, locals
           return conjuncts if arguments.empty?
 
-          verdicts = conjuncts.map { |c| conjunct_key_verdict(c, api_map) }
+          verdicts = conjuncts.map { |c| conjunct_argument_verdict(c, api_map, name_pin, locals) }
           return conjuncts if verdicts.any?(&:nil?)
 
           matching = conjuncts.zip(verdicts).select { |(_c, matched)| matched }.map(&:first)
           matching.empty? ? conjuncts : matching
         end
 
-        # Whether this conjunct's key_types match the call's literal
-        # argument (see Signature#hash_key_param_index), or nil if unknown.
+        # Whether any of this conjunct's resolved method signatures
+        # match the call's actual arguments, or nil if the conjunct's
+        # method pin/signatures don't resolve at all.
         #
         # @param conjunct [ComplexType]
         # @param api_map [ApiMap]
+        # @param name_pin [Pin::Base]
+        # @param locals [::Array<Pin::LocalVariable, Pin::Parameter>]
         # @return [Boolean, nil]
-        def conjunct_key_verdict conjunct, api_map
-          verdicts = conjunct.items.map { |unique_type| unique_type_key_verdict(unique_type, api_map) }
-          return nil if verdicts.any?(&:nil?)
+        def conjunct_argument_verdict conjunct, api_map, name_pin, locals
+          pins = method_pins_for_binder(conjunct, api_map, name_pin, locals)
+          return nil if pins.empty?
 
-          verdicts.all?
+          signatures = pins.flat_map(&:signatures)
+          return nil if signatures.empty?
+
+          signatures.any? { |s| matching_arg_types(s, api_map, name_pin, locals) }
         end
 
-        # @param unique_type [ComplexType::UniqueType]
-        # @param api_map [ApiMap]
-        # @return [Boolean, nil]
-        def unique_type_key_verdict unique_type, api_map
-          return nil unless unique_type.literal_keyed?
-
-          ns_tag = unique_type.namespace == '' ? '' : unique_type.namespace_type.tag
-          pin = api_map.get_method_stack(ns_tag, word, scope: unique_type.scope).first
-          return nil if pin.nil?
-
-          key_tags = unique_type.key_types.map(&:tag)
-          index = pin.signatures.filter_map { |s| s.hash_key_param_index(api_map, key_tags) }.first
-          return nil if index.nil? || index >= arguments.length
-
-          key_tag = literal_node_tag(arguments[index]&.node)
-          return nil if key_tag.nil?
-
-          unique_type.key_type_tag?(key_tag)
-        end
-
-        # The literal tag (e.g. `"Index"`, `:index`, `1`) a `UniqueType`
-        # built from this argument node's literal value would have, or nil
-        # if the node isn't a literal Hash-key-shaped value.
+        # Whether an overload's arity and each parameter's declared
+        # type accept the call's actual arguments. Used both for
+        # regular overload resolution and, per conjunct, to narrow an
+        # Intersection's conjuncts to the ones a call can actually
+        # dispatch to (see #conjunct_argument_verdict) - the same
+        # question either way: does this signature accept these
+        # arguments.
         #
-        # @param node [Parser::AST::Node, Object]
-        # @return [String, nil]
-        def literal_node_tag node
-          return nil unless Parser.is_ast_node?(node)
+        # @param overload [Pin::Signature]
+        # @param api_map [ApiMap]
+        # @param name_pin [Pin::Base]
+        # @param locals [::Array<Solargraph::Pin::LocalVariable, Solargraph::Pin::Parameter>]
+        # @return [::Array<ComplexType>, nil] the arguments' inferred types if it matches, nil otherwise
+        def matching_arg_types overload, api_map, name_pin, locals
+          return nil unless overload.arity_matches?(arguments, with_block?)
 
-          # @sg-ignore flow sensitive typing needs to narrow through a predicate wrapper like Parser.is_ast_node?
-          case node.type
-          # @sg-ignore flow sensitive typing needs to narrow through a predicate wrapper like Parser.is_ast_node?
-          when :str then node.children.first.inspect
-          # @sg-ignore flow sensitive typing needs to narrow through a predicate wrapper like Parser.is_ast_node?
-          when :sym then ":#{node.children.first}"
-          # @sg-ignore flow sensitive typing needs to narrow through a predicate wrapper like Parser.is_ast_node?
-          when :int then node.children.first.to_s
+          atypes = []
+          arguments.each_with_index do |arg, idx|
+            param = overload.parameters[idx]
+            if param.nil?
+              return nil unless overload.parameters.any?(&:restarg?)
+              break
+            end
+            arg_name_pin = Pin::ProxyType.anonymous(name_pin.context,
+                                                    closure: name_pin.closure,
+                                                    gates: name_pin.gates,
+                                                    source: :chain)
+            atype = atypes[idx] = arg.infer(api_map, arg_name_pin, locals)
+            # @sg-ignore flow sensitive typing should handle is_a? and next
+            return nil unless param.compatible_arg?(atype, api_map) || param.restarg?
           end
+          atypes
         end
 
         # Checks whether a single overload signature matches the call's
@@ -187,28 +196,8 @@ module Solargraph
         # @param new_signature_pin [Pin::Signature, nil]
         # @return [::Array(ComplexType, Pin::Signature)]
         def match_overload_type overload, pin, api_map, name_pin, locals, type, new_signature_pin
-          return [type, new_signature_pin] unless overload.arity_matches?(arguments, with_block?)
-
-          match = true
-          atypes = []
-          arguments.each_with_index do |arg, idx|
-            param = overload.parameters[idx]
-            if param.nil?
-              match = overload.parameters.any?(&:restarg?)
-              break
-            end
-            arg_name_pin = Pin::ProxyType.anonymous(name_pin.context,
-                                                    closure: name_pin.closure,
-                                                    gates: name_pin.gates,
-                                                    source: :chain)
-            atype = atypes[idx] ||= arg.infer(api_map, arg_name_pin, locals)
-            # @sg-ignore flow sensitive typing should handle is_a? and next
-            unless param.compatible_arg?(atype, api_map) || param.restarg?
-              match = false
-              break
-            end
-          end
-          return [type, new_signature_pin] unless match
+          atypes = matching_arg_types(overload, api_map, name_pin, locals)
+          return [type, new_signature_pin] if atypes.nil?
 
           if overload.block && with_block?
             block_atypes = overload.block.parameters.map(&:return_type)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -145,12 +145,7 @@ module Solargraph
         end
 
         # Whether an overload's arity and each parameter's declared
-        # type accept the call's actual arguments. Used both for
-        # regular overload resolution and, per conjunct, to narrow an
-        # Intersection's conjuncts to the ones a call can actually
-        # dispatch to (see #conjunct_accepts_arguments) - the same
-        # question either way: does this signature accept these
-        # arguments.
+        # type accept the call's actual arguments.
         #
         # @param overload [Pin::Signature]
         # @param api_map [ApiMap]

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -154,10 +154,10 @@ module Solargraph
         end
 
         # Whether this conjunct's own literal `key_types` positively match
-        # the call's own literal argument at the `_Key`-typed parameter's
-        # position, or nil if that can't be determined (no `_Key`-shaped
-        # parameter here, non-literal argument, or no literal `key_types`
-        # to compare against).
+        # the call's own literal argument at the key parameter's position
+        # (see Pin::Signature#key_param_index), or nil if that can't be
+        # determined (no key-shaped parameter here, non-literal argument,
+        # or no literal `key_types` to compare against).
         #
         # @param conjunct [ComplexType]
         # @param api_map [ApiMap]
@@ -179,7 +179,8 @@ module Solargraph
           pin = api_map.get_method_stack(ns_tag, word, scope: unique_type.scope).first
           return nil if pin.nil?
 
-          index = pin.signatures.filter_map { |s| s.key_param_index(unique_type.namespace, api_map) }.first
+          key_tags = unique_type.key_types.map(&:tag)
+          index = pin.signatures.filter_map { |s| s.key_param_index(unique_type.namespace, api_map, key_tags) }.first
           return nil if index.nil? || index >= arguments.length
 
           key_tag = literal_node_tag(arguments[index]&.node)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -64,8 +64,8 @@ module Solargraph
 
         private
 
-        # Resolves the pins for calling `word` on every top-level
-        # alternative of a binder type (loose_unions allows leniency).
+        # Resolves the pins for calling `word` on a binder type, with an
+        # intersection narrowed to the conjuncts this call can dispatch to.
         #
         # @param binder_type [ComplexType, ComplexType::UniqueType]
         # @param api_map [ApiMap]
@@ -73,38 +73,10 @@ module Solargraph
         # @param locals [::Array<Pin::LocalVariable, Pin::Parameter>]
         # @return [::Array<Pin::Base>]
         def method_pins_for_binder binder_type, api_map, name_pin, locals
-          top_level_types = binder_type.is_a?(ComplexType) ? binder_type.to_a : [binder_type]
-          pin_groups = top_level_types.map { |unique_type| method_stack_pins(unique_type, api_map, name_pin, locals) }
-          pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:nil?)
-          # Dedup on path *and* return type: alternatives can share a
-          # path (e.g. same generic method on different instantiations).
-          # @param p [Pin::Base]
-          pin_groups.compact.flatten.uniq { |p| [p.path, p.return_type.tag] }
-        end
-
-        # Resolves the method stack's first pin for one top-level type.
-        # An Intersection needs only one conjunct to define the method.
-        #
-        # @param unique_type [ComplexType::UniqueType]
-        # @param api_map [ApiMap]
-        # @param name_pin [Pin::Base]
-        # @param locals [::Array<Pin::LocalVariable, Pin::Parameter>]
-        # @return [::Array<Pin::Base>, nil] nil when unresolved
-        def method_stack_pins unique_type, api_map, name_pin, locals
-          if unique_type.is_a?(ComplexType::UniqueType::Intersection)
-            resolved = argument_verified_conjuncts(unique_type.conjuncts, api_map, name_pin, locals).filter_map do |conjunct|
-              pins = method_pins_for_binder(conjunct, api_map, name_pin, locals)
-              pins.empty? ? nil : pins
-            end
-            return nil if resolved.empty?
-            # @param p [Pin::Base]
-            resolved.flatten.uniq { |p| [p.path, p.return_type.tag] }
-          else
-            ns_tag = unique_type.namespace == '' ? '' : unique_type.namespace_type.tag
-            stack = api_map.get_method_stack(ns_tag, word, scope: unique_type.scope)
-            return nil if stack.first.nil?
-            [stack.first]
+          pins = binder_type.method_stack_pins(word, api_map) do |conjuncts|
+            argument_verified_conjuncts(conjuncts, api_map, name_pin, locals)
           end
+          pins || []
         end
 
         # Narrows conjuncts to the ones with at least one signature

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -388,9 +388,9 @@ module Solargraph
           end
         end
 
-        # @param type [ComplexType]
+        # @param type [ComplexType, ComplexType::UniqueType]
         # @param context [ComplexType, ComplexType::UniqueType]
-        # @return [ComplexType]
+        # @return [ComplexType, ComplexType::UniqueType]
         def with_params type, context
           return type unless type.to_s.include?('$')
           ComplexType.try_parse(type.to_s.gsub('$', context.value_types.map(&:rooted_tag).join(', ')).gsub('<>', ''))

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -7,17 +7,27 @@ module Solargraph
         # @param type [String]
         # @param node [Parser::AST::Node]
         # @param splatted [Boolean]
-        def initialize type, node, splatted = false
+        # @param pairs [::Array<::Array(Chain, Chain)>, nil] Each key/value
+        #   pair's key and value chained separately, or nil if the literal
+        #   isn't just a plain list of `key => value` pairs (e.g. it
+        #   contains a `**splat`) - see NodeChainer#hash_pairs.
+        def initialize type, node, splatted = false, pairs = nil
           super(type, node)
           @splatted = splatted
+          # @type [::Array<::Array(Chain, Chain)>, nil]
+          @pairs = pairs
         end
 
         def word
           @word ||= "<#{@type}>"
         end
 
-        def resolve api_map, name_pin, locals
-          [Pin::ProxyType.anonymous(@complex_type, source: :chain)]
+        # @param api_map [ApiMap]
+        # @param name_pin [Pin::Base]
+        # @param locals [::Array<Pin::Base>]
+        # @param _receiver_path [::Array<String>, nil]
+        def resolve api_map, name_pin, locals, _receiver_path = nil
+          [Pin::ProxyType.anonymous(inferred_type(api_map, name_pin, locals), source: :chain)]
         end
 
         def splatted?
@@ -30,6 +40,39 @@ module Solargraph
         def equality_fields
           # @sg-ignore literal arrays in this module turn into ::Solargraph::Source::Chain::Array
           super + [@splatted]
+        end
+
+        private
+
+        # Infers Hash{K => V} from the literal's actual key/value pairs,
+        # the same way Chain::Array infers Array<T> from its elements
+        # (see Chain::Array#resolve). Falls back to the bare, generic-less
+        # ::Hash type - the only type a splatted hash or one that fails to
+        # infer any pair concretely ever had - rather than reporting a
+        # partial/incorrect Hash{K => V}.
+        #
+        # @param api_map [ApiMap]
+        # @param name_pin [Pin::Base]
+        # @param locals [::Array<Pin::Base>]
+        # @return [ComplexType]
+        def inferred_type api_map, name_pin, locals
+          # @type [::Array<::Array(Chain, Chain)>, nil]
+          pairs = @pairs
+          return @complex_type if pairs.nil? || pairs.empty?
+
+          key_types = []
+          value_types = []
+          pairs.each do |pair|
+            key_chain, value_chain = pair
+            key_type = key_chain.infer(api_map, name_pin, locals).simplify_literals
+            value_type = value_chain.infer(api_map, name_pin, locals).simplify_literals
+            return @complex_type if key_type.undefined? || value_type.undefined?
+
+            key_types.push key_type
+            value_types.push value_type
+          end
+          ComplexType.new([ComplexType::UniqueType.new('Hash', key_types.uniq, value_types.uniq,
+                                                       rooted: true, parameters_type: :hash)])
         end
       end
     end

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -56,7 +56,6 @@ module Solargraph
         # @param locals [::Array<Pin::Base>]
         # @return [ComplexType]
         def inferred_type api_map, name_pin, locals
-          # @type [::Array<::Array(Chain, Chain)>, nil]
           pairs = @pairs
           return @complex_type if pairs.nil? || pairs.empty?
 

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -14,7 +14,6 @@ module Solargraph
         def initialize type, node, splatted = false, pairs = nil
           super(type, node)
           @splatted = splatted
-          # @type [::Array<::Array(Chain, Chain)>, nil]
           @pairs = pairs
         end
 

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -7,10 +7,9 @@ module Solargraph
         # @param type [String]
         # @param node [Parser::AST::Node]
         # @param splatted [Boolean]
-        # @param pairs [::Array<::Array(Chain, Chain)>, nil] Each key/value
-        #   pair's key and value chained separately, or nil if the literal
-        #   isn't just a plain list of `key => value` pairs (e.g. it
-        #   contains a `**splat`) - see NodeChainer#hash_pairs.
+        # @param pairs [::Array<::Array(Chain, Chain)>, nil] Chained key/value
+        #   pairs, or nil for a splatted or non-plain-pairs literal - see
+        #   NodeChainer#hash_pairs.
         def initialize type, node, splatted = false, pairs = nil
           super(type, node)
           @splatted = splatted
@@ -43,12 +42,9 @@ module Solargraph
 
         private
 
-        # Infers Hash{K => V} from the literal's actual key/value pairs,
-        # the same way Chain::Array infers Array<T> from its elements
-        # (see Chain::Array#resolve). Falls back to the bare, generic-less
-        # ::Hash type - the only type a splatted hash or one that fails to
-        # infer any pair concretely ever had - rather than reporting a
-        # partial/incorrect Hash{K => V}.
+        # Infers Hash{K => V} from the literal's pairs, mirroring
+        # Chain::Array's element inference. Falls back to bare ::Hash
+        # when splatted or any pair fails to infer.
         #
         # @param api_map [ApiMap]
         # @param name_pin [Pin::Base]

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -51,7 +51,6 @@ module Solargraph
         # @param locals [::Array<Pin::Base>]
         # @return [ComplexType]
         def inferred_type api_map, name_pin, locals
-          # @type [::Array<::Array(Chain, Chain)>, nil]
           pairs = @pairs
           return @complex_type if pairs.nil? || pairs.empty?
 

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -23,8 +23,7 @@ module Solargraph
         # @param api_map [ApiMap]
         # @param name_pin [Pin::Base]
         # @param locals [::Array<Pin::Base>]
-        # @param _receiver_path [::Array<String>, nil]
-        def resolve api_map, name_pin, locals, _receiver_path = nil
+        def resolve api_map, name_pin, locals
           [Pin::ProxyType.anonymous(inferred_type(api_map, name_pin, locals), source: :chain)]
         end
 

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -55,7 +55,9 @@ module Solargraph
           pairs = @pairs
           return @complex_type if pairs.nil? || pairs.empty?
 
+          # @type [::Array<ComplexType>]
           key_types = []
+          # @type [::Array<ComplexType>]
           value_types = []
           pairs.each do |pair|
             key_chain, value_chain = pair

--- a/lib/solargraph/source/chain/literal.rb
+++ b/lib/solargraph/source/chain/literal.rb
@@ -24,7 +24,7 @@ module Solargraph
           #   elsif node.type == :false
           #     @value = false
           #   # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
-          #   elsif %i[int sym].include?(node.type)
+          #   elsif %i[int sym str].include?(node.type)
           #     # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
           #     @value = node.children.first
           #   end

--- a/lib/solargraph/source/chain/literal.rb
+++ b/lib/solargraph/source/chain/literal.rb
@@ -24,7 +24,7 @@ module Solargraph
           #   elsif node.type == :false
           #     @value = false
           #   # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
-          #   elsif %i[int sym str].include?(node.type)
+          #   elsif %i[int sym].include?(node.type)
           #     # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
           #     @value = node.children.first
           #   end

--- a/lib/solargraph/type_checker/rules.rb
+++ b/lib/solargraph/type_checker/rules.rb
@@ -75,13 +75,13 @@ module Solargraph
       # @todo 22: Translate to something flow sensitive typing understands
       # @todo 3: Need a downcast here
       #
-      # flow sensitive typing could handle (96):
+      # flow sensitive typing could handle (103):
       #
       # @todo 36: flow sensitive typing needs to handle attrs
       # @todo 29: flow sensitive typing should be able to handle redefinition
       # @todo 19: flow sensitive typing needs to narrow down type with an if is_a? check
       # @todo 13: Need to validate config
-      # @todo 11: flow sensitive typing ought to be able to handle 'when ClassName'
+      # @todo 10: flow sensitive typing ought to be able to handle 'when ClassName'
       # @todo 8: flow sensitive typing should support .class == .class
       # @todo 6: need boolish support for ? methods
       # @todo 6: flow sensitive typing needs better handling of ||= on lvars
@@ -96,9 +96,10 @@ module Solargraph
       # @todo 2: Should better support meaning of '&' in RBS
       # @todo 2: (*) flow sensitive typing needs to handle "if foo = bar"
       # @todo 2: flow sensitive typing needs to handle "if foo = bar"
-      # @todo 2: Need to handle duck-typed method calls on union types
+      # @todo 2: flow sensitive typing needs to infer Enumerable#find's block return type from an is_a? check
       # @todo 2: Need better handling of #compact
       # @todo 2: flow sensitive typing should allow shadowing of Kernel#caller
+      # @todo 1: Need to handle duck-typed method calls on union types
       # @todo 1: flow sensitive typing not smart enough to handle this case
       # @todo 1: flow sensitive typing needs to handle if foo = bar
       # @todo 1: flow sensitive typing needs to handle "if foo.nil?"

--- a/lib/solargraph/type_checker/rules.rb
+++ b/lib/solargraph/type_checker/rules.rb
@@ -81,6 +81,7 @@ module Solargraph
       # @todo 29: flow sensitive typing should be able to handle redefinition
       # @todo 19: flow sensitive typing needs to narrow down type with an if is_a? check
       # @todo 13: Need to validate config
+      # @todo 11: flow sensitive typing ought to be able to handle 'when ClassName'
       # @todo 8: flow sensitive typing should support .class == .class
       # @todo 6: need boolish support for ? methods
       # @todo 6: flow sensitive typing needs better handling of ||= on lvars
@@ -88,7 +89,6 @@ module Solargraph
       # @todo 5: flow sensitive typing needs to handle 'raise if'
       # @todo 4: flow sensitive typing needs to eliminate literal from union with [:bar].include?(foo)
       # @todo 4: nil? support in flow sensitive typing
-      # @todo 3: flow sensitive typing ought to be able to handle 'when ClassName'
       # @todo 2: downcast output of Enumerable#select
       # @todo 2: flow sensitive typing should handle return nil if location&.name.nil?
       # @todo 2: flow sensitive typing should handle is_a? and next

--- a/lib/solargraph/type_checker/rules.rb
+++ b/lib/solargraph/type_checker/rules.rb
@@ -75,14 +75,14 @@ module Solargraph
       # @todo 22: Translate to something flow sensitive typing understands
       # @todo 3: Need a downcast here
       #
-      # flow sensitive typing could handle (103):
+      # flow sensitive typing could handle (104):
       #
       # @todo 36: flow sensitive typing needs to handle attrs
       # @todo 29: flow sensitive typing should be able to handle redefinition
       # @todo 19: flow sensitive typing needs to narrow down type with an if is_a? check
       # @todo 13: Need to validate config
       # @todo 10: flow sensitive typing ought to be able to handle 'when ClassName'
-      # @todo 8: flow sensitive typing should support .class == .class
+      # @todo 9: flow sensitive typing should support .class == .class
       # @todo 6: need boolish support for ? methods
       # @todo 6: flow sensitive typing needs better handling of ||= on lvars
       # @todo 5: literal arrays in this module turn into ::Solargraph::Source::Chain::Array

--- a/lib/solargraph/type_checker/rules.rb
+++ b/lib/solargraph/type_checker/rules.rb
@@ -75,9 +75,9 @@ module Solargraph
       # @todo 22: Translate to something flow sensitive typing understands
       # @todo 3: Need a downcast here
       #
-      # flow sensitive typing could handle (104):
+      # flow sensitive typing could handle (98):
       #
-      # @todo 36: flow sensitive typing needs to handle attrs
+      # @todo 30: flow sensitive typing needs to handle attrs
       # @todo 29: flow sensitive typing should be able to handle redefinition
       # @todo 19: flow sensitive typing needs to narrow down type with an if is_a? check
       # @todo 13: Need to validate config

--- a/lib/solargraph/type_checker/rules.rb
+++ b/lib/solargraph/type_checker/rules.rb
@@ -17,18 +17,20 @@ module Solargraph
       attr_reader :level
 
       # @return [Integer]
+      # @sg-ignore https://github.com/castwide/solargraph/pull/1266
       attr_reader :rank
 
       # @param level [Symbol]
       # @param overrides [Hash{Symbol => Symbol}]
       def initialize level, overrides
-        @rank = if LEVELS.key?(level)
-                  LEVELS[level]
-                else
-                  Solargraph.logger.warn "Unrecognized TypeChecker level #{level}, assuming normal"
-                  0
-                end
-        @level = LEVELS[LEVELS.values.index(@rank)]
+        if LEVELS.key?(level)
+          @rank = LEVELS.fetch(level)
+          @level = level
+        else
+          Solargraph.logger.warn "Unrecognized TypeChecker level #{level}, assuming normal"
+          @rank = 0
+          @level = :normal
+        end
         @overrides = overrides
       end
 
@@ -150,7 +152,8 @@ module Solargraph
       # @param type [Symbol]
       # @param level [Symbol]
       def report? type, level
-        rank >= LEVELS[@overrides.fetch(type, level)]
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1266
+        rank >= LEVELS.fetch(@overrides.fetch(type, level))
       end
     end
   end

--- a/rbs/overrides/hash/hash.rbs
+++ b/rbs/overrides/hash/hash.rbs
@@ -1,0 +1,14 @@
+# RBS 4.1 retyped Hash key lookups as the structural interface
+# `Hash::_Key` - anything answering `hash`/`eql?`. That is accurate
+# about what Ruby accepts, but it erases the receiver's own key type,
+# so a call on a record type (`Hash{"Index" => Float}`) can no longer
+# be resolved against the key it was declared with.
+#
+# Restore RBS 4.0's shape, which typed these as the class parameter
+# `K`. Remove this once Solargraph can resolve a structural interface
+# to the receiver's corresponding type parameter.
+class Hash[unchecked out K, unchecked out V]
+  def fetch: (K arg0) -> V
+           | [X] (K arg0, X arg1) -> (V | X)
+           | [X] (K arg0) { (K arg0) -> X } -> (V | X)
+end

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -223,6 +223,12 @@ describe Solargraph::ApiMap do
     expect(pins.map(&:path)).to eq(['Bar#meth', 'Foo#meth', 'Mixin#meth'])
   end
 
+  it 'returns no methods for an unparseable tag instead of raising' do
+    pins = nil
+    expect { pins = @api_map.get_method_stack('Hash{"a" => Float}{"b" => Float}', 'keys') }.not_to raise_error
+    expect(pins).to eq([])
+  end
+
   it 'finds symbols' do
     map = Solargraph::SourceMap.load_string('sym = :sym')
     @api_map.index map.pins

--- a/spec/complex_type/combine_via_spec.rb
+++ b/spec/complex_type/combine_via_spec.rb
@@ -24,7 +24,7 @@ describe Solargraph::ComplexType do
 
   describe '.union' do
     it 'returns a repeated type as itself rather than as a union of one' do
-      type = described_class.parse('A').first
+      type = described_class.parse('A').items.first
       expect(described_class.union(type, type)).to be(type)
     end
   end

--- a/spec/complex_type/combine_via_spec.rb
+++ b/spec/complex_type/combine_via_spec.rb
@@ -1,0 +1,81 @@
+# frozen_string_literal: true
+
+# #combine_via pairs two types up member by member. The block below
+# states the same rule Pin::Base#combine_return_type passes in, so
+# these are the results that method produces.
+describe Solargraph::ComplexType do
+  let(:self_tags) { 'Foo' }
+
+  def intersection *tags
+    Solargraph::ComplexType::UniqueType::Intersection.new(tags.map { |tag| Solargraph::ComplexType.parse(tag) })
+  end
+
+  def combine left, right
+    left.combine_via(right) do |mine, theirs|
+      if mine.rooted_tags == theirs.rooted_tags || (mine.selfy? && theirs.rooted_tags == self_tags)
+        mine
+      elsif theirs.selfy? && mine.rooted_tags == self_tags
+        theirs
+      else
+        Solargraph::ComplexType.union(mine, theirs)
+      end
+    end
+  end
+
+  describe '.union' do
+    it 'returns a repeated type as itself rather than as a union of one' do
+      type = described_class.parse('A').first
+      expect(described_class.union(type, type)).to be(type)
+    end
+  end
+
+  describe '#combine_via' do
+    it 'matches the members both sides carry whatever order they appear in' do
+      expect(combine(described_class.parse('A, B'), described_class.parse('B, A')).rooted_tags).to eq('A, B')
+    end
+
+    it 'zips up the members left over once the shared ones are matched' do
+      expect(combine(described_class.parse('A, C'), described_class.parse('D, A')).rooted_tags).to eq('A, C, D')
+    end
+
+    it 'hands the whole remainder of the longer side to the last member of the shorter' do
+      expect(combine(described_class.parse('A, B, C, D'), described_class.parse('A, E, F')).rooted_tags)
+        .to eq('A, B, E, C, D, F')
+    end
+
+    it 'sets a lone member on the right against the whole union on the left' do
+      expect(combine(described_class.parse('A, B'), described_class.parse('A')).rooted_tags).to eq('A, B')
+    end
+
+    it 'sets a lone member on the left against the whole union on the right' do
+      expect(combine(described_class.parse('A'), described_class.parse('B, C')).rooted_tags).to eq('A, B, C')
+    end
+
+    it 'keeps a member the other side ran out of counterparts for' do
+      expect(combine(described_class.parse('String, nil'), described_class.parse('String, Symbol, nil')).rooted_tags)
+        .to eq('String, nil, Symbol')
+    end
+
+    it 'reads a declaration naming both self and the enclosing class as self' do
+      expect(combine(described_class.parse('self'), described_class.parse('Foo')).rooted_tags).to eq('self')
+    end
+
+    it 'reads it the same way with the enclosing class named first' do
+      expect(combine(described_class.parse('Foo'), described_class.parse('self')).rooted_tags).to eq('self')
+    end
+
+    context 'with an intersection on the left' do
+      it 'unions with a type that has no conjuncts to line up against' do
+        expect(combine(intersection('X', 'Y'), described_class.parse('Z')).rooted_tags).to eq('X & Y, Z')
+      end
+
+      it 'stays unchanged when the other intersection carries the same conjuncts' do
+        expect(combine(intersection('A', 'B'), intersection('A', 'B')).rooted_tags).to eq('A & B')
+      end
+
+      it 'widens only the conjunct the two intersections disagree on' do
+        expect(combine(intersection('A', 'B'), intersection('A', 'C')).rooted_tags).to eq('A & [B, C]')
+      end
+    end
+  end
+end

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -315,6 +315,23 @@ describe Solargraph::ComplexType do
         exp = described_class.parse('Sub & Unrelated')
         expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
       end
+
+      it 'conforms to a union that offers the same intersection as one alternative' do
+        inf = described_class.parse('Sub & Unrelated')
+        exp = described_class.parse('Sub & Integer', 'Sub & Unrelated', 'nil')
+        expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+      end
+
+      it 'conforms to itself when it is a union of intersections' do
+        type = described_class.parse('Sub & Unrelated', 'Sub & Integer', 'nil')
+        expect(type.conforms_to?(api_map, type, :assignment)).to be(true)
+      end
+
+      it 'still rejects a union whose alternatives no conjunct combination covers' do
+        inf = described_class.parse('Sub & Unrelated')
+        exp = described_class.parse('Sub & Integer', 'Float')
+        expect(inf.conforms_to?(api_map, exp, :method_call)).to be(false)
+      end
     end
 
     it 'combines a class and a mix-in as conjuncts' do

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -240,7 +240,6 @@ describe Solargraph::ComplexType do
     end
   end
 
-  # https://github.com/castwide/solargraph/issues/1229
   context 'with intersection types' do
     let(:source) do
       Solargraph::Source.load_string(%(

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -284,14 +284,7 @@ describe Solargraph::ComplexType do
     end
 
     context 'when both the inferred and expected types are intersections' do
-      # A & B <: C & D iff every conjunct of the expected side is
-      # satisfied by *some* conjunct of the inferred side - not "one
-      # single inferred conjunct satisfies the whole expected type."
-      # Checking a single already-chosen conjunct against the full
-      # expected intersection (rather than letting different inferred
-      # conjuncts cover different expected conjuncts) makes an
-      # intersection fail to conform to an identical copy of itself
-      # whenever its conjuncts don't already relate to each other.
+      # A & B <: C & D: each expected conjunct needs some inferred match.
       it 'conforms to an identical intersection with unrelated conjuncts' do
         inf = described_class.parse('Sub & Unrelated')
         exp = described_class.parse('Sub & Unrelated')

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -283,6 +283,40 @@ describe Solargraph::ComplexType do
       expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
     end
 
+    context 'when both the inferred and expected types are intersections' do
+      # A & B <: C & D iff every conjunct of the expected side is
+      # satisfied by *some* conjunct of the inferred side - not "one
+      # single inferred conjunct satisfies the whole expected type."
+      # Checking a single already-chosen conjunct against the full
+      # expected intersection (rather than letting different inferred
+      # conjuncts cover different expected conjuncts) makes an
+      # intersection fail to conform to an identical copy of itself
+      # whenever its conjuncts don't already relate to each other.
+      it 'conforms to an identical intersection with unrelated conjuncts' do
+        inf = described_class.parse('Sub & Unrelated')
+        exp = described_class.parse('Sub & Unrelated')
+        expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+      end
+
+      it 'conforms to an identical intersection regardless of conjunct order' do
+        inf = described_class.parse('Sub & Unrelated')
+        exp = described_class.parse('Unrelated & Sub')
+        expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+      end
+
+      it 'still requires every expected conjunct to be covered by some inferred conjunct' do
+        inf = described_class.parse('Sub & Unrelated')
+        exp = described_class.parse('Sub & Integer')
+        expect(inf.conforms_to?(api_map, exp, :method_call)).to be(false)
+      end
+
+      it 'lets a wider inferred intersection satisfy a narrower expected one' do
+        inf = described_class.parse('Sub & Unrelated & Integer')
+        exp = described_class.parse('Sub & Unrelated')
+        expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+      end
+    end
+
     it 'combines a class and a mix-in as conjuncts' do
       inf = described_class.parse('String & Comparable')
       expect(inf.conforms_to?(api_map, described_class.parse('Comparable'), :method_call)).to be(true)

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -240,6 +240,51 @@ describe Solargraph::ComplexType do
     end
   end
 
+  # https://github.com/castwide/solargraph/issues/1229
+  context 'with intersection types' do
+    let(:source) do
+      Solargraph::Source.load_string(%(
+        class Sup; end
+        class Sub < Sup; end
+        class Unrelated; end
+      ))
+    end
+
+    before do
+      api_map.map source
+    end
+
+    it 'lets an intersection satisfy an expectation of any one conjunct (A & B <: A)' do
+      inf = described_class.parse('Sub & Unrelated')
+      exp = described_class.parse('Sub')
+      expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+    end
+
+    it 'lets an intersection satisfy an expectation of any one conjunct (A & B <: B)' do
+      inf = described_class.parse('Sub & Unrelated')
+      exp = described_class.parse('Unrelated')
+      expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+    end
+
+    it 'does not let an intersection satisfy an expectation none of its conjuncts meet' do
+      inf = described_class.parse('Sub & Unrelated')
+      exp = described_class.parse('Integer')
+      expect(inf.conforms_to?(api_map, exp, :method_call)).to be(false)
+    end
+
+    it 'requires every conjunct to be satisfied to conform to an intersection expectation' do
+      inf = described_class.parse('Sub')
+      exp = described_class.parse('Sup & Unrelated')
+      expect(inf.conforms_to?(api_map, exp, :method_call)).to be(false)
+    end
+
+    it 'conforms to an intersection expectation when every conjunct is satisfied' do
+      inf = described_class.parse('Sub')
+      exp = described_class.parse('Sup & Sub')
+      expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+    end
+  end
+
   context 'with inheritance relationship in allow_reverse_match mode' do
     let(:api_map) { Solargraph::ApiMap.new }
     let(:sup) { described_class.parse('String') }

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -283,6 +283,44 @@ describe Solargraph::ComplexType do
       exp = described_class.parse('Sup & Sub')
       expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
     end
+
+    it 'combines a class and a mix-in as conjuncts' do
+      inf = described_class.parse('String & Comparable')
+      expect(inf.conforms_to?(api_map, described_class.parse('Comparable'), :method_call)).to be(true)
+      expect(inf.conforms_to?(api_map, described_class.parse('Enumerable'), :method_call)).to be(false)
+    end
+
+    it 'lets a value satisfy a class-and-mix-in intersection expectation' do
+      exp = described_class.parse('Comparable & String')
+      expect(described_class.parse('String').conforms_to?(api_map, exp, :method_call)).to be(true)
+      expect(described_class.parse('Integer').conforms_to?(api_map, exp, :method_call)).to be(false)
+    end
+
+    context 'with a duck-typed conjunct in the expectation' do
+      let(:source) do
+        Solargraph::Source.load_string(%(
+          class Sup; end
+          class Sub < Sup; end
+          class Unrelated; end
+
+          class Quacker
+            def to_str
+              ''
+            end
+          end
+        ))
+      end
+
+      it 'structurally verifies a duck-typed conjunct alongside a nominal one' do
+        exp = described_class.parse('Object & #to_str')
+        expect(described_class.parse('Quacker').conforms_to?(api_map, exp, :method_call)).to be(true)
+      end
+
+      it 'still requires the nominal conjunct even if the duck-typed one matches' do
+        exp = described_class.parse('Comparable & #to_str')
+        expect(described_class.parse('Quacker').conforms_to?(api_map, exp, :method_call)).to be(false)
+      end
+    end
   end
 
   context 'with inheritance relationship in allow_reverse_match mode' do

--- a/spec/complex_type/exclude_spec.rb
+++ b/spec/complex_type/exclude_spec.rb
@@ -1,16 +1,8 @@
 # frozen_string_literal: true
 
-# ComplexType#exclude already accepts an api_map parameter, but its
-# current implementation ignores it and does plain exact-match array
-# subtraction. This documents the api_map-aware behavior it would
-# ideally have (a third example of api-map-driven type simplification,
-# alongside narrow_with's subtype/mix-in reduction and qualify's name
-# resolution): excluding a type should also exclude any union member
-# already known to be one of its subtypes, since a value that fails
-# `is_a?(Sup)` can't be a `Sub` either.
-#
-# Not implemented - out of scope for the PR that added this file.
-# These specs exist so the gap is tracked rather than silently unknown.
+# ComplexType#exclude accepts an api_map parameter but ignores it,
+# doing plain exact-match subtraction instead of also excluding
+# known subtypes of an excluded type.
 describe Solargraph::ComplexType do
   let(:api_map) { Solargraph::ApiMap.new }
 

--- a/spec/complex_type/exclude_spec.rb
+++ b/spec/complex_type/exclude_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# ComplexType#exclude already accepts an api_map parameter, but its
+# current implementation ignores it and does plain exact-match array
+# subtraction. This documents the api_map-aware behavior it would
+# ideally have (a third example of api-map-driven type simplification,
+# alongside narrow_with's subtype/mix-in reduction and qualify's name
+# resolution): excluding a type should also exclude any union member
+# already known to be one of its subtypes, since a value that fails
+# `is_a?(Sup)` can't be a `Sub` either.
+#
+# Not implemented - out of scope for the PR that added this file.
+# These specs exist so the gap is tracked rather than silently unknown.
+describe Solargraph::ComplexType do
+  let(:api_map) { Solargraph::ApiMap.new }
+
+  let(:source) do
+    Solargraph::Source.load_string(%(
+      class Sup; end
+      class Sub < Sup; end
+      class Unrelated; end
+    ))
+  end
+
+  before { api_map.map source }
+
+  it 'excludes known subtypes of an excluded type, not just exact matches' do
+    pending 'exclude ignores its api_map parameter and only removes exact matches'
+    type = described_class.parse('Sub, Sup, Unrelated')
+    result = type.exclude(described_class.parse('Sup'), api_map)
+    expect(result.tags).to eq('Unrelated')
+  end
+
+  it 'falls back to UNDEFINED when every member is excluded transitively' do
+    pending 'exclude ignores its api_map parameter and only removes exact matches'
+    type = described_class.parse('Sub, Sup')
+    result = type.exclude(described_class.parse('Sup'), api_map)
+    expect(result.undefined?).to be(true)
+  end
+end

--- a/spec/complex_type/narrow_with_spec.rb
+++ b/spec/complex_type/narrow_with_spec.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 # ComplexType#narrow_with is flow-sensitive type narrowing (e.g.
-# refining a declared type using a type learned from an `is_a?`
-# guard) - see spec/parser/flow_sensitive_typing_spec.rb for
-# end-to-end coverage through real source. These specs exercise the
-# narrowing logic directly.
+# from an `is_a?` guard) - see
+# spec/parser/flow_sensitive_typing_spec.rb for end-to-end coverage.
 describe Solargraph::ComplexType do
   let(:api_map) { Solargraph::ApiMap.new }
 

--- a/spec/complex_type/narrow_with_spec.rb
+++ b/spec/complex_type/narrow_with_spec.rb
@@ -52,4 +52,22 @@ describe Solargraph::ComplexType do
       expect(narrowed.tag).to eq('T')
     end
   end
+
+  context 'when narrowing a class with a duck type' do
+    let(:source) do
+      Solargraph::Source.load_string(%(
+        class T; end
+      ))
+    end
+
+    before { api_map.map source }
+
+    it 'builds an intersection rather than discarding the class' do
+      pending 'https://github.com/castwide/solargraph/pull/1297'
+      declared = described_class.parse('T')
+      learned = described_class.parse('#bar')
+      narrowed = declared.narrow_with(learned, api_map)
+      expect(narrowed.tag).to eq('T & #bar')
+    end
+  end
 end

--- a/spec/complex_type/narrow_with_spec.rb
+++ b/spec/complex_type/narrow_with_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# ComplexType#narrow_with is flow-sensitive type narrowing (e.g.
+# refining a declared type using a type learned from an `is_a?`
+# guard) - see spec/parser/flow_sensitive_typing_spec.rb for
+# end-to-end coverage through real source. These specs exercise the
+# narrowing logic directly.
+describe Solargraph::ComplexType do
+  let(:api_map) { Solargraph::ApiMap.new }
+
+  context 'when narrowing a class with an unrelated mix-in' do
+    let(:source) do
+      Solargraph::Source.load_string(%(
+        module M; end
+        class T; end
+      ))
+    end
+
+    before { api_map.map source }
+
+    it 'builds an intersection rather than discarding both facts' do
+      declared = described_class.parse('T')
+      learned = described_class.parse('M')
+      narrowed = declared.narrow_with(learned, api_map)
+      expect(narrowed.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+      expect(narrowed.tag).to eq('T & M')
+    end
+
+    it 'lets the narrowed intersection satisfy either original fact' do
+      declared = described_class.parse('T')
+      learned = described_class.parse('M')
+      narrowed = declared.narrow_with(learned, api_map)
+      expect(narrowed.conforms_to?(api_map, described_class.parse('T'), :method_call)).to be(true)
+      expect(narrowed.conforms_to?(api_map, described_class.parse('M'), :method_call)).to be(true)
+    end
+  end
+
+  context 'when the mix-in is already known to be included' do
+    let(:source) do
+      Solargraph::Source.load_string(%(
+        module M; end
+        class T
+          include M
+        end
+      ))
+    end
+
+    before { api_map.map source }
+
+    it 'simplifies to the already-more-specific type instead of building a redundant intersection' do
+      declared = described_class.parse('T')
+      learned = described_class.parse('M')
+      narrowed = declared.narrow_with(learned, api_map)
+      expect(narrowed.tag).to eq('T')
+    end
+  end
+end

--- a/spec/complex_type/narrow_with_spec.rb
+++ b/spec/complex_type/narrow_with_spec.rb
@@ -20,7 +20,7 @@ describe Solargraph::ComplexType do
       declared = described_class.parse('T')
       learned = described_class.parse('M')
       narrowed = declared.narrow_with(learned, api_map)
-      expect(narrowed.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+      expect(narrowed.items.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
       expect(narrowed.tag).to eq('T & M')
     end
 

--- a/spec/complex_type/unique_type_spec.rb
+++ b/spec/complex_type/unique_type_spec.rb
@@ -26,6 +26,11 @@ describe Solargraph::ComplexType::UniqueType do
     end
   end
 
+  # UniqueType#narrow_with duplicates ComplexType#narrow_with (see
+  # spec/complex_type/narrow_with_spec.rb) but is reachable on its
+  # own: BaseVariable#adjust_type calls #exclude before #narrow_with,
+  # and #exclude returns self - a bare UniqueType, unwrapped - when
+  # there's no exclusion type to apply.
   describe '#narrow_with' do
     let(:api_map) { Solargraph::ApiMap.new }
 

--- a/spec/complex_type/unique_type_spec.rb
+++ b/spec/complex_type/unique_type_spec.rb
@@ -25,4 +25,120 @@ describe Solargraph::ComplexType::UniqueType do
       expect(type.key_type_tag?('"Other"')).to be(false)
     end
   end
+
+  # UniqueType#narrow_with duplicates ComplexType#narrow_with (see
+  # spec/complex_type/narrow_with_spec.rb) but is reachable on its
+  # own: BaseVariable#adjust_type calls #exclude before #narrow_with,
+  # and #exclude returns self - a bare UniqueType, unwrapped - when
+  # there's no exclusion type to apply.
+  describe '#narrow_with' do
+    let(:api_map) { Solargraph::ApiMap.new }
+
+    it 'returns self unchanged when narrowing_type is nil' do
+      type = described_class.parse('String')
+      expect(type.narrow_with(nil, api_map)).to be(type)
+    end
+
+    it 'returns the narrowing type unchanged when self is undefined' do
+      narrowing = Solargraph::ComplexType.parse('String')
+      expect(described_class::UNDEFINED.narrow_with(narrowing, api_map)).to be(narrowing)
+    end
+
+    it 'keeps the original type when it already conforms to the narrowing type' do
+      type = described_class.parse('String')
+      narrowing = Solargraph::ComplexType.parse('Object')
+      narrowed = type.narrow_with(narrowing, api_map)
+      expect(narrowed.tag).to eq('String')
+    end
+
+    it 'uses the narrowing type when it is the more specific of the pair' do
+      type = described_class.parse('Object')
+      narrowing = Solargraph::ComplexType.parse('String')
+      narrowed = type.narrow_with(narrowing, api_map)
+      expect(narrowed.tag).to eq('String')
+    end
+
+    it 'falls back to undefined when neither side conforms and neither is a mix-in' do
+      type = described_class.parse('String')
+      narrowing = Solargraph::ComplexType.parse('Integer')
+      narrowed = type.narrow_with(narrowing, api_map)
+      expect(narrowed.tag).to eq('undefined')
+    end
+
+    context 'when narrowing a class with an unrelated mix-in' do
+      let(:source) do
+        Solargraph::Source.load_string(%(
+          module M; end
+          class T; end
+        ))
+      end
+
+      before { api_map.map source }
+
+      it 'combines both facts into an Intersection instead of dropping the pair' do
+        type = described_class.parse('T')
+        narrowing = Solargraph::ComplexType.parse('M')
+        narrowed = type.narrow_with(narrowing, api_map)
+        expect(narrowed.first).to be_a(described_class::Intersection)
+        expect(narrowed.tag).to eq('T & M')
+      end
+    end
+  end
+
+  describe '#mixin_pairing?' do
+    let(:api_map) { Solargraph::ApiMap.new }
+    let(:source) do
+      Solargraph::Source.load_string(%(
+        module M; end
+        class C; end
+      ))
+    end
+
+    before { api_map.map source }
+
+    it 'is true when the declared side is a module' do
+      declared = described_class.parse('M')
+      candidate = described_class.parse('C')
+      expect(declared.send(:mixin_pairing?, api_map, declared, candidate)).to be(true)
+    end
+
+    it 'is true when the candidate side is a module' do
+      declared = described_class.parse('C')
+      candidate = described_class.parse('M')
+      expect(declared.send(:mixin_pairing?, api_map, declared, candidate)).to be(true)
+    end
+
+    it 'is false when neither side is a module' do
+      declared = described_class.parse('C')
+      candidate = described_class.parse('C')
+      expect(declared.send(:mixin_pairing?, api_map, declared, candidate)).to be(false)
+    end
+  end
+
+  describe '#namespace_kind' do
+    let(:api_map) { Solargraph::ApiMap.new }
+    let(:source) do
+      Solargraph::Source.load_string(%(
+        module M; end
+        class C; end
+      ))
+    end
+
+    before { api_map.map source }
+
+    it 'identifies a class' do
+      type = described_class.parse('C')
+      expect(type.send(:namespace_kind, api_map, type)).to be(:class)
+    end
+
+    it 'identifies a module' do
+      type = described_class.parse('M')
+      expect(type.send(:namespace_kind, api_map, type)).to be(:module)
+    end
+
+    it 'returns nil when the namespace has no pin' do
+      type = described_class.parse('NoSuchNamespace')
+      expect(type.send(:namespace_kind, api_map, type)).to be_nil
+    end
+  end
 end

--- a/spec/complex_type/unique_type_spec.rb
+++ b/spec/complex_type/unique_type_spec.rb
@@ -26,11 +26,6 @@ describe Solargraph::ComplexType::UniqueType do
     end
   end
 
-  # UniqueType#narrow_with duplicates ComplexType#narrow_with (see
-  # spec/complex_type/narrow_with_spec.rb) but is reachable on its
-  # own: BaseVariable#adjust_type calls #exclude before #narrow_with,
-  # and #exclude returns self - a bare UniqueType, unwrapped - when
-  # there's no exclusion type to apply.
   describe '#narrow_with' do
     let(:api_map) { Solargraph::ApiMap.new }
 

--- a/spec/complex_type/unique_type_spec.rb
+++ b/spec/complex_type/unique_type_spec.rb
@@ -10,4 +10,19 @@ describe Solargraph::ComplexType::UniqueType do
       expect(types_encountered).to eq([type])
     end
   end
+
+  describe '#key_type_tag?' do
+    it 'matches a single literal key type' do
+      type = Solargraph::ComplexType.parse('Hash{"Index" => Float}').first
+      expect(type.key_type_tag?('"Index"')).to be(true)
+      expect(type.key_type_tag?('"Other"')).to be(false)
+    end
+
+    it 'matches every member of a union key type, not just the first' do
+      type = Solargraph::ComplexType.parse('Hash{"Index"|"Name" => Float}').first
+      expect(type.key_type_tag?('"Index"')).to be(true)
+      expect(type.key_type_tag?('"Name"')).to be(true)
+      expect(type.key_type_tag?('"Other"')).to be(false)
+    end
+  end
 end

--- a/spec/complex_type/unique_type_spec.rb
+++ b/spec/complex_type/unique_type_spec.rb
@@ -11,6 +11,18 @@ describe Solargraph::ComplexType::UniqueType do
     end
   end
 
+  describe '#literal_keyed?' do
+    it 'is false when there are no key types' do
+      type = described_class.parse('String')
+      expect(type.literal_keyed?).to be(false)
+    end
+
+    it 'is false when a key type is not a literal' do
+      type = Solargraph::ComplexType.parse('Hash{Float => Float}').first
+      expect(type.literal_keyed?).to be(false)
+    end
+  end
+
   describe '#key_type_tag?' do
     it 'matches a single literal key type' do
       type = Solargraph::ComplexType.parse('Hash{"Index" => Float}').first

--- a/spec/complex_type/unique_type_spec.rb
+++ b/spec/complex_type/unique_type_spec.rb
@@ -11,6 +11,19 @@ describe Solargraph::ComplexType::UniqueType do
     end
   end
 
+  describe '#rooted_tags' do
+    it 'leaves a symbol literal alone, so the tag can be parsed back' do
+      type = Solargraph::ComplexType.parse('Array<:Sym>').first.force_rooted
+      expect(type.rooted_tags).to eq('::Array<:Sym>')
+      expect(Solargraph::ComplexType.parse(type.rooted_tags).tags).to eq('Array<:Sym>')
+    end
+
+    it 'leaves a capitalized string literal alone when it is a hash key' do
+      type = Solargraph::ComplexType.parse('Hash{"Index" => Float}').first.force_rooted
+      expect(type.rooted_tags).to eq('::Hash{"Index" => ::Float}')
+    end
+  end
+
   # UniqueType#narrow_with duplicates ComplexType#narrow_with (see
   # spec/complex_type/narrow_with_spec.rb) but is reachable on its
   # own: BaseVariable#adjust_type calls #exclude before #narrow_with,

--- a/spec/complex_type/unique_type_spec.rb
+++ b/spec/complex_type/unique_type_spec.rb
@@ -11,33 +11,6 @@ describe Solargraph::ComplexType::UniqueType do
     end
   end
 
-  describe '#literal_keyed?' do
-    it 'is false when there are no key types' do
-      type = described_class.parse('String')
-      expect(type.literal_keyed?).to be(false)
-    end
-
-    it 'is false when a key type is not a literal' do
-      type = Solargraph::ComplexType.parse('Hash{Float => Float}').first
-      expect(type.literal_keyed?).to be(false)
-    end
-  end
-
-  describe '#key_type_tag?' do
-    it 'matches a single literal key type' do
-      type = Solargraph::ComplexType.parse('Hash{"Index" => Float}').first
-      expect(type.key_type_tag?('"Index"')).to be(true)
-      expect(type.key_type_tag?('"Other"')).to be(false)
-    end
-
-    it 'matches every member of a union key type, not just the first' do
-      type = Solargraph::ComplexType.parse('Hash{"Index"|"Name" => Float}').first
-      expect(type.key_type_tag?('"Index"')).to be(true)
-      expect(type.key_type_tag?('"Name"')).to be(true)
-      expect(type.key_type_tag?('"Other"')).to be(false)
-    end
-  end
-
   # UniqueType#narrow_with duplicates ComplexType#narrow_with (see
   # spec/complex_type/narrow_with_spec.rb) but is reachable on its
   # own: BaseVariable#adjust_type calls #exclude before #narrow_with,

--- a/spec/complex_type/unique_type_spec.rb
+++ b/spec/complex_type/unique_type_spec.rb
@@ -1,13 +1,11 @@
 # frozen_string_literal: true
 
 describe Solargraph::ComplexType::UniqueType do
-  describe '#any?' do
+  describe '#items' do
     let(:type) { described_class.parse('String') }
 
-    it 'yields one and only one type, itself' do
-      types_encountered = []
-      type.any? { |t| types_encountered << t }
-      expect(types_encountered).to eq([type])
+    it 'holds one and only one type, itself' do
+      expect(type.items).to eq([type])
     end
   end
 

--- a/spec/complex_type/unique_type_spec.rb
+++ b/spec/complex_type/unique_type_spec.rb
@@ -13,13 +13,13 @@ describe Solargraph::ComplexType::UniqueType do
 
   describe '#rooted_tags' do
     it 'leaves a symbol literal alone, so the tag can be parsed back' do
-      type = Solargraph::ComplexType.parse('Array<:Sym>').first.force_rooted
+      type = Solargraph::ComplexType.parse('Array<:Sym>').items.first.force_rooted
       expect(type.rooted_tags).to eq('::Array<:Sym>')
       expect(Solargraph::ComplexType.parse(type.rooted_tags).tags).to eq('Array<:Sym>')
     end
 
     it 'leaves a capitalized string literal alone when it is a hash key' do
-      type = Solargraph::ComplexType.parse('Hash{"Index" => Float}').first.force_rooted
+      type = Solargraph::ComplexType.parse('Hash{"Index" => Float}').items.first.force_rooted
       expect(type.rooted_tags).to eq('::Hash{"Index" => ::Float}')
     end
   end
@@ -77,7 +77,7 @@ describe Solargraph::ComplexType::UniqueType do
         type = described_class.parse('T')
         narrowing = Solargraph::ComplexType.parse('M')
         narrowed = type.narrow_with(narrowing, api_map)
-        expect(narrowed.first).to be_a(described_class::Intersection)
+        expect(narrowed.items.first).to be_a(described_class::Intersection)
         expect(narrowed.tag).to eq('T & M')
       end
     end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -341,6 +341,36 @@ describe 'YARD type specifier list parsing' do
     xit 'understands reference tags'
   end
 
+  # https://github.com/ruby/rbs/blob/master/docs/syntax.md#intersection-type
+  context 'when parsing RBS intersection types' do
+    it 'parses two conjuncts as a single unique type' do
+      types = Solargraph::ComplexType.parse('String & Comparable')
+      expect(types.length).to eq(1)
+      expect(types.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+      expect(types.first.tag).to eq('String & Comparable')
+      expect(types.to_rbs).to eq('String & Comparable')
+    end
+
+    it 'parses more than two conjuncts' do
+      types = Solargraph::ComplexType.parse('String & Comparable & Enumerable')
+      expect(types.length).to eq(1)
+      expect(types.first.conjuncts.map(&:tag)).to eq(%w[String Comparable Enumerable])
+    end
+
+    it 'distinguishes intersections from unions in the same list' do
+      types = Solargraph::ComplexType.parse('String & Comparable, Integer')
+      expect(types.length).to eq(2)
+      expect(types[0].tag).to eq('String & Comparable')
+      expect(types[1].tag).to eq('Integer')
+    end
+
+    it 'parses intersections nested in subtypes' do
+      types = Solargraph::ComplexType.parse('Array<String & Comparable>')
+      expect(types.first.tag).to eq('Array<String & Comparable>')
+      expect(types.to_rbs).to eq('Array[String & Comparable]')
+    end
+  end
+
   context 'when given non-sensical types by machine users' do
     it 'raises ComplexTypeError for unmatched brackets' do
       expect do

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -802,7 +802,11 @@ describe 'YARD type specifier list parsing' do
         ['generic<A>', 'Array<String>', { 'A' => 'String' }, 'String', { 'A' => 'String' }],
         ['generic<A>', 'Array<generic<B>>', { 'B' => 'Integer' }, 'Array<Integer>',
          { 'B' => 'Integer', 'A' => 'Array<Integer>' }],
-        ['Array<generic<A>>', 'Array<String>', {}, 'Array<String>', { 'A' => 'String' }]
+        ['Array<generic<A>>', 'Array<String>', {}, 'Array<String>', { 'A' => 'String' }],
+        ['Class<generic<A>> & #new', 'Class<String>', {}, 'Class<String> & #new', { 'A' => 'String' }],
+        ['#each & Array<generic<A>>', 'Array<String>', {}, '#each & Array<String>', { 'A' => 'String' }],
+        ['Class<generic<A>> & #new', 'Class<String>', { 'A' => 'Integer' }, 'Class<Integer> & #new',
+         { 'A' => 'Integer' }]
       ].freeze
 
       UNIQUE_METHOD_GENERIC_TESTS.each do |tag, context_type_tag, unfrozen_input_map, expected_tag, expected_output_map|

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -1124,5 +1124,24 @@ describe 'YARD type specifier list parsing' do
       atype = Solargraph::ComplexType.parse('#foo')
       expect(atype.conforms_to?(api_map, ptype, :method_call)).to be(true)
     end
+
+    it 'returns itself unchanged when erasing parameters on an intersection' do
+      itype = Solargraph::ComplexType.parse('Hash{:a => Integer} & Hash{:b => String}').first
+      expect(itype.erase_parameters).to be(itype)
+    end
+
+    it 'falls back to ordinary conjunct matching when an expected conjunct is not a record' do
+      api_map = Solargraph::ApiMap.new
+      atype = Solargraph::ComplexType.parse('Hash{:a => Integer} & String')
+      ptype = Solargraph::ComplexType.parse('Hash{:a => Integer} & String')
+      expect(atype.conforms_to?(api_map, ptype, :assignment)).to be(true)
+    end
+
+    it 'rejects an intersection assignment when the non-record conjunct does not conform' do
+      api_map = Solargraph::ApiMap.new
+      atype = Solargraph::ComplexType.parse('Hash{:a => Integer} & Integer')
+      ptype = Solargraph::ComplexType.parse('Hash{:a => Integer} & String')
+      expect(atype.conforms_to?(api_map, ptype, :assignment)).to be(false)
+    end
   end
 end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -420,23 +420,127 @@ describe 'YARD type specifier list parsing' do
         expect(intersection.conjuncts.map(&:tags)).to eq(['Array(A, B)', 'C'])
       end
 
-      it 'has no standalone grouping syntax, so a bare union in parens reads as an anonymous tuple' do
-        # Unlike `Array(A, B)`, a bare `(A, B)` isn't preceded by a
-        # type name - Solargraph's tag grammar interprets it as an
-        # anonymous tuple (the same way `(A, B)` reads standalone
-        # elsewhere), not as "the union of A and B, grouped". There is
-        # currently no way to write a grouped union as a YARD/RBS tag
-        # *string* - `(A | B) & C` can only be built by translating
-        # real RBS (see RbsTranslator specs) or constructing
-        # ComplexType::UniqueType::Intersection directly.
+      it 'reads a bare comma-separated parenthesized group as an anonymous fixed tuple, not a grouped union' do
+        # `(A, B)` (parentheses, not brackets) is the anonymous form of
+        # the fixed-tuple-parameter syntax (see "anonymous shorthand"
+        # specs below) - its name defaults to Array, and its comma
+        # keeps positional/fixed-arity meaning rather than becoming a
+        # grouped union. `[...]` (below) is the actual grouping
+        # syntax; `(...)` never is, with or without a leading name.
         types = Solargraph::ComplexType.parse('(A, B) & C')
         expect(types.length).to eq(1)
         intersection = types.first
         expect(intersection.conjuncts.length).to eq(2)
         tuple_conjunct = intersection.conjuncts.first.first
-        expect(tuple_conjunct.name).to eq('')
+        expect(tuple_conjunct.name).to eq('Array')
         expect(tuple_conjunct.fixed_parameters?).to be(true)
         expect(tuple_conjunct.subtypes.map(&:tags)).to eq(%w[A B])
+      end
+    end
+
+    # https://github.com/lsegal/yard/pull/1700
+    context 'with the | union operator' do
+      it 'parses a top-level union the same as a comma-separated one' do
+        types = Solargraph::ComplexType.parse('String | Integer')
+        expect(types.length).to eq(2)
+        expect(types.tags).to eq('String, Integer')
+      end
+
+      it 'binds looser than &' do
+        types = Solargraph::ComplexType.parse('A & B | C')
+        expect(types.length).to eq(2)
+        expect(types[0].tag).to eq('A & B')
+        expect(types[1].tag).to eq('C')
+      end
+
+      it 'binds looser than & on either side' do
+        types = Solargraph::ComplexType.parse('A | B & C')
+        expect(types.length).to eq(2)
+        expect(types[0].tag).to eq('A')
+        expect(types[1].tag).to eq('B & C')
+      end
+
+      it 'groups multiple types into a single positional slot of a fixed tuple' do
+        ut = Solargraph::ComplexType.parse('Array(Foo | Bar, Baz)').first
+        expect(ut.fixed_parameters?).to be(true)
+        expect(ut.subtypes.length).to eq(2)
+        expect(ut.subtypes[0].tags).to eq('Foo, Bar')
+        expect(ut.to_rbs).to eq('[(Foo | Bar), Baz]')
+        expect(ut.subtypes[1].tags).to eq('Baz')
+      end
+
+      it 'groups multiple types into a single positional slot of a generic type parameter list' do
+        ut = Solargraph::ComplexType.parse('Result<Success | Failure, Other>').first
+        expect(ut.subtypes.length).to eq(2)
+        expect(ut.subtypes[0].tags).to eq('Success, Failure')
+        expect(ut.to_rbs).to eq('Result[(Success | Failure), Other]')
+      end
+
+      it 'lands on the same result as a comma inside an implicit-union context (Array<...>)' do
+        # Both mean "an Array of Foo-or-Bar". They differ in how many
+        # subtype slots hold the union (one 2-item slot for `|`, two
+        # 1-item slots for `,`) - implicit_union? treats both the same
+        # way, so #tags (which doesn't group-render a slot) matches;
+        # #to_rbs parenthesizes a multi-item slot wherever it appears,
+        # so it doesn't happen to here, same as any other multi-item
+        # subtype slot (see the fixed-tuple specs above).
+        piped = Solargraph::ComplexType.parse('Array<Foo | Bar>').first
+        commaed = Solargraph::ComplexType.parse('Array<Foo, Bar>').first
+        expect(piped.tag).to eq(commaed.tag)
+      end
+    end
+
+    # https://github.com/lsegal/yard/pull/1700
+    context 'with [...] grouping brackets' do
+      it 'groups a union so it can be one conjunct of an intersection' do
+        types = Solargraph::ComplexType.parse('[Foo | Bar] & Baz')
+        expect(types.length).to eq(1)
+        intersection = types.first
+        expect(intersection).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+        expect(intersection.conjuncts.map(&:tags)).to eq(['Foo, Bar', 'Baz'])
+        expect(intersection.to_rbs).to eq('(Foo | Bar) & Baz')
+      end
+
+      it 'groups a union as the second conjunct of an intersection' do
+        types = Solargraph::ComplexType.parse('Foo & [Bar | Baz]')
+        intersection = types.first
+        expect(intersection.conjuncts.map(&:tags)).to eq(['Foo', 'Bar, Baz'])
+        expect(intersection.to_rbs).to eq('Foo & (Bar | Baz)')
+      end
+
+      it 'raises on an unclosed bracket' do
+        expect { Solargraph::ComplexType.parse('[Foo | Bar & Baz') }.to raise_error(Solargraph::ComplexTypeError)
+      end
+    end
+
+    # https://github.com/lsegal/yard/pull/1700
+    context 'with anonymous shorthand forms' do
+      it 'defaults <A> to Array<A>' do
+        ut = Solargraph::ComplexType.parse('<String>').first
+        expect(ut.name).to eq('Array')
+        expect(ut.list_parameters?).to be(true)
+        expect(ut.tag).to eq('Array<String>')
+      end
+
+      it 'defaults (A) to Array(A)' do
+        ut = Solargraph::ComplexType.parse('(String)').first
+        expect(ut.name).to eq('Array')
+        expect(ut.fixed_parameters?).to be(true)
+        expect(ut.tag).to eq('Array(String)')
+      end
+
+      it 'defaults {A=>B} to Hash{A=>B}' do
+        ut = Solargraph::ComplexType.parse('{String=>Integer}').first
+        expect(ut.name).to eq('Hash')
+        expect(ut.hash_parameters?).to be(true)
+        expect(ut.tag).to eq('Hash{String => Integer}')
+        expect(ut.to_rbs).to eq('Hash[String, Integer]')
+      end
+
+      it 'roots an anonymous shorthand the same way its named equivalent would be' do
+        anonymous = Solargraph::ComplexType.parse('<String>').first
+        named = Solargraph::ComplexType.parse('Array<String>').first
+        expect(anonymous.rooted?).to eq(named.rooted?)
       end
     end
   end
@@ -828,7 +932,10 @@ describe 'YARD type specifier list parsing' do
     it 'resolves self keywords in ordered array types' do
       selfy = Solargraph::ComplexType.parse('Array<(String, Symbol, self)>')
       type = selfy.self_to_type(Solargraph::ComplexType.parse('Foo'))
-      expect(type.tag).to eq('Array<(String, Symbol, Foo)>')
+      # the anonymous `(...)` tuple defaults its name to Array (see
+      # "anonymous shorthand" specs below), so it renders with that
+      # name now instead of bare parentheses
+      expect(type.tag).to eq('Array<Array(String, Symbol, Foo)>')
       expect(type.to_rbs).to eq('Array[[String, Symbol, Foo]]')
     end
 

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -285,6 +285,27 @@ describe 'YARD type specifier list parsing' do
       expect(type.to_s).to eq('String')
     end
 
+    # A string literal is opaque: the characters that separate or
+    # group types everywhere else are just content inside one.
+    ['"a,b"', '"a|b"', '"a&b"', '"a<b>"', '"[]"', "'a,b'"].each do |tag|
+      it "treats #{tag} as one literal, not a separator" do
+        type = Solargraph::ComplexType.parse(tag)
+        expect(type.length).to eq(1)
+        expect(type.tag).to eq(tag)
+        expect(type.first.name).to eq(tag)
+      end
+    end
+
+    it 'keeps a string literal whole inside a hash key' do
+      type = Solargraph::ComplexType.parse('Hash{"a,b" => Float}')
+      expect(type.tag).to eq('Hash{"a,b" => Float}')
+      expect(type.to_rbs).to eq('Hash["a,b", Float]')
+    end
+
+    it 'raises on an unclosed string literal' do
+      expect { Solargraph::ComplexType.parse('"abc') }.to raise_error(Solargraph::ComplexTypeError)
+    end
+
     it 'understands literal symbols' do
       type = Solargraph::ComplexType.parse(':foo')
       expect(type.tag).to eq(':foo')
@@ -510,6 +531,35 @@ describe 'YARD type specifier list parsing' do
 
       it 'raises on an unclosed bracket' do
         expect { Solargraph::ComplexType.parse('[Foo | Bar & Baz') }.to raise_error(Solargraph::ComplexTypeError)
+      end
+
+      # `&` binds tighter than the `,`/`|` of a union, so a grouped
+      # conjunct has to keep its brackets when rendered back to a tag -
+      # otherwise `[Foo | Bar] & Baz` renders as `Foo, Bar & Baz` and
+      # parses back as `Foo | (Bar & Baz)`.
+      [
+        '[Foo | Bar] & Baz',
+        'Foo & [Bar | Baz]',
+        'Hash{[Foo | Bar] & Baz => Qux}',
+        '[Foo | Bar] & [Baz | Qux]'
+      ].each do |tag|
+        it "round-trips #{tag} through its tag" do
+          original = Solargraph::ComplexType.parse(tag)
+          reparsed = Solargraph::ComplexType.parse(original.tag)
+          expect(reparsed.tag).to eq(original.tag)
+          expect(reparsed.to_rbs).to eq(original.to_rbs)
+        end
+      end
+
+      it 'brackets a grouped conjunct when generating a tag' do
+        types = Solargraph::ComplexType.parse('[Foo | Bar] & Baz')
+        expect(types.tag).to eq('[Foo, Bar] & Baz')
+        expect(types.to_rbs).to eq('(Foo | Bar) & Baz')
+      end
+
+      it 'leaves a single-type conjunct unbracketed' do
+        types = Solargraph::ComplexType.parse('Foo & Baz')
+        expect(types.tag).to eq('Foo & Baz')
       end
     end
 

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -933,8 +933,7 @@ describe 'YARD type specifier list parsing' do
       selfy = Solargraph::ComplexType.parse('Array<(String, Symbol, self)>')
       type = selfy.self_to_type(Solargraph::ComplexType.parse('Foo'))
       # the anonymous `(...)` tuple defaults its name to Array (see
-      # "anonymous shorthand" specs below), so it renders with that
-      # name now instead of bare parentheses
+      # "anonymous shorthand" specs below)
       expect(type.tag).to eq('Array<Array(String, Symbol, Foo)>')
       expect(type.to_rbs).to eq('Array[[String, Symbol, Foo]]')
     end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -1035,6 +1035,22 @@ describe 'YARD type specifier list parsing' do
       expect(atype.conforms_to?(api_map, ptype, :method_call)).to be(true)
     end
 
+    it 'recognizes a union of intersections conforms with itself' do
+      # Regression test: when an inferred union has a member that is
+      # itself an intersection (e.g. `Class<Foo> & false`), comparing
+      # the union to itself must not fall back to asking that single
+      # conjunct to satisfy the whole union on its own - `false` can't
+      # conform to `Class<Foo> & nil, Class<Foo> & false, nil` by
+      # itself, even though the union as a whole conforms to itself.
+      # This depends on
+      # Intersection#any_union_alternative_conforms? trying each
+      # union alternative individually before falling back to the
+      # "every conjunct must satisfy the whole union" comparison.
+      api_map = Solargraph::ApiMap.new
+      type = Solargraph::ComplexType.parse('Class<Foo> & nil, Class<Foo> & false, nil')
+      expect(type.conforms_to?(api_map, type, :method_call)).to be(true)
+    end
+
     it 'recognizes a literal conforms with its type' do
       pending 'Maybe feasible'
       api_map = Solargraph::ApiMap.new

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -391,6 +391,51 @@ describe 'YARD type specifier list parsing' do
       expect(types.to_rbs).to eq('Array[String & Comparable]')
     end
 
+    describe 'delegating to the first conjunct' do
+      let(:intersection) { Solargraph::ComplexType.parse('String & Comparable').first }
+
+      it 'reports the scope of its first conjunct' do
+        expect(intersection.scope).to eq(:instance)
+      end
+
+      it 'reports rooted for #namespace via the first conjunct' do
+        expect(intersection.namespace).to eq('String')
+      end
+    end
+
+    describe '#all_rooted?' do
+      it 'is true when every conjunct is rooted' do
+        intersection = Solargraph::ComplexType.parse('::String & ::Comparable').first
+        expect(intersection.all_rooted?).to be true
+      end
+
+      it 'is false when any conjunct is unrooted' do
+        intersection = Solargraph::ComplexType.parse('::String & Comparable').first
+        expect(intersection.all_rooted?).to be false
+      end
+    end
+
+    describe '#each_unique_type' do
+      it 'yields the unique type from every conjunct' do
+        intersection = Solargraph::ComplexType.parse('String & Comparable').first
+        yielded = []
+        intersection.each_unique_type { |ut| yielded << ut.tag }
+        expect(yielded).to eq(%w[String Comparable])
+      end
+
+      it 'returns an enumerator when no block is given' do
+        intersection = Solargraph::ComplexType.parse('String & Comparable').first
+        expect(intersection.each_unique_type.map(&:tag)).to eq(%w[String Comparable])
+      end
+    end
+
+    describe '#erase_parameters' do
+      it 'returns itself unchanged' do
+        intersection = Solargraph::ComplexType.parse('Hash{"a" => String} & Comparable').first
+        expect(intersection.erase_parameters).to equal(intersection)
+      end
+    end
+
     # `&` binds tighter than the top-level `,` (union), matching RBS's
     # documented precedence: "A & B | C is (A & B) | C". Our
     # single-pass parser doesn't implement precedence via grouping -

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -364,6 +364,14 @@ describe 'YARD type specifier list parsing' do
 
   # https://github.com/ruby/rbs/blob/master/docs/syntax.md#intersection-type
   context 'when parsing RBS intersection types' do
+    # The four-way record intersection from plate-spinner's
+    # AppleHealthSource#detail, which used to crash a whole typecheck run.
+    let(:intersection_tag) do
+      'Hash{"qty" => Float} & Hash{"expected" => Float} & ' \
+        'Hash{"original_expected" => Float} & Hash{"expected_adjusted" => Boolean}'
+    end
+    let(:detail_tag) { "Hash{Symbol => #{intersection_tag}, nil}" }
+
     it 'parses two conjuncts as a single unique type' do
       types = Solargraph::ComplexType.parse('String & Comparable')
       expect(types.length).to eq(1)
@@ -383,6 +391,43 @@ describe 'YARD type specifier list parsing' do
       expect(types.length).to eq(2)
       expect(types[0].tag).to eq('String & Comparable')
       expect(types[1].tag).to eq('Integer')
+    end
+
+    it 'parses a record type in a value position' do
+      types = Solargraph::ComplexType.parse('Hash{Symbol => Hash{"qty" => Float}}')
+      expect(types.first.tag).to eq('Hash{Symbol => Hash{"qty" => Float}}')
+    end
+
+    it 'parses two record types joined by &' do
+      types = Solargraph::ComplexType.parse('Hash{"qty" => Float} & Hash{"expected" => Float}')
+      expect(types.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+      expect(types.first.conjuncts.map(&:tag)).to eq(['Hash{"qty" => Float}', 'Hash{"expected" => Float}'])
+    end
+
+    it 'parses a four-way record intersection with a trailing nil union member' do
+      types = Solargraph::ComplexType.parse(detail_tag)
+      expect(types.first.tag).to eq(detail_tag)
+      expect(types.first.subtypes.map(&:tag)).to eq([intersection_tag, 'nil'])
+    end
+
+    # Regression: resolve_generics calls transform(name), and an
+    # Intersection's `name` is the synthetic "A & B" string. Forwarding
+    # it renamed every conjunct to the whole intersection, producing a
+    # tag that no longer parses and raising ComplexTypeError out of
+    # ApiMap#get_method_stack.
+    it 'keeps each conjunct name when transformed with the intersection name' do
+      intersection = Solargraph::ComplexType.parse(intersection_tag).first
+      transformed = intersection.transform(intersection.name) { |t| t }
+      expect(transformed.tag).to eq(intersection_tag)
+      expect { Solargraph::ComplexType.parse(transformed.tag) }.not_to raise_error
+    end
+
+    it 'resolves generics on a record intersection without mangling it' do
+      api_map = Solargraph::ApiMap.new
+      hash_pin = api_map.get_path_pins('Hash').first
+      type = Solargraph::ComplexType.parse(intersection_tag).first
+      resolved = type.resolve_generics(hash_pin, Solargraph::ComplexType.parse('Hash{Symbol => String}'))
+      expect { Solargraph::ComplexType.parse(resolved.tag) }.not_to raise_error
     end
 
     it 'parses intersections nested in subtypes' do

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -369,6 +369,76 @@ describe 'YARD type specifier list parsing' do
       expect(types.first.tag).to eq('Array<String & Comparable>')
       expect(types.to_rbs).to eq('Array[String & Comparable]')
     end
+
+    # `&` binds tighter than the top-level `,` (union), matching RBS's
+    # documented precedence: "A & B | C is (A & B) | C". Our
+    # single-pass parser doesn't implement precedence via grouping -
+    # it greedily gathers `&`-separated conjuncts until the next `,`
+    # or end of string - but that happens to produce the same result
+    # as real operator precedence for every case reachable through
+    # this tag-string grammar, since there is no way to write a
+    # standalone grouped union in it (see below).
+    context 'with & and , precedence' do
+      it 'binds & tighter than , when & comes first' do
+        types = Solargraph::ComplexType.parse('A & B, C')
+        expect(types.length).to eq(2)
+        expect(types[0].tag).to eq('A & B')
+        expect(types[1].tag).to eq('C')
+      end
+
+      it 'binds & tighter than , when , comes first' do
+        types = Solargraph::ComplexType.parse('A, B & C')
+        expect(types.length).to eq(2)
+        expect(types[0].tag).to eq('A')
+        expect(types[1].tag).to eq('B & C')
+      end
+
+      it 'handles multiple intersections in the same union' do
+        types = Solargraph::ComplexType.parse('A & B, C & D')
+        expect(types.length).to eq(2)
+        expect(types[0].tag).to eq('A & B')
+        expect(types[1].tag).to eq('C & D')
+      end
+
+      it 'handles intersections of different sizes in the same union' do
+        types = Solargraph::ComplexType.parse('A & B & C, D & E')
+        expect(types.length).to eq(2)
+        expect(types[0].conjuncts.map(&:tags)).to eq(%w[A B C])
+        expect(types[1].conjuncts.map(&:tags)).to eq(%w[D E])
+      end
+    end
+
+    context 'with parentheses' do
+      it 'does not confuse a fixed-tuple-parameter name with a grouped union' do
+        # `Array(A, B)` is Solargraph's existing fixed-tuple-parameter
+        # syntax (a tuple `[A, B]`), unrelated to grouping. `&` after
+        # it still means "intersected with", not "and one more tuple
+        # element".
+        types = Solargraph::ComplexType.parse('Array(A, B) & C')
+        expect(types.length).to eq(1)
+        intersection = types.first
+        expect(intersection.conjuncts.map(&:tags)).to eq(['Array(A, B)', 'C'])
+      end
+
+      it 'has no standalone grouping syntax, so a bare union in parens reads as an anonymous tuple' do
+        # Unlike `Array(A, B)`, a bare `(A, B)` isn't preceded by a
+        # type name - Solargraph's tag grammar interprets it as an
+        # anonymous tuple (the same way `(A, B)` reads standalone
+        # elsewhere), not as "the union of A and B, grouped". There is
+        # currently no way to write a grouped union as a YARD/RBS tag
+        # *string* - `(A | B) & C` can only be built by translating
+        # real RBS (see RbsTranslator specs) or constructing
+        # ComplexType::UniqueType::Intersection directly.
+        types = Solargraph::ComplexType.parse('(A, B) & C')
+        expect(types.length).to eq(1)
+        intersection = types.first
+        expect(intersection.conjuncts.length).to eq(2)
+        tuple_conjunct = intersection.conjuncts.first.first
+        expect(tuple_conjunct.name).to eq('')
+        expect(tuple_conjunct.fixed_parameters?).to be(true)
+        expect(tuple_conjunct.subtypes.map(&:tags)).to eq(%w[A B])
+      end
+    end
   end
 
   context 'when given non-sensical types by machine users' do

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -441,6 +441,45 @@ describe 'YARD type specifier list parsing' do
     end
   end
 
+  # Redundant-member simplification for plain unions, based on a
+  # specific api_map's class hierarchy - a second example of
+  # api-map-driven type simplification, alongside narrow_with's
+  # subtype/mix-in reduction and (differently) qualify's name
+  # resolution. `Superclass, Subclass` is logically the same set as
+  # `Superclass` alone, since every Subclass instance already is a
+  # Superclass instance - but ComplexType.parse has no api_map to
+  # check that with, and no such simplification happens anywhere else
+  # either (verified: nothing in the codebase does this today).
+  #
+  # Not implemented - out of scope for the PR that added this file.
+  # `simplify_redundant_members` below is a proposed/illustrative
+  # interface, not a settled design; these specs exist so the gap is
+  # tracked rather than silently unknown.
+  context 'when simplifying unions of a known superclass and subclass' do
+    let(:api_map) { Solargraph::ApiMap.new }
+
+    let(:source) do
+      Solargraph::Source.load_string(%(
+        class Sup; end
+        class Sub < Sup; end
+      ))
+    end
+
+    before { api_map.map source }
+
+    it 'drops a redundant subclass when the superclass is already listed' do
+      pending 'no api_map-aware union simplification exists yet'
+      type = described_class.parse('Sup, Sub')
+      expect(type.simplify_redundant_members(api_map).tags).to eq('Sup')
+    end
+
+    it 'drops the redundant subclass regardless of listed order' do
+      pending 'no api_map-aware union simplification exists yet'
+      type = described_class.parse('Sub, Sup')
+      expect(type.simplify_redundant_members(api_map).tags).to eq('Sup')
+    end
+  end
+
   context 'when given non-sensical types by machine users' do
     it 'raises ComplexTypeError for unmatched brackets' do
       expect do

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -436,15 +436,15 @@ describe 'YARD type specifier list parsing' do
       expect(types.to_rbs).to eq('Array[String & Comparable]')
     end
 
-    describe 'delegating to the first conjunct' do
+    describe 'questions with no single answer' do
       let(:intersection) { Solargraph::ComplexType.parse('String & Comparable').first }
 
-      it 'reports the scope of its first conjunct' do
-        expect(intersection.scope).to eq(:instance)
+      it 'has no scope of its own to report' do
+        expect { intersection.scope }.to raise_error(NotImplementedError)
       end
 
-      it 'reports rooted for #namespace via the first conjunct' do
-        expect(intersection.namespace).to eq('String')
+      it 'has no namespace of its own to report' do
+        expect { intersection.namespace }.to raise_error(NotImplementedError)
       end
     end
 

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -24,10 +24,10 @@ describe 'YARD type specifier list parsing' do
     it 'parses a single type' do
       types = Solargraph::ComplexType.parse 'String'
       expect(types.items.length).to eq(1)
-      expect(types.first.tag).to eq('String')
-      expect(types.first.name).to eq('String')
-      expect(types.first.subtypes).to be_empty
-      expect(types.first.to_rbs).to eq('String')
+      expect(types.items.first.tag).to eq('String')
+      expect(types.items.first.name).to eq('String')
+      expect(types.items.first.subtypes).to be_empty
+      expect(types.items.first.to_rbs).to eq('String')
     end
 
     it 'parses multiple types as separate arguments' do
@@ -73,9 +73,9 @@ describe 'YARD type specifier list parsing' do
     it 'parses duck types' do
       types = Solargraph::ComplexType.parse('#method')
       expect(types.items.length).to eq(1)
-      expect(types.first.namespace).to eq('Object')
-      expect(types.first.scope).to eq(:instance)
-      expect(types.first.duck_type?).to be(true)
+      expect(types.items.first.namespace).to eq('Object')
+      expect(types.items.first.scope).to eq(:instance)
+      expect(types.items.first.duck_type?).to be(true)
       # RBS solves this problem with type-only signatures
       expect(types.to_rbs).to eq('untyped')
     end
@@ -142,10 +142,10 @@ describe 'YARD type specifier list parsing' do
     it 'parses a subtype' do
       types = Solargraph::ComplexType.parse 'Array<String>'
       expect(types.items.length).to eq(1)
-      expect(types.first.tag).to eq('Array<String>')
-      expect(types.first.name).to eq('Array')
-      expect(types.first.subtypes.length).to eq(1)
-      expect(types.first.subtypes.first.name).to eq('String')
+      expect(types.items.first.tag).to eq('Array<String>')
+      expect(types.items.first.name).to eq('Array')
+      expect(types.items.first.subtypes.length).to eq(1)
+      expect(types.items.first.subtypes.first.name).to eq('String')
       expect(types.to_rbs).to eq('Array[String]')
     end
 
@@ -154,11 +154,11 @@ describe 'YARD type specifier list parsing' do
     it 'parses multiple subtypes' do
       types = Solargraph::ComplexType.parse 'Array<Symbol, String>'
       expect(types.items.length).to eq(1)
-      expect(types.first.tag).to eq('Array<Symbol, String>')
-      expect(types.first.name).to eq('Array')
-      expect(types.first.subtypes.length).to eq(2)
-      expect(types.first.subtypes[0].name).to eq('Symbol')
-      expect(types.first.subtypes[1].name).to eq('String')
+      expect(types.items.first.tag).to eq('Array<Symbol, String>')
+      expect(types.items.first.name).to eq('Array')
+      expect(types.items.first.subtypes.length).to eq(2)
+      expect(types.items.first.subtypes[0].name).to eq('Symbol')
+      expect(types.items.first.subtypes[1].name).to eq('String')
       expect(types.to_rbs).to eq('Array[Symbol, String]')
     end
 
@@ -191,23 +191,23 @@ describe 'YARD type specifier list parsing' do
     it 'parses Hash using hash rocket notation' do
       types = Solargraph::ComplexType.parse('Hash{String => Integer}')
       expect(types.items.length).to eq(1)
-      expect(types.first.tag).to eq('Hash{String => Integer}')
-      expect(types.first.namespace).to eq('Hash')
-      expect(types.first.substring).to eq('{String => Integer}')
-      expect(types.first.key_types.map(&:name)).to eq(['String'])
-      expect(types.first.value_types.map(&:name)).to eq(['Integer'])
+      expect(types.items.first.tag).to eq('Hash{String => Integer}')
+      expect(types.items.first.namespace).to eq('Hash')
+      expect(types.items.first.substring).to eq('{String => Integer}')
+      expect(types.items.first.key_types.map(&:name)).to eq(['String'])
+      expect(types.items.first.value_types.map(&:name)).to eq(['Integer'])
       expect(types.to_rbs).to eq('Hash[String, Integer]')
     end
 
     it 'parses Hash using <> notation' do
       types = Solargraph::ComplexType.parse 'Hash<Symbol, String>'
       expect(types.items.length).to eq(1)
-      expect(types.first.tag).to eq('Hash<Symbol, String>')
-      expect(types.first.name).to eq('Hash')
-      expect(types.first.key_types.length).to eq(1)
-      expect(types.first.key_types[0].name).to eq('Symbol')
-      expect(types.first.subtypes.length).to eq(1)
-      expect(types.first.subtypes[0].name).to eq('String')
+      expect(types.items.first.tag).to eq('Hash<Symbol, String>')
+      expect(types.items.first.name).to eq('Hash')
+      expect(types.items.first.key_types.length).to eq(1)
+      expect(types.items.first.key_types[0].name).to eq('Symbol')
+      expect(types.items.first.subtypes.length).to eq(1)
+      expect(types.items.first.subtypes[0].name).to eq('String')
       expect(types.to_rbs).to eq('Hash[Symbol, String]')
     end
 
@@ -216,7 +216,7 @@ describe 'YARD type specifier list parsing' do
     it 'parses multiple key/value types in hash parameters' do
       types = Solargraph::ComplexType.parse('Hash{String, Symbol => Integer, BigDecimal}')
       expect(types.items.length).to eq(1)
-      type = types.first
+      type = types.items.first
       expect(type.hash_parameters?).to be(true)
       expect(type.key_types.map(&:name)).to eq(%w[String Symbol])
       expect(type.value_types.map(&:name)).to eq(%w[Integer BigDecimal])
@@ -292,7 +292,7 @@ describe 'YARD type specifier list parsing' do
         type = Solargraph::ComplexType.parse(tag)
         expect(type.items.length).to eq(1)
         expect(type.tag).to eq(tag)
-        expect(type.first.name).to eq(tag)
+        expect(type.items.first.name).to eq(tag)
       end
     end
 
@@ -375,15 +375,15 @@ describe 'YARD type specifier list parsing' do
     it 'parses two conjuncts as a single unique type' do
       types = Solargraph::ComplexType.parse('String & Comparable')
       expect(types.items.length).to eq(1)
-      expect(types.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
-      expect(types.first.tag).to eq('String & Comparable')
+      expect(types.items.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+      expect(types.items.first.tag).to eq('String & Comparable')
       expect(types.to_rbs).to eq('String & Comparable')
     end
 
     it 'parses more than two conjuncts' do
       types = Solargraph::ComplexType.parse('String & Comparable & Enumerable')
       expect(types.items.length).to eq(1)
-      expect(types.first.conjuncts.map(&:tag)).to eq(%w[String Comparable Enumerable])
+      expect(types.items.first.conjuncts.map(&:tag)).to eq(%w[String Comparable Enumerable])
     end
 
     it 'distinguishes intersections from unions in the same list' do
@@ -395,19 +395,19 @@ describe 'YARD type specifier list parsing' do
 
     it 'parses a record type in a value position' do
       types = Solargraph::ComplexType.parse('Hash{Symbol => Hash{"qty" => Float}}')
-      expect(types.first.tag).to eq('Hash{Symbol => Hash{"qty" => Float}}')
+      expect(types.items.first.tag).to eq('Hash{Symbol => Hash{"qty" => Float}}')
     end
 
     it 'parses two record types joined by &' do
       types = Solargraph::ComplexType.parse('Hash{"qty" => Float} & Hash{"expected" => Float}')
-      expect(types.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
-      expect(types.first.conjuncts.map(&:tag)).to eq(['Hash{"qty" => Float}', 'Hash{"expected" => Float}'])
+      expect(types.items.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+      expect(types.items.first.conjuncts.map(&:tag)).to eq(['Hash{"qty" => Float}', 'Hash{"expected" => Float}'])
     end
 
     it 'parses a four-way record intersection with a trailing nil union member' do
       types = Solargraph::ComplexType.parse(detail_tag)
-      expect(types.first.tag).to eq(detail_tag)
-      expect(types.first.subtypes.map(&:tag)).to eq([intersection_tag, 'nil'])
+      expect(types.items.first.tag).to eq(detail_tag)
+      expect(types.items.first.subtypes.map(&:tag)).to eq([intersection_tag, 'nil'])
     end
 
     # Regression: resolve_generics calls transform(name), and an
@@ -416,7 +416,7 @@ describe 'YARD type specifier list parsing' do
     # tag that no longer parses and raising ComplexTypeError out of
     # ApiMap#get_method_stack.
     it 'keeps each conjunct name when transformed with the intersection name' do
-      intersection = Solargraph::ComplexType.parse(intersection_tag).first
+      intersection = Solargraph::ComplexType.parse(intersection_tag).items.first
       transformed = intersection.transform(intersection.name) { |t| t }
       expect(transformed.tag).to eq(intersection_tag)
       expect { Solargraph::ComplexType.parse(transformed.tag) }.not_to raise_error
@@ -425,19 +425,19 @@ describe 'YARD type specifier list parsing' do
     it 'resolves generics on a record intersection without mangling it' do
       api_map = Solargraph::ApiMap.new
       hash_pin = api_map.get_path_pins('Hash').first
-      type = Solargraph::ComplexType.parse(intersection_tag).first
+      type = Solargraph::ComplexType.parse(intersection_tag).items.first
       resolved = type.resolve_generics(hash_pin, Solargraph::ComplexType.parse('Hash{Symbol => String}'))
       expect { Solargraph::ComplexType.parse(resolved.tag) }.not_to raise_error
     end
 
     it 'parses intersections nested in subtypes' do
       types = Solargraph::ComplexType.parse('Array<String & Comparable>')
-      expect(types.first.tag).to eq('Array<String & Comparable>')
+      expect(types.items.first.tag).to eq('Array<String & Comparable>')
       expect(types.to_rbs).to eq('Array[String & Comparable]')
     end
 
     describe 'questions with no single answer' do
-      let(:intersection) { Solargraph::ComplexType.parse('String & Comparable').first }
+      let(:intersection) { Solargraph::ComplexType.parse('String & Comparable').items.first }
 
       it 'has no scope of its own to report' do
         expect { intersection.scope }.to raise_error(NotImplementedError)
@@ -450,33 +450,33 @@ describe 'YARD type specifier list parsing' do
 
     describe '#all_rooted?' do
       it 'is true when every conjunct is rooted' do
-        intersection = Solargraph::ComplexType.parse('::String & ::Comparable').first
+        intersection = Solargraph::ComplexType.parse('::String & ::Comparable').items.first
         expect(intersection.all_rooted?).to be true
       end
 
       it 'is false when any conjunct is unrooted' do
-        intersection = Solargraph::ComplexType.parse('::String & Comparable').first
+        intersection = Solargraph::ComplexType.parse('::String & Comparable').items.first
         expect(intersection.all_rooted?).to be false
       end
     end
 
     describe '#each_unique_type' do
       it 'yields the unique type from every conjunct' do
-        intersection = Solargraph::ComplexType.parse('String & Comparable').first
+        intersection = Solargraph::ComplexType.parse('String & Comparable').items.first
         yielded = []
         intersection.each_unique_type { |ut| yielded << ut.tag }
         expect(yielded).to eq(%w[String Comparable])
       end
 
       it 'returns an enumerator when no block is given' do
-        intersection = Solargraph::ComplexType.parse('String & Comparable').first
+        intersection = Solargraph::ComplexType.parse('String & Comparable').items.first
         expect(intersection.each_unique_type.map(&:tag)).to eq(%w[String Comparable])
       end
     end
 
     describe '#erase_parameters' do
       it 'returns itself unchanged' do
-        intersection = Solargraph::ComplexType.parse('Hash{"a" => String} & Comparable').first
+        intersection = Solargraph::ComplexType.parse('Hash{"a" => String} & Comparable').items.first
         expect(intersection.erase_parameters).to equal(intersection)
       end
     end
@@ -527,7 +527,7 @@ describe 'YARD type specifier list parsing' do
         # element".
         types = Solargraph::ComplexType.parse('Array(A, B) & C')
         expect(types.items.length).to eq(1)
-        intersection = types.first
+        intersection = types.items.first
         expect(intersection.conjuncts.map(&:tags)).to eq(['Array(A, B)', 'C'])
       end
 
@@ -540,9 +540,9 @@ describe 'YARD type specifier list parsing' do
         # syntax; `(...)` never is, with or without a leading name.
         types = Solargraph::ComplexType.parse('(A, B) & C')
         expect(types.items.length).to eq(1)
-        intersection = types.first
+        intersection = types.items.first
         expect(intersection.conjuncts.length).to eq(2)
-        tuple_conjunct = intersection.conjuncts.first.first
+        tuple_conjunct = intersection.conjuncts.first.items.first
         expect(tuple_conjunct.name).to eq('Array')
         expect(tuple_conjunct.fixed_parameters?).to be(true)
         expect(tuple_conjunct.subtypes.map(&:tags)).to eq(%w[A B])
@@ -572,7 +572,7 @@ describe 'YARD type specifier list parsing' do
       end
 
       it 'groups multiple types into a single positional slot of a fixed tuple' do
-        ut = Solargraph::ComplexType.parse('Array(Foo | Bar, Baz)').first
+        ut = Solargraph::ComplexType.parse('Array(Foo | Bar, Baz)').items.first
         expect(ut.fixed_parameters?).to be(true)
         expect(ut.subtypes.length).to eq(2)
         expect(ut.subtypes[0].tags).to eq('Foo, Bar')
@@ -581,7 +581,7 @@ describe 'YARD type specifier list parsing' do
       end
 
       it 'groups multiple types into a single positional slot of a generic type parameter list' do
-        ut = Solargraph::ComplexType.parse('Result<Success | Failure, Other>').first
+        ut = Solargraph::ComplexType.parse('Result<Success | Failure, Other>').items.first
         expect(ut.subtypes.length).to eq(2)
         expect(ut.subtypes[0].tags).to eq('Success, Failure')
         expect(ut.to_rbs).to eq('Result[(Success | Failure), Other]')
@@ -595,8 +595,8 @@ describe 'YARD type specifier list parsing' do
         # #to_rbs parenthesizes a multi-item slot wherever it appears,
         # so it doesn't happen to here, same as any other multi-item
         # subtype slot (see the fixed-tuple specs above).
-        piped = Solargraph::ComplexType.parse('Array<Foo | Bar>').first
-        commaed = Solargraph::ComplexType.parse('Array<Foo, Bar>').first
+        piped = Solargraph::ComplexType.parse('Array<Foo | Bar>').items.first
+        commaed = Solargraph::ComplexType.parse('Array<Foo, Bar>').items.first
         expect(piped.tag).to eq(commaed.tag)
       end
     end
@@ -606,7 +606,7 @@ describe 'YARD type specifier list parsing' do
       it 'groups a union so it can be one conjunct of an intersection' do
         types = Solargraph::ComplexType.parse('[Foo | Bar] & Baz')
         expect(types.items.length).to eq(1)
-        intersection = types.first
+        intersection = types.items.first
         expect(intersection).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
         expect(intersection.conjuncts.map(&:tags)).to eq(['Foo, Bar', 'Baz'])
         expect(intersection.to_rbs).to eq('(Foo | Bar) & Baz')
@@ -614,7 +614,7 @@ describe 'YARD type specifier list parsing' do
 
       it 'groups a union as the second conjunct of an intersection' do
         types = Solargraph::ComplexType.parse('Foo & [Bar | Baz]')
-        intersection = types.first
+        intersection = types.items.first
         expect(intersection.conjuncts.map(&:tags)).to eq(['Foo', 'Bar, Baz'])
         expect(intersection.to_rbs).to eq('Foo & (Bar | Baz)')
       end
@@ -656,21 +656,21 @@ describe 'YARD type specifier list parsing' do
     # https://github.com/lsegal/yard/pull/1700
     context 'with anonymous shorthand forms' do
       it 'defaults <A> to Array<A>' do
-        ut = Solargraph::ComplexType.parse('<String>').first
+        ut = Solargraph::ComplexType.parse('<String>').items.first
         expect(ut.name).to eq('Array')
         expect(ut.list_parameters?).to be(true)
         expect(ut.tag).to eq('Array<String>')
       end
 
       it 'defaults (A) to Array(A)' do
-        ut = Solargraph::ComplexType.parse('(String)').first
+        ut = Solargraph::ComplexType.parse('(String)').items.first
         expect(ut.name).to eq('Array')
         expect(ut.fixed_parameters?).to be(true)
         expect(ut.tag).to eq('Array(String)')
       end
 
       it 'defaults {A=>B} to Hash{A=>B}' do
-        ut = Solargraph::ComplexType.parse('{String=>Integer}').first
+        ut = Solargraph::ComplexType.parse('{String=>Integer}').items.first
         expect(ut.name).to eq('Hash')
         expect(ut.hash_parameters?).to be(true)
         expect(ut.tag).to eq('Hash{String => Integer}')
@@ -678,8 +678,8 @@ describe 'YARD type specifier list parsing' do
       end
 
       it 'roots an anonymous shorthand the same way its named equivalent would be' do
-        anonymous = Solargraph::ComplexType.parse('<String>').first
-        named = Solargraph::ComplexType.parse('Array<String>').first
+        anonymous = Solargraph::ComplexType.parse('<String>').items.first
+        named = Solargraph::ComplexType.parse('Array<String>').items.first
         expect(anonymous.rooted?).to eq(named.rooted?)
       end
     end
@@ -765,16 +765,16 @@ describe 'YARD type specifier list parsing' do
       it 'detects namespace and scope for simple types' do
         types = Solargraph::ComplexType.parse 'Class'
         expect(types.items.length).to eq(1)
-        expect(types.first.namespace).to eq('Class')
-        expect(types.first.scope).to eq(:instance)
+        expect(types.items.first.namespace).to eq('Class')
+        expect(types.items.first.scope).to eq(:instance)
         expect(types.to_rbs).to eq('Class')
       end
 
       it 'detects namespace and scope for classes with subtypes' do
         types = Solargraph::ComplexType.parse 'Class<String>'
         expect(types.items.length).to eq(1)
-        expect(types.first.namespace).to eq('String')
-        expect(types.first.scope).to eq(:class)
+        expect(types.items.first.namespace).to eq('String')
+        expect(types.items.first.scope).to eq(:class)
         # RBS doesn't support individual class types like this
         expect(types.to_rbs).to eq('Class')
       end
@@ -782,8 +782,8 @@ describe 'YARD type specifier list parsing' do
       it 'detects namespace and scope for modules with subtypes' do
         types = Solargraph::ComplexType.parse 'Module<Foo>'
         expect(types.items.length).to eq(1)
-        expect(types.first.namespace).to eq('Foo')
-        expect(types.first.scope).to eq(:class)
+        expect(types.items.first.namespace).to eq('Foo')
+        expect(types.items.first.scope).to eq(:class)
         expect(types.to_rbs).to eq('Module')
         multiple_types = Solargraph::ComplexType.parse 'Module<Foo>, Class<Bar>, String, nil'
         expect(multiple_types.items.length).to eq(4)
@@ -825,9 +825,9 @@ describe 'YARD type specifier list parsing' do
       %w[nil Nil NIL].each do |t|
         types = Solargraph::ComplexType.parse(t)
         expect(types.items.length).to eq(1)
-        expect(types.first.namespace).to eq('NilClass')
-        expect(types.first.scope).to eq(:instance)
-        expect(types.first.nil_type?).to be(true)
+        expect(types.items.first.namespace).to eq('NilClass')
+        expect(types.items.first.scope).to eq(:instance)
+        expect(types.items.first.nil_type?).to be(true)
         expect(types.to_rbs).to eq('nil')
       end
     end
@@ -902,7 +902,7 @@ describe 'YARD type specifier list parsing' do
       UNIQUE_METHOD_GENERIC_TESTS.each do |tag, context_type_tag, unfrozen_input_map, expected_tag, expected_output_map|
         context "when resolveing #{tag} with context #{context_type_tag} and existing resolved generics #{unfrozen_input_map}" do
           let(:complex_type) { Solargraph::ComplexType.parse(tag) }
-          let(:unique_type) { complex_type.first }
+          let(:unique_type) { complex_type.items.first }
 
           let(:context_type) { Solargraph::ComplexType.parse(context_type_tag) }
           let(:generic_value) { unfrozen_input_map.transform_values! { |tag| Solargraph::ComplexType.parse(tag) } }
@@ -931,14 +931,14 @@ describe 'YARD type specifier list parsing' do
 
     it 'identifies list parameter types' do
       types = Solargraph::ComplexType.parse('Array<String, Symbol>')
-      expect(types.first.list_parameters?).to be(true)
+      expect(types.items.first.list_parameters?).to be(true)
       expect(types.to_rbs).to eq('Array[String, Symbol]')
     end
 
     it 'identifies fixed parameters' do
       types = Solargraph::ComplexType.parse('Array(String, Symbol)')
-      expect(types.first.fixed_parameters?).to be(true)
-      expect(types.first.subtypes.map(&:namespace)).to eq(%w[String Symbol])
+      expect(types.items.first.fixed_parameters?).to be(true)
+      expect(types.items.first.subtypes.map(&:namespace)).to eq(%w[String Symbol])
       # RBS doesn't use a type name for tuples, just the [] shorthand
       expect(types.to_rbs).to eq('[String, Symbol]')
     end
@@ -946,7 +946,7 @@ describe 'YARD type specifier list parsing' do
     it 'identifies hash parameters' do
       types = Solargraph::ComplexType.parse('Hash{String => Integer}')
       expect(types.items.length).to eq(1)
-      expect(types.first.hash_parameters?).to be(true)
+      expect(types.items.first.hash_parameters?).to be(true)
     end
   end
 
@@ -995,13 +995,13 @@ describe 'YARD type specifier list parsing' do
     it 'parses recursive subtypes' do
       types = Solargraph::ComplexType.parse('Array<Hash{String => Integer}>')
       expect(types.items.length).to eq(1)
-      expect(types.first.namespace).to eq('Array')
-      expect(types.first.substring).to eq('<Hash{String => Integer}>')
-      expect(types.first.subtypes.length).to eq(1)
-      expect(types.first.subtypes.first.namespace).to eq('Hash')
-      expect(types.first.subtypes.first.substring).to eq('{String => Integer}')
-      expect(types.first.subtypes.first.key_types.map(&:namespace)).to eq(['String'])
-      expect(types.first.subtypes.first.value_types.map(&:namespace)).to eq(['Integer'])
+      expect(types.items.first.namespace).to eq('Array')
+      expect(types.items.first.substring).to eq('<Hash{String => Integer}>')
+      expect(types.items.first.subtypes.length).to eq(1)
+      expect(types.items.first.subtypes.first.namespace).to eq('Hash')
+      expect(types.items.first.subtypes.first.substring).to eq('{String => Integer}')
+      expect(types.items.first.subtypes.first.key_types.map(&:namespace)).to eq(['String'])
+      expect(types.items.first.subtypes.first.value_types.map(&:namespace)).to eq(['Integer'])
       expect(types.to_rbs).to eq('Array[Hash[String, Integer]]')
     end
 
@@ -1012,7 +1012,7 @@ describe 'YARD type specifier list parsing' do
     end
 
     it 'qualifies types with list parameters' do
-      original = Solargraph::ComplexType.parse('Class<Bar>').first
+      original = Solargraph::ComplexType.parse('Class<Bar>').items.first
       expect(original).not_to be_rooted
       qualified = original.qualify(foo_bar_api_map, 'Foo')
       expect(qualified.tag).to eq('Class<Foo::Bar>')
@@ -1022,7 +1022,7 @@ describe 'YARD type specifier list parsing' do
     end
 
     it 'qualifies types with fixed parameters' do
-      original = Solargraph::ComplexType.parse('Array(String, Bar)').first
+      original = Solargraph::ComplexType.parse('Array(String, Bar)').items.first
       expect(original.to_rbs).to eq('[String, Bar]')
       qualified = original.qualify(foo_bar_api_map, 'Foo')
       expect(qualified).to be_rooted
@@ -1031,7 +1031,7 @@ describe 'YARD type specifier list parsing' do
     end
 
     it 'qualifies types with hash parameters' do
-      original = Solargraph::ComplexType.parse('Hash{String => Bar}').first
+      original = Solargraph::ComplexType.parse('Hash{String => Bar}').items.first
       qualified = original.qualify(foo_bar_api_map, 'Foo')
       expect(qualified.tag).to eq('Hash{String => Foo::Bar}')
       expect(qualified.to_rbs).to eq('::Hash[::String, ::Foo::Bar]')
@@ -1171,7 +1171,7 @@ describe 'YARD type specifier list parsing' do
     end
 
     it 'returns itself unchanged when erasing parameters on an intersection' do
-      itype = Solargraph::ComplexType.parse('Hash{:a => Integer} & Hash{:b => String}').first
+      itype = Solargraph::ComplexType.parse('Hash{:a => Integer} & Hash{:b => String}').items.first
       expect(itype.erase_parameters).to be(itype)
     end
 

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -847,7 +847,7 @@ describe 'YARD type specifier list parsing' do
       ['generic<T>', 'nil', 'true', 'false', ':123', '123'].each do |tag|
         it "treats #{tag} as rooted" do
           types = Solargraph::ComplexType.parse(tag)
-          expect(types.all?(&:rooted?)).to be(true)
+          expect(types.items.all?(&:rooted?)).to be(true)
         end
       end
     end
@@ -1007,7 +1007,7 @@ describe 'YARD type specifier list parsing' do
 
     it 'allows various parameterized types as parameterized type' do
       types = Solargraph::ComplexType.parse('Array<String>, Hash{String => Symbol}, Array(String, Integer)')
-      expect(types.all?(&:parameters?)).to be(true)
+      expect(types.items.all?(&:parameters?)).to be(true)
       expect(types.to_rbs).to eq('(Array[String] | Hash[String, Symbol] | [String, Integer])')
     end
 

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -33,16 +33,16 @@ describe 'YARD type specifier list parsing' do
     it 'parses multiple types as separate arguments' do
       types = Solargraph::ComplexType.parse 'String', 'Integer'
       expect(types.length).to eq(2)
-      expect(types[0].tag).to eq('String')
-      expect(types[1].tag).to eq('Integer')
+      expect(types.items[0].tag).to eq('String')
+      expect(types.items[1].tag).to eq('Integer')
       expect(types.to_rbs).to eq('(String | Integer)')
     end
 
     it 'parses multiple types in a string' do
       types = Solargraph::ComplexType.parse 'String, Integer'
       expect(types.length).to eq(2)
-      expect(types[0].tag).to eq('String')
-      expect(types[1].tag).to eq('Integer')
+      expect(types.items[0].tag).to eq('String')
+      expect(types.items[1].tag).to eq('Integer')
       expect(types.to_rbs).to eq('(String | Integer)')
     end
 
@@ -56,9 +56,9 @@ describe 'YARD type specifier list parsing' do
     it 'parses class, generic class and literal in a string' do
       types = Solargraph::ComplexType.parse 'String, Array<String>, nil'
       expect(types.length).to eq(3)
-      expect(types[0].tag).to eq('String')
-      expect(types[1].tag).to eq('Array<String>')
-      expect(types[2].tag).to eq('nil')
+      expect(types.items[0].tag).to eq('String')
+      expect(types.items[1].tag).to eq('Array<String>')
+      expect(types.items[2].tag).to eq('nil')
       expect(types.to_rbs).to eq('(String | Array[String] | nil)')
     end
 
@@ -389,8 +389,8 @@ describe 'YARD type specifier list parsing' do
     it 'distinguishes intersections from unions in the same list' do
       types = Solargraph::ComplexType.parse('String & Comparable, Integer')
       expect(types.length).to eq(2)
-      expect(types[0].tag).to eq('String & Comparable')
-      expect(types[1].tag).to eq('Integer')
+      expect(types.items[0].tag).to eq('String & Comparable')
+      expect(types.items[1].tag).to eq('Integer')
     end
 
     it 'parses a record type in a value position' do
@@ -493,29 +493,29 @@ describe 'YARD type specifier list parsing' do
       it 'binds & tighter than , when & comes first' do
         types = Solargraph::ComplexType.parse('A & B, C')
         expect(types.length).to eq(2)
-        expect(types[0].tag).to eq('A & B')
-        expect(types[1].tag).to eq('C')
+        expect(types.items[0].tag).to eq('A & B')
+        expect(types.items[1].tag).to eq('C')
       end
 
       it 'binds & tighter than , when , comes first' do
         types = Solargraph::ComplexType.parse('A, B & C')
         expect(types.length).to eq(2)
-        expect(types[0].tag).to eq('A')
-        expect(types[1].tag).to eq('B & C')
+        expect(types.items[0].tag).to eq('A')
+        expect(types.items[1].tag).to eq('B & C')
       end
 
       it 'handles multiple intersections in the same union' do
         types = Solargraph::ComplexType.parse('A & B, C & D')
         expect(types.length).to eq(2)
-        expect(types[0].tag).to eq('A & B')
-        expect(types[1].tag).to eq('C & D')
+        expect(types.items[0].tag).to eq('A & B')
+        expect(types.items[1].tag).to eq('C & D')
       end
 
       it 'handles intersections of different sizes in the same union' do
         types = Solargraph::ComplexType.parse('A & B & C, D & E')
         expect(types.length).to eq(2)
-        expect(types[0].conjuncts.map(&:tags)).to eq(%w[A B C])
-        expect(types[1].conjuncts.map(&:tags)).to eq(%w[D E])
+        expect(types.items[0].conjuncts.map(&:tags)).to eq(%w[A B C])
+        expect(types.items[1].conjuncts.map(&:tags)).to eq(%w[D E])
       end
     end
 
@@ -560,15 +560,15 @@ describe 'YARD type specifier list parsing' do
       it 'binds looser than &' do
         types = Solargraph::ComplexType.parse('A & B | C')
         expect(types.length).to eq(2)
-        expect(types[0].tag).to eq('A & B')
-        expect(types[1].tag).to eq('C')
+        expect(types.items[0].tag).to eq('A & B')
+        expect(types.items[1].tag).to eq('C')
       end
 
       it 'binds looser than & on either side' do
         types = Solargraph::ComplexType.parse('A | B & C')
         expect(types.length).to eq(2)
-        expect(types[0].tag).to eq('A')
-        expect(types[1].tag).to eq('B & C')
+        expect(types.items[0].tag).to eq('A')
+        expect(types.items[1].tag).to eq('B & C')
       end
 
       it 'groups multiple types into a single positional slot of a fixed tuple' do

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -12,18 +12,18 @@ describe 'YARD type specifier list parsing' do
     #
     it 'parses zero types as separate arguments' do
       types = Solargraph::ComplexType.parse
-      expect(types.length).to eq(0)
+      expect(types.items.length).to eq(0)
     end
 
     it 'parses zero types as a string' do
       pending('special case being added')
       types = Solargraph::ComplexType.parse ''
-      expect(types.length).to eq(0)
+      expect(types.items.length).to eq(0)
     end
 
     it 'parses a single type' do
       types = Solargraph::ComplexType.parse 'String'
-      expect(types.length).to eq(1)
+      expect(types.items.length).to eq(1)
       expect(types.first.tag).to eq('String')
       expect(types.first.name).to eq('String')
       expect(types.first.subtypes).to be_empty
@@ -32,7 +32,7 @@ describe 'YARD type specifier list parsing' do
 
     it 'parses multiple types as separate arguments' do
       types = Solargraph::ComplexType.parse 'String', 'Integer'
-      expect(types.length).to eq(2)
+      expect(types.items.length).to eq(2)
       expect(types.items[0].tag).to eq('String')
       expect(types.items[1].tag).to eq('Integer')
       expect(types.to_rbs).to eq('(String | Integer)')
@@ -40,7 +40,7 @@ describe 'YARD type specifier list parsing' do
 
     it 'parses multiple types in a string' do
       types = Solargraph::ComplexType.parse 'String, Integer'
-      expect(types.length).to eq(2)
+      expect(types.items.length).to eq(2)
       expect(types.items[0].tag).to eq('String')
       expect(types.items[1].tag).to eq('Integer')
       expect(types.to_rbs).to eq('(String | Integer)')
@@ -55,7 +55,7 @@ describe 'YARD type specifier list parsing' do
     #   def find(query) finder_code_here end
     it 'parses class, generic class and literal in a string' do
       types = Solargraph::ComplexType.parse 'String, Array<String>, nil'
-      expect(types.length).to eq(3)
+      expect(types.items.length).to eq(3)
       expect(types.items[0].tag).to eq('String')
       expect(types.items[1].tag).to eq('Array<String>')
       expect(types.items[2].tag).to eq('nil')
@@ -72,7 +72,7 @@ describe 'YARD type specifier list parsing' do
     # allowed.
     it 'parses duck types' do
       types = Solargraph::ComplexType.parse('#method')
-      expect(types.length).to eq(1)
+      expect(types.items.length).to eq(1)
       expect(types.first.namespace).to eq('Object')
       expect(types.first.scope).to eq(:instance)
       expect(types.first.duck_type?).to be(true)
@@ -141,7 +141,7 @@ describe 'YARD type specifier list parsing' do
 
     it 'parses a subtype' do
       types = Solargraph::ComplexType.parse 'Array<String>'
-      expect(types.length).to eq(1)
+      expect(types.items.length).to eq(1)
       expect(types.first.tag).to eq('Array<String>')
       expect(types.first.name).to eq('Array')
       expect(types.first.subtypes.length).to eq(1)
@@ -153,7 +153,7 @@ describe 'YARD type specifier list parsing' do
 
     it 'parses multiple subtypes' do
       types = Solargraph::ComplexType.parse 'Array<Symbol, String>'
-      expect(types.length).to eq(1)
+      expect(types.items.length).to eq(1)
       expect(types.first.tag).to eq('Array<Symbol, String>')
       expect(types.first.name).to eq('Array')
       expect(types.first.subtypes.length).to eq(2)
@@ -190,7 +190,7 @@ describe 'YARD type specifier list parsing' do
     # specific syntax: Hash{KeyTypes=>ValueTypes}.
     it 'parses Hash using hash rocket notation' do
       types = Solargraph::ComplexType.parse('Hash{String => Integer}')
-      expect(types.length).to eq(1)
+      expect(types.items.length).to eq(1)
       expect(types.first.tag).to eq('Hash{String => Integer}')
       expect(types.first.namespace).to eq('Hash')
       expect(types.first.substring).to eq('{String => Integer}')
@@ -201,7 +201,7 @@ describe 'YARD type specifier list parsing' do
 
     it 'parses Hash using <> notation' do
       types = Solargraph::ComplexType.parse 'Hash<Symbol, String>'
-      expect(types.length).to eq(1)
+      expect(types.items.length).to eq(1)
       expect(types.first.tag).to eq('Hash<Symbol, String>')
       expect(types.first.name).to eq('Hash')
       expect(types.first.key_types.length).to eq(1)
@@ -215,7 +215,7 @@ describe 'YARD type specifier list parsing' do
     # types separated by commas."
     it 'parses multiple key/value types in hash parameters' do
       types = Solargraph::ComplexType.parse('Hash{String, Symbol => Integer, BigDecimal}')
-      expect(types.length).to eq(1)
+      expect(types.items.length).to eq(1)
       type = types.first
       expect(type.hash_parameters?).to be(true)
       expect(type.key_types.map(&:name)).to eq(%w[String Symbol])
@@ -290,7 +290,7 @@ describe 'YARD type specifier list parsing' do
     ['"a,b"', '"a|b"', '"a&b"', '"a<b>"', '"[]"', "'a,b'"].each do |tag|
       it "treats #{tag} as one literal, not a separator" do
         type = Solargraph::ComplexType.parse(tag)
-        expect(type.length).to eq(1)
+        expect(type.items.length).to eq(1)
         expect(type.tag).to eq(tag)
         expect(type.first.name).to eq(tag)
       end
@@ -374,7 +374,7 @@ describe 'YARD type specifier list parsing' do
 
     it 'parses two conjuncts as a single unique type' do
       types = Solargraph::ComplexType.parse('String & Comparable')
-      expect(types.length).to eq(1)
+      expect(types.items.length).to eq(1)
       expect(types.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
       expect(types.first.tag).to eq('String & Comparable')
       expect(types.to_rbs).to eq('String & Comparable')
@@ -382,13 +382,13 @@ describe 'YARD type specifier list parsing' do
 
     it 'parses more than two conjuncts' do
       types = Solargraph::ComplexType.parse('String & Comparable & Enumerable')
-      expect(types.length).to eq(1)
+      expect(types.items.length).to eq(1)
       expect(types.first.conjuncts.map(&:tag)).to eq(%w[String Comparable Enumerable])
     end
 
     it 'distinguishes intersections from unions in the same list' do
       types = Solargraph::ComplexType.parse('String & Comparable, Integer')
-      expect(types.length).to eq(2)
+      expect(types.items.length).to eq(2)
       expect(types.items[0].tag).to eq('String & Comparable')
       expect(types.items[1].tag).to eq('Integer')
     end
@@ -492,28 +492,28 @@ describe 'YARD type specifier list parsing' do
     context 'with & and , precedence' do
       it 'binds & tighter than , when & comes first' do
         types = Solargraph::ComplexType.parse('A & B, C')
-        expect(types.length).to eq(2)
+        expect(types.items.length).to eq(2)
         expect(types.items[0].tag).to eq('A & B')
         expect(types.items[1].tag).to eq('C')
       end
 
       it 'binds & tighter than , when , comes first' do
         types = Solargraph::ComplexType.parse('A, B & C')
-        expect(types.length).to eq(2)
+        expect(types.items.length).to eq(2)
         expect(types.items[0].tag).to eq('A')
         expect(types.items[1].tag).to eq('B & C')
       end
 
       it 'handles multiple intersections in the same union' do
         types = Solargraph::ComplexType.parse('A & B, C & D')
-        expect(types.length).to eq(2)
+        expect(types.items.length).to eq(2)
         expect(types.items[0].tag).to eq('A & B')
         expect(types.items[1].tag).to eq('C & D')
       end
 
       it 'handles intersections of different sizes in the same union' do
         types = Solargraph::ComplexType.parse('A & B & C, D & E')
-        expect(types.length).to eq(2)
+        expect(types.items.length).to eq(2)
         expect(types.items[0].conjuncts.map(&:tags)).to eq(%w[A B C])
         expect(types.items[1].conjuncts.map(&:tags)).to eq(%w[D E])
       end
@@ -526,7 +526,7 @@ describe 'YARD type specifier list parsing' do
         # it still means "intersected with", not "and one more tuple
         # element".
         types = Solargraph::ComplexType.parse('Array(A, B) & C')
-        expect(types.length).to eq(1)
+        expect(types.items.length).to eq(1)
         intersection = types.first
         expect(intersection.conjuncts.map(&:tags)).to eq(['Array(A, B)', 'C'])
       end
@@ -539,7 +539,7 @@ describe 'YARD type specifier list parsing' do
         # grouped union. `[...]` (below) is the actual grouping
         # syntax; `(...)` never is, with or without a leading name.
         types = Solargraph::ComplexType.parse('(A, B) & C')
-        expect(types.length).to eq(1)
+        expect(types.items.length).to eq(1)
         intersection = types.first
         expect(intersection.conjuncts.length).to eq(2)
         tuple_conjunct = intersection.conjuncts.first.first
@@ -553,20 +553,20 @@ describe 'YARD type specifier list parsing' do
     context 'with the | union operator' do
       it 'parses a top-level union the same as a comma-separated one' do
         types = Solargraph::ComplexType.parse('String | Integer')
-        expect(types.length).to eq(2)
+        expect(types.items.length).to eq(2)
         expect(types.tags).to eq('String, Integer')
       end
 
       it 'binds looser than &' do
         types = Solargraph::ComplexType.parse('A & B | C')
-        expect(types.length).to eq(2)
+        expect(types.items.length).to eq(2)
         expect(types.items[0].tag).to eq('A & B')
         expect(types.items[1].tag).to eq('C')
       end
 
       it 'binds looser than & on either side' do
         types = Solargraph::ComplexType.parse('A | B & C')
-        expect(types.length).to eq(2)
+        expect(types.items.length).to eq(2)
         expect(types.items[0].tag).to eq('A')
         expect(types.items[1].tag).to eq('B & C')
       end
@@ -605,7 +605,7 @@ describe 'YARD type specifier list parsing' do
     context 'with [...] grouping brackets' do
       it 'groups a union so it can be one conjunct of an intersection' do
         types = Solargraph::ComplexType.parse('[Foo | Bar] & Baz')
-        expect(types.length).to eq(1)
+        expect(types.items.length).to eq(1)
         intersection = types.first
         expect(intersection).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
         expect(intersection.conjuncts.map(&:tags)).to eq(['Foo, Bar', 'Baz'])
@@ -764,7 +764,7 @@ describe 'YARD type specifier list parsing' do
 
       it 'detects namespace and scope for simple types' do
         types = Solargraph::ComplexType.parse 'Class'
-        expect(types.length).to eq(1)
+        expect(types.items.length).to eq(1)
         expect(types.first.namespace).to eq('Class')
         expect(types.first.scope).to eq(:instance)
         expect(types.to_rbs).to eq('Class')
@@ -772,7 +772,7 @@ describe 'YARD type specifier list parsing' do
 
       it 'detects namespace and scope for classes with subtypes' do
         types = Solargraph::ComplexType.parse 'Class<String>'
-        expect(types.length).to eq(1)
+        expect(types.items.length).to eq(1)
         expect(types.first.namespace).to eq('String')
         expect(types.first.scope).to eq(:class)
         # RBS doesn't support individual class types like this
@@ -781,12 +781,12 @@ describe 'YARD type specifier list parsing' do
 
       it 'detects namespace and scope for modules with subtypes' do
         types = Solargraph::ComplexType.parse 'Module<Foo>'
-        expect(types.length).to eq(1)
+        expect(types.items.length).to eq(1)
         expect(types.first.namespace).to eq('Foo')
         expect(types.first.scope).to eq(:class)
         expect(types.to_rbs).to eq('Module')
         multiple_types = Solargraph::ComplexType.parse 'Module<Foo>, Class<Bar>, String, nil'
-        expect(multiple_types.length).to eq(4)
+        expect(multiple_types.items.length).to eq(4)
         expect(multiple_types.namespaces).to eq(%w[Foo Bar String NilClass])
         # RBS doesn't support individual module types like this
         expect(multiple_types.to_rbs).to eq('(Module | Class | String | nil)')
@@ -824,7 +824,7 @@ describe 'YARD type specifier list parsing' do
     it 'identifies nil types regardless of capitalization' do
       %w[nil Nil NIL].each do |t|
         types = Solargraph::ComplexType.parse(t)
-        expect(types.length).to eq(1)
+        expect(types.items.length).to eq(1)
         expect(types.first.namespace).to eq('NilClass')
         expect(types.first.scope).to eq(:instance)
         expect(types.first.nil_type?).to be(true)
@@ -908,7 +908,7 @@ describe 'YARD type specifier list parsing' do
           let(:generic_value) { unfrozen_input_map.transform_values! { |tag| Solargraph::ComplexType.parse(tag) } }
 
           it "#{tag} is a unique type" do
-            expect(complex_type.length).to eq(1)
+            expect(complex_type.items.length).to eq(1)
           end
 
           it "resolves to #{expected_tag} with updated map #{expected_output_map}" do
@@ -945,7 +945,7 @@ describe 'YARD type specifier list parsing' do
 
     it 'identifies hash parameters' do
       types = Solargraph::ComplexType.parse('Hash{String => Integer}')
-      expect(types.length).to eq(1)
+      expect(types.items.length).to eq(1)
       expect(types.first.hash_parameters?).to be(true)
     end
   end
@@ -994,7 +994,7 @@ describe 'YARD type specifier list parsing' do
 
     it 'parses recursive subtypes' do
       types = Solargraph::ComplexType.parse('Array<Hash{String => Integer}>')
-      expect(types.length).to eq(1)
+      expect(types.items.length).to eq(1)
       expect(types.first.namespace).to eq('Array')
       expect(types.first.substring).to eq('<Hash{String => Integer}>')
       expect(types.first.subtypes.length).to eq(1)

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -835,13 +835,13 @@ describe 'YARD type specifier list parsing' do
     context 'when defining rooted and unrooted concept' do
       it 'identify rooted types' do
         types = Solargraph::ComplexType.parse '::Array'
-        expect(types.map(&:rooted?)).to eq([true])
+        expect(types.items.map(&:rooted?)).to eq([true])
         expect(types.to_rbs).to eq('::Array')
       end
 
       it 'identify unrooted types' do
         types = Solargraph::ComplexType.parse 'Array'
-        expect(types.map(&:rooted?)).to eq([false])
+        expect(types.items.map(&:rooted?)).to eq([false])
       end
 
       ['generic<T>', 'nil', 'true', 'false', ':123', '123'].each do |tag|

--- a/spec/convention/activesupport_concern_spec.rb
+++ b/spec/convention/activesupport_concern_spec.rb
@@ -187,17 +187,13 @@ describe Solargraph::Convention::ActiveSupportConcern do
       end
 
       it 'finds superclass method pin parameter type' do
-        # RBS core's Hash#[] started taking its key as the _Key duck-type
-        # interface instead of the generic K as of RBS 4.1.0, so instantiating
-        # Hash{Symbol => untyped} no longer substitutes the param type on
-        # newer RBS - see ruby/rbs core/hash.rbs.
-        expected = if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
-                     ['::Hash::_Key']
-                   else
-                     ['Symbol']
-                   end
+        # RBS core's Hash#[] takes its key as the _Key duck-type interface
+        # rather than the generic K as of RBS 4.1.0. RbsTranslator stubs
+        # that back to K (see RBS_INTERFACE_TO_GENERIC), so instantiating
+        # Hash{Symbol => untyped} substitutes the param type on every RBS
+        # version rather than leaving the interface unresolved.
         expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
-                 .uniq).to eq(expected)
+                 .uniq).to eq(['Symbol'])
       end
     end
   end

--- a/spec/convention/activesupport_concern_spec.rb
+++ b/spec/convention/activesupport_concern_spec.rb
@@ -187,11 +187,6 @@ describe Solargraph::Convention::ActiveSupportConcern do
       end
 
       it 'finds superclass method pin parameter type' do
-        # RBS core's Hash#[] takes its key as the _Key duck-type interface
-        # rather than the generic K as of RBS 4.1.0. RbsTranslator stubs
-        # that back to K (see RBS_INTERFACE_TO_GENERIC), so instantiating
-        # Hash{Symbol => untyped} substitutes the param type on every RBS
-        # version rather than leaving the interface unresolved.
         expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
                  .uniq).to eq(['Symbol'])
       end

--- a/spec/convention/activesupport_concern_spec.rb
+++ b/spec/convention/activesupport_concern_spec.rb
@@ -93,7 +93,7 @@ describe Solargraph::Convention::ActiveSupportConcern do
     end
 
     it 'is able to typify from superclass' do
-      expect(pins.first.typify(api_map).map(&:tag)).to include('Numeric')
+      expect(pins.first.typify(api_map).items.map(&:tag)).to include('Numeric')
     end
   end
 

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -24,6 +24,50 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.to_s).to eq('ReproBase')
   end
 
+  it 'narrows to an intersection when is_a? checks an unrelated mix-in' do
+    source = Solargraph::Source.load_string(%(
+      module M; end
+      class T; end
+      # @param t [T]
+      def verify(t)
+        if t.is_a?(M)
+          t
+        else
+          t
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [6, 10])
+    expect(clip.infer.to_s).to eq('T & M')
+
+    clip = api_map.clip_at('test.rb', [8, 10])
+    expect(clip.infer.to_s).to eq('T')
+  end
+
+  it 'does not build a redundant intersection when the mix-in is already included' do
+    source = Solargraph::Source.load_string(%(
+      module M; end
+      class T
+        include M
+      end
+      # @param t [T]
+      def verify(t)
+        if t.is_a?(M)
+          t
+        else
+          t
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [7, 10])
+    expect(clip.infer.to_s).to eq('T')
+
+    clip = api_map.clip_at('test.rb', [9, 10])
+    expect(clip.infer.to_s).to eq('T')
+  end
+
   it 'uses is_a? in a simple if() with a union to refine types' do
     source = Solargraph::Source.load_string(%(
       class ReproBase; end

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -683,11 +683,8 @@ describe Solargraph::Pin::Method do
       expect(pin.return_type.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
     end
 
-    # RBS allows a union as one member of an intersection - `&` and
-    # `|` nest freely in either direction, unlike the YARD/tag-string
-    # grammar (see complex_type_spec.rb "with parentheses"), so these
-    # go through RbsTranslator directly instead of round-tripping
-    # through a tag string.
+    # RBS nests `&`/`|` freely, unlike the YARD/tag-string grammar, so
+    # these go through RbsTranslator instead of a round-tripped tag string.
     context 'with a union nested inside an intersection' do
       it 'preserves a union as the first conjunct' do
         source = Solargraph::Source.load_string(%(

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -635,6 +635,19 @@ describe Solargraph::Pin::Method do
       expect(pin.return_type.to_s).to eq('Boolean')
     end
 
+    it 'sets intersection return types' do
+      # https://github.com/castwide/solargraph/issues/1229
+      source = Solargraph::Source.load_string(%(
+        #: () -> (String & Comparable)
+        def foo; end
+      ))
+      api_map = Solargraph::ApiMap.new
+      api_map.map source
+      pin = api_map.get_path_pins('#foo').first
+      expect(pin.return_type.to_s).to eq('String & Comparable')
+      expect(pin.return_type.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+    end
+
     it 'sets required positional parameters' do
       source = Solargraph::Source.load_string(%(
         #: (String) -> bool

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -694,15 +694,7 @@ describe Solargraph::Pin::Method do
         expect(intersection.to_rbs).to eq('::String & ::Comparable & ::Enumerable')
       end
 
-      it 'is not round-trippable through the tag string, unlike to_rbs' do
-        # The object model built directly by RbsTranslator is
-        # correct (verified above), but there is no way to express a
-        # grouped union as a plain tag *string* (see
-        # complex_type_spec.rb). Re-parsing the informal `tag`/`to_s`
-        # output therefore does not reproduce the same structure -
-        # this is a known, documented limitation, not a silent
-        # inconsistency. `to_rbs` uses real RBS grouping syntax and
-        # does round-trip correctly.
+      it 'round-trips through both the tag string and to_rbs' do
         source = Solargraph::Source.load_string(%(
           #: () -> ((String | Integer) & Comparable)
           def foo; end
@@ -711,17 +703,20 @@ describe Solargraph::Pin::Method do
         api_map.map source
         pin = api_map.get_path_pins('#foo').first
         original = pin.return_type
-        expect(original.tag).to eq('String, Integer & Comparable')
 
+        # `&` binds tighter than a union's `,`, so the grouped conjunct
+        # keeps its brackets and re-parses to the same structure.
+        expect(original.tag).to eq('[String, Integer] & Comparable')
         reparsed = Solargraph::ComplexType.parse(original.tag)
-        expect(reparsed.length).to eq(2)
-        expect(reparsed[0].tag).to eq('String')
-        expect(reparsed[1].tag).to eq('Integer & Comparable')
+        expect(reparsed.length).to eq(1)
+        expect(reparsed.first.conjuncts.map(&:tags)).to eq(['String, Integer', 'Comparable'])
 
-        # to_rbs, by contrast, produces real RBS syntax and round-trips
-        # correctly through RBS's own parser (not Solargraph's tag parser,
-        # which speaks a different dialect and doesn't understand `|` or
-        # bare grouping parens).
+        # rooted_tag keeps the `::` prefixes that tag drops, so it is
+        # the form that round-trips to an identical RBS rendering.
+        expect(Solargraph::ComplexType.parse(original.rooted_tag).to_rbs).to eq(original.to_rbs)
+
+        # to_rbs uses RBS's own grouping syntax and round-trips through
+        # RBS's parser rather than Solargraph's tag parser.
         rbs_type = RBS::Parser.parse_type(original.to_rbs)
         reparsed_via_rbs = Solargraph::RbsTranslator.to_complex_type(rbs_type)
         expect(reparsed_via_rbs.length).to eq(1)

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -636,7 +636,6 @@ describe Solargraph::Pin::Method do
     end
 
     it 'sets intersection return types' do
-      # https://github.com/castwide/solargraph/issues/1229
       source = Solargraph::Source.load_string(%(
         #: () -> (String & Comparable)
         def foo; end
@@ -646,6 +645,88 @@ describe Solargraph::Pin::Method do
       pin = api_map.get_path_pins('#foo').first
       expect(pin.return_type.to_s).to eq('String & Comparable')
       expect(pin.return_type.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+    end
+
+    # RBS allows a union as one member of an intersection - `&` and
+    # `|` nest freely in either direction, unlike the YARD/tag-string
+    # grammar (see complex_type_spec.rb "with parentheses"), so these
+    # go through RbsTranslator directly instead of round-tripping
+    # through a tag string.
+    context 'with a union nested inside an intersection' do
+      it 'preserves a union as the first conjunct' do
+        source = Solargraph::Source.load_string(%(
+          #: () -> ((String | Integer) & Comparable)
+          def foo; end
+        ))
+        api_map = Solargraph::ApiMap.new
+        api_map.map source
+        pin = api_map.get_path_pins('#foo').first
+        intersection = pin.return_type.first
+        expect(intersection).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+        expect(intersection.conjuncts.length).to eq(2)
+        expect(intersection.conjuncts.first.length).to eq(2)
+        expect(intersection.conjuncts.first.tags).to eq('String, Integer')
+        expect(intersection.to_rbs).to eq('(::String | ::Integer) & ::Comparable')
+      end
+
+      it 'preserves a union as the second conjunct' do
+        source = Solargraph::Source.load_string(%(
+          #: () -> (Comparable & (String | Integer))
+          def foo; end
+        ))
+        api_map = Solargraph::ApiMap.new
+        api_map.map source
+        pin = api_map.get_path_pins('#foo').first
+        intersection = pin.return_type.first
+        expect(intersection.conjuncts.last.length).to eq(2)
+        expect(intersection.to_rbs).to eq('::Comparable & (::String | ::Integer)')
+      end
+
+      it 'flattens a nested intersection into the same conjunct list' do
+        source = Solargraph::Source.load_string(%(
+          #: () -> (String & (Comparable & Enumerable))
+          def foo; end
+        ))
+        api_map = Solargraph::ApiMap.new
+        api_map.map source
+        pin = api_map.get_path_pins('#foo').first
+        intersection = pin.return_type.first
+        expect(intersection.to_rbs).to eq('::String & ::Comparable & ::Enumerable')
+      end
+
+      it 'is not round-trippable through the tag string, unlike to_rbs' do
+        # The object model built directly by RbsTranslator is
+        # correct (verified above), but there is no way to express a
+        # grouped union as a plain tag *string* (see
+        # complex_type_spec.rb). Re-parsing the informal `tag`/`to_s`
+        # output therefore does not reproduce the same structure -
+        # this is a known, documented limitation, not a silent
+        # inconsistency. `to_rbs` uses real RBS grouping syntax and
+        # does round-trip correctly.
+        source = Solargraph::Source.load_string(%(
+          #: () -> ((String | Integer) & Comparable)
+          def foo; end
+        ))
+        api_map = Solargraph::ApiMap.new
+        api_map.map source
+        pin = api_map.get_path_pins('#foo').first
+        original = pin.return_type
+        expect(original.tag).to eq('String, Integer & Comparable')
+
+        reparsed = Solargraph::ComplexType.parse(original.tag)
+        expect(reparsed.length).to eq(2)
+        expect(reparsed[0].tag).to eq('String')
+        expect(reparsed[1].tag).to eq('Integer & Comparable')
+
+        # to_rbs, by contrast, produces real RBS syntax and round-trips
+        # correctly through RBS's own parser (not Solargraph's tag parser,
+        # which speaks a different dialect and doesn't understand `|` or
+        # bare grouping parens).
+        rbs_type = RBS::Parser.parse_type(original.to_rbs)
+        reparsed_via_rbs = Solargraph::RbsTranslator.to_complex_type(rbs_type)
+        expect(reparsed_via_rbs.length).to eq(1)
+        expect(reparsed_via_rbs.first.conjuncts.map(&:tags)).to eq(['String, Integer', 'Comparable'])
+      end
     end
 
     it 'sets required positional parameters' do

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -698,7 +698,7 @@ describe Solargraph::Pin::Method do
       api_map.map source
       pin = api_map.get_path_pins('#foo').first
       expect(pin.return_type.to_s).to eq('String & Comparable')
-      expect(pin.return_type.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+      expect(pin.return_type.items.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
     end
 
     # RBS nests `&`/`|` freely, unlike the YARD/tag-string grammar, so
@@ -712,7 +712,7 @@ describe Solargraph::Pin::Method do
         api_map = Solargraph::ApiMap.new
         api_map.map source
         pin = api_map.get_path_pins('#foo').first
-        intersection = pin.return_type.first
+        intersection = pin.return_type.items.first
         expect(intersection).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
         expect(intersection.conjuncts.length).to eq(2)
         expect(intersection.conjuncts.first.items.length).to eq(2)
@@ -728,7 +728,7 @@ describe Solargraph::Pin::Method do
         api_map = Solargraph::ApiMap.new
         api_map.map source
         pin = api_map.get_path_pins('#foo').first
-        intersection = pin.return_type.first
+        intersection = pin.return_type.items.first
         expect(intersection.conjuncts.last.items.length).to eq(2)
         expect(intersection.to_rbs).to eq('::Comparable & (::String | ::Integer)')
       end
@@ -741,7 +741,7 @@ describe Solargraph::Pin::Method do
         api_map = Solargraph::ApiMap.new
         api_map.map source
         pin = api_map.get_path_pins('#foo').first
-        intersection = pin.return_type.first
+        intersection = pin.return_type.items.first
         expect(intersection.to_rbs).to eq('::String & ::Comparable & ::Enumerable')
       end
 
@@ -760,7 +760,7 @@ describe Solargraph::Pin::Method do
         expect(original.tag).to eq('[String, Integer] & Comparable')
         reparsed = Solargraph::ComplexType.parse(original.tag)
         expect(reparsed.items.length).to eq(1)
-        expect(reparsed.first.conjuncts.map(&:tags)).to eq(['String, Integer', 'Comparable'])
+        expect(reparsed.items.first.conjuncts.map(&:tags)).to eq(['String, Integer', 'Comparable'])
 
         # rooted_tag keeps the `::` prefixes that tag drops, so it is
         # the form that round-trips to an identical RBS rendering.
@@ -771,7 +771,7 @@ describe Solargraph::Pin::Method do
         rbs_type = RBS::Parser.parse_type(original.to_rbs)
         reparsed_via_rbs = Solargraph::RbsTranslator.to_complex_type(rbs_type)
         expect(reparsed_via_rbs.items.length).to eq(1)
-        expect(reparsed_via_rbs.first.conjuncts.map(&:tags)).to eq(['String, Integer', 'Comparable'])
+        expect(reparsed_via_rbs.items.first.conjuncts.map(&:tags)).to eq(['String, Integer', 'Comparable'])
       end
     end
 

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -715,7 +715,7 @@ describe Solargraph::Pin::Method do
         intersection = pin.return_type.first
         expect(intersection).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
         expect(intersection.conjuncts.length).to eq(2)
-        expect(intersection.conjuncts.first.length).to eq(2)
+        expect(intersection.conjuncts.first.items.length).to eq(2)
         expect(intersection.conjuncts.first.tags).to eq('String, Integer')
         expect(intersection.to_rbs).to eq('(::String | ::Integer) & ::Comparable')
       end
@@ -729,7 +729,7 @@ describe Solargraph::Pin::Method do
         api_map.map source
         pin = api_map.get_path_pins('#foo').first
         intersection = pin.return_type.first
-        expect(intersection.conjuncts.last.length).to eq(2)
+        expect(intersection.conjuncts.last.items.length).to eq(2)
         expect(intersection.to_rbs).to eq('::Comparable & (::String | ::Integer)')
       end
 
@@ -759,7 +759,7 @@ describe Solargraph::Pin::Method do
         # keeps its brackets and re-parses to the same structure.
         expect(original.tag).to eq('[String, Integer] & Comparable')
         reparsed = Solargraph::ComplexType.parse(original.tag)
-        expect(reparsed.length).to eq(1)
+        expect(reparsed.items.length).to eq(1)
         expect(reparsed.first.conjuncts.map(&:tags)).to eq(['String, Integer', 'Comparable'])
 
         # rooted_tag keeps the `::` prefixes that tag drops, so it is
@@ -770,7 +770,7 @@ describe Solargraph::Pin::Method do
         # RBS's parser rather than Solargraph's tag parser.
         rbs_type = RBS::Parser.parse_type(original.to_rbs)
         reparsed_via_rbs = Solargraph::RbsTranslator.to_complex_type(rbs_type)
-        expect(reparsed_via_rbs.length).to eq(1)
+        expect(reparsed_via_rbs.items.length).to eq(1)
         expect(reparsed_via_rbs.first.conjuncts.map(&:tags)).to eq(['String, Integer', 'Comparable'])
       end
     end

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -128,6 +128,24 @@ describe Solargraph::Pin::Method do
     expect(result.length).to eq(signatures.length)
   end
 
+  it 'keeps a signature per parameter type when combining, so an argument type can still select its own return type' do
+    pending 'parameter types never widen when combining, so the type_arity check that would keep the signatures apart cannot fire'
+    closure = Solargraph::Pin::Namespace.new(name: 'Foo', type: :class)
+    integer_pin = described_class.new(closure: closure, name: 'add', scope: :instance, comments: %(
+@overload add(bar)
+  @param bar [Integer]
+  @return [Integer]
+    ))
+    float_pin = described_class.new(closure: closure, name: 'add', scope: :instance, comments: %(
+@overload add(bar)
+  @param bar [Float]
+  @return [Float]
+    ))
+    combined = integer_pin.combine_with(float_pin)
+    expect(combined.signatures.length).to eq(2)
+    expect(combined.signatures.flat_map { |sig| sig.parameters.map { |param| param.return_type.rooted_tags } }).to contain_exactly('Integer', 'Float')
+  end
+
   it 'does not merge with changes in parameters' do
     # @todo Method pin parameters are pins now
     pin1 = described_class.new(name: 'bar', parameters: %w[one two])

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -162,11 +162,6 @@ describe Solargraph::RbsMap::Conversions do
       end
 
       it 'finds superclass method pin parameter type' do
-        # RBS core's Hash#[] takes its key as the _Key duck-type interface
-        # rather than the generic K as of RBS 4.1.0. RbsTranslator stubs
-        # that back to K (see RBS_INTERFACE_TO_GENERIC), so instantiating
-        # Hash{Symbol => untyped} substitutes the param type on every RBS
-        # version rather than leaving the interface unresolved.
         expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
                  .uniq).to eq(['Symbol'])
       end

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -142,17 +142,13 @@ describe Solargraph::RbsMap::Conversions do
       end
 
       it 'finds superclass method pin parameter type' do
-        # RBS core's Hash#[] started taking its key as the _Key duck-type
-        # interface instead of the generic K as of RBS 4.1.0, so instantiating
-        # Hash{Symbol => untyped} no longer substitutes the param type on
-        # newer RBS - see ruby/rbs core/hash.rbs.
-        expected = if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
-                     ['::Hash::_Key']
-                   else
-                     ['Symbol']
-                   end
+        # RBS core's Hash#[] takes its key as the _Key duck-type interface
+        # rather than the generic K as of RBS 4.1.0. RbsTranslator stubs
+        # that back to K (see RBS_INTERFACE_TO_GENERIC), so instantiating
+        # Hash{Symbol => untyped} substitutes the param type on every RBS
+        # version rather than leaving the interface unresolved.
         expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
-                 .uniq).to eq(expected)
+                 .uniq).to eq(['Symbol'])
       end
     end
   end

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -93,6 +93,26 @@ describe Solargraph::RbsMap::Conversions do
         expect(method_pin.return_type.tag).to eq('undefined')
       end
     end
+
+    context 'with an implicitly-returns-nil annotation' do
+      subject(:method_pin) { conversions.pins.find { |pin| pin.path == 'Foo#bar' } }
+
+      let(:rbs) do
+        <<~RBS
+          class Foo
+            def bar: %a{implicitly-returns-nil} () -> ::String
+          end
+        RBS
+      end
+
+      it 'adds nil to the declared return type' do
+        expect(method_pin.return_type.tags).to eq('String, nil')
+      end
+
+      it 'keeps the declared return type rooted' do
+        expect(method_pin.return_type.rooted_tags).to eq('::String, nil')
+      end
+    end
   end
 
   context 'with standard loads for solargraph project' do

--- a/spec/rbs_translator_spec.rb
+++ b/spec/rbs_translator_spec.rb
@@ -26,6 +26,22 @@ describe Solargraph::RbsTranslator do
     described_class.to_complex_type(RBS::Parser.parse_type(rbs_string))
   end
 
+  context 'with RBS 4.1+ structural key interfaces' do
+    it 'stubs Hash::_Key in as the class\'s own K' do
+      expect(translate('Hash::_Key').tag).to eq('generic<K>')
+    end
+
+    it 'leaves an unqualified _Key alone' do
+      # the stub is keyed on the well-known qualified name, so an
+      # unrelated interface that happens to be called _Key is untouched
+      expect(translate('_Key').tag).to eq('_Key')
+    end
+
+    it 'leaves other interfaces alone' do
+      expect(translate('Enumerable::_Each').tag).to eq('Enumerable::_Each')
+    end
+  end
+
   context 'when translating at the top level (already correct)' do
     it 'builds a real intersection from a union conjunct' do
       type = translate('(Integer | String) & Comparable')

--- a/spec/rbs_translator_spec.rb
+++ b/spec/rbs_translator_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rbs'
+
+# RbsTranslator.to_complex_type builds ComplexType::UniqueType::Intersection
+# directly from the RBS AST for a *top-level* RBS::Types::Intersection,
+# rather than flattening it through a joined tag string - see
+# spec/pin/method_spec.rb "with a union nested inside an intersection".
+# That fix only covers the entry point used for method return types and
+# parameter types. Every other place a type gets recursively translated
+# - RBS::Types::Optional, RBS::Types::Union members, RBS::Types::Tuple
+# elements, and generic type arguments (Array[...], Hash[...], and any
+# other name with type args, via build_type/type_tag) - still goes
+# through the same flattening `type_to_tag` string join that caused the
+# original bug, whenever the nested type is an intersection with a union
+# conjunct. A plain (non-union-conjunct) intersection nested anywhere is
+# fine; only the combination of "intersection containing a union" nested
+# below the top level is affected.
+#
+# This spec covers that whole class of position, not just the one
+# reported.
+describe Solargraph::RbsTranslator do
+  # @param rbs_string [String]
+  # @return [Solargraph::ComplexType]
+  def translate rbs_string
+    described_class.to_complex_type(RBS::Parser.parse_type(rbs_string))
+  end
+
+  context 'when translating at the top level (already correct)' do
+    it 'builds a real intersection from a union conjunct' do
+      type = translate('(Integer | String) & Comparable')
+      expect(type.length).to eq(1)
+      expect(type.to_rbs).to eq('(::Integer | ::String) & ::Comparable')
+    end
+  end
+
+  context 'with a plain intersection (no union conjunct) nested anywhere' do
+    it 'translates correctly inside a generic argument' do
+      type = translate('Array[Integer & Comparable]')
+      expect(type.to_rbs).to eq('::Array[::Integer & ::Comparable]')
+    end
+  end
+
+  context 'with a union-in-intersection nested below the top level' do
+    it 'preserves grouping inside a generic argument (Array)' do
+      type = translate('Array[(Integer | String) & Comparable]')
+      expect(type.to_rbs).to eq('::Array[(::Integer | ::String) & ::Comparable]')
+    end
+
+    it 'preserves grouping inside a Hash value' do
+      type = translate('Hash[Symbol, (Integer | String) & Comparable]')
+      expect(type.to_rbs).to eq('::Hash[::Symbol, (::Integer | ::String) & ::Comparable]')
+    end
+
+    it 'preserves grouping inside a Hash key' do
+      type = translate('Hash[(Integer | String) & Comparable, Symbol]')
+      expect(type.to_rbs).to eq('::Hash[(::Integer | ::String) & ::Comparable, ::Symbol]')
+    end
+
+    it 'preserves grouping when doubly nested (Array of Hash values)' do
+      type = translate('Array[Hash[Symbol, (Integer | String) & Comparable]]')
+      expect(type.to_rbs).to eq('::Array[::Hash[::Symbol, (::Integer | ::String) & ::Comparable]]')
+    end
+
+    it 'preserves grouping under an optional (nilable) wrapper' do
+      type = translate('((Integer | String) & Comparable)?')
+      # T? is T | nil - a 2-item union of [the intersection, nil], not a
+      # 3-item union that leaks the intersection's own first conjunct
+      # out to the top level.
+      expect(type.length).to eq(2)
+      expect(type.to_rbs).to eq('((::Integer | ::String) & ::Comparable | nil)')
+    end
+
+    it 'preserves grouping as one member of an outer union' do
+      # NilClass renders as the literal `nil` tag everywhere in this
+      # codebase (see RBS_TO_YARD_TYPE), independent of this fix.
+      type = translate('((Integer | String) & Comparable) | NilClass')
+      expect(type.length).to eq(2)
+      expect(type.to_rbs).to eq('((::Integer | ::String) & ::Comparable | nil)')
+    end
+
+    it 'preserves grouping as a tuple element' do
+      type = translate('[(Integer | String) & Comparable, Integer]')
+      # a 2-element tuple - the intersection, then Integer - not a
+      # 3-element tuple that leaks the intersection's first conjunct out
+      # as its own element.
+      expect(type.to_rbs).to eq('[(::Integer | ::String) & ::Comparable, ::Integer]')
+    end
+  end
+end

--- a/spec/rbs_translator_spec.rb
+++ b/spec/rbs_translator_spec.rb
@@ -42,6 +42,16 @@ describe Solargraph::RbsTranslator do
     end
   end
 
+  context 'with literal type arguments' do
+    it 'roots the class name but not a symbol literal argument' do
+      expect(translate('::Array[:Sym]').rooted_tags).to eq('::Array<:Sym>')
+    end
+
+    it 'roots the class name but not a capitalized string literal key' do
+      expect(translate('::Hash["Index", ::Float]').rooted_tags).to eq('::Hash{"Index" => ::Float}')
+    end
+  end
+
   context 'when translating at the top level (already correct)' do
     it 'builds a real intersection from a union conjunct' do
       type = translate('(Integer | String) & Comparable')

--- a/spec/rbs_translator_spec.rb
+++ b/spec/rbs_translator_spec.rb
@@ -55,7 +55,7 @@ describe Solargraph::RbsTranslator do
   context 'when translating at the top level (already correct)' do
     it 'builds a real intersection from a union conjunct' do
       type = translate('(Integer | String) & Comparable')
-      expect(type.length).to eq(1)
+      expect(type.items.length).to eq(1)
       expect(type.to_rbs).to eq('(::Integer | ::String) & ::Comparable')
     end
   end
@@ -93,7 +93,7 @@ describe Solargraph::RbsTranslator do
       # T? is T | nil - a 2-item union of [the intersection, nil], not a
       # 3-item union that leaks the intersection's own first conjunct
       # out to the top level.
-      expect(type.length).to eq(2)
+      expect(type.items.length).to eq(2)
       expect(type.to_rbs).to eq('((::Integer | ::String) & ::Comparable | nil)')
     end
 
@@ -101,7 +101,7 @@ describe Solargraph::RbsTranslator do
       # NilClass renders as the literal `nil` tag everywhere in this
       # codebase (see RBS_TO_YARD_TYPE), independent of this fix.
       type = translate('((Integer | String) & Comparable) | NilClass')
-      expect(type.length).to eq(2)
+      expect(type.items.length).to eq(2)
       expect(type.to_rbs).to eq('((::Integer | ::String) & ::Comparable | nil)')
     end
 

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -389,6 +389,37 @@ describe Solargraph::Source::Chain::Call do
     expect(type.tag).to eq('undefined')
   end
 
+  it 'denies calls on a two-class union when loose union mode is off and only one class defines the method' do
+    # The nilable spec above exercises this same "every union member must
+    # define the method, unless loose_unions" rule, but only via
+    # nullable?/without_nil stripping nil out first - it never actually
+    # tests the general two-real-class case. Found while checking whether
+    # the Call#resolve fix for intersections (A & B <: A, A & B <: B)
+    # regressed real union semantics (A, B calls require both) - it
+    # doesn't (this reproduces identically on unmodified HEAD, before that
+    # fix), but this specific shape was never covered.
+    pending 'strict union mode does not deny a call when only one of two plain classes defines it'
+    source = Solargraph::Source.load_string(%(
+      class A
+        # @return [void]
+        def foo; end
+      end
+
+      class B
+      end
+
+      # @type [A, B]
+      x = make
+      x.foo
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new(loose_unions: false)
+    api_map.map source
+
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(10, 8))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    expect(type.tag).to eq('undefined')
+  end
+
   it 'preserves unions in value position in Hash' do
     source = Solargraph::Source.load_string(%(
       # @param params [Hash{String => Array<undefined>, Hash{String => undefined}, String, Integer}]

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -737,4 +737,38 @@ describe Solargraph::Source::Chain::Call do
     clip = api_map.clip_at('test.rb', [14, 14])
     expect(clip.infer.rooted_tags).to eq('::Set<::Foo::Bar::Symbol>')
   end
+
+  describe '#literal_node_tag' do
+    # literal_node_tag (#1231) turns a literal argument AST node into
+    # the dispatch tag used to narrow an intersection's Hash-keyed
+    # conjuncts to the one whose key_types match a call's literal
+    # argument - e.g. `period.fetch("Index")` narrowing
+    # `Hash{"Index" => Float} & Hash{"Triggers" => Array}` down to the
+    # first conjunct. Called from #unique_type_key_verdict.
+    let(:call) { described_class.new('fetch') }
+
+    it 'tags a string literal node' do
+      node = Solargraph::Parser.parse('"Index"')
+      expect(call.send(:literal_node_tag, node)).to eq('"Index"')
+    end
+
+    it 'tags a symbol literal node' do
+      node = Solargraph::Parser.parse(':Index')
+      expect(call.send(:literal_node_tag, node)).to eq(':Index')
+    end
+
+    it 'tags an integer literal node' do
+      node = Solargraph::Parser.parse('1')
+      expect(call.send(:literal_node_tag, node)).to eq('1')
+    end
+
+    it 'returns nil for a non-literal node' do
+      node = Solargraph::Parser.parse('[1, 2]')
+      expect(call.send(:literal_node_tag, node)).to be_nil
+    end
+
+    it 'returns nil for a non-AST-node argument' do
+      expect(call.send(:literal_node_tag, nil)).to be_nil
+    end
+  end
 end

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -732,34 +732,4 @@ describe Solargraph::Source::Chain::Call do
     clip = api_map.clip_at('test.rb', [14, 14])
     expect(clip.infer.rooted_tags).to eq('::Set<::Foo::Bar::Symbol>')
   end
-
-  describe '#literal_node_tag' do
-    # Turns a literal argument node into the dispatch tag used to
-    # narrow an intersection's Hash-keyed conjuncts by key.
-    let(:call) { described_class.new('fetch') }
-
-    it 'tags a string literal node' do
-      node = Solargraph::Parser.parse('"Index"')
-      expect(call.send(:literal_node_tag, node)).to eq('"Index"')
-    end
-
-    it 'tags a symbol literal node' do
-      node = Solargraph::Parser.parse(':Index')
-      expect(call.send(:literal_node_tag, node)).to eq(':Index')
-    end
-
-    it 'tags an integer literal node' do
-      node = Solargraph::Parser.parse('1')
-      expect(call.send(:literal_node_tag, node)).to eq('1')
-    end
-
-    it 'returns nil for a non-literal node' do
-      node = Solargraph::Parser.parse('[1, 2]')
-      expect(call.send(:literal_node_tag, node)).to be_nil
-    end
-
-    it 'returns nil for a non-AST-node argument' do
-      expect(call.send(:literal_node_tag, nil)).to be_nil
-    end
-  end
 end

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -390,14 +390,11 @@ describe Solargraph::Source::Chain::Call do
   end
 
   it 'denies calls on a two-class union when loose union mode is off and only one class defines the method' do
-    # The nilable spec above exercises this same "every union member must
+    # The nilable spec above covers the same "every union member must
     # define the method, unless loose_unions" rule, but only via
-    # nullable?/without_nil stripping nil out first - it never actually
-    # tests the general two-real-class case. Found while checking whether
-    # the Call#resolve fix for intersections (A & B <: A, A & B <: B)
-    # regressed real union semantics (A, B calls require both) - it
-    # doesn't (this reproduces identically on unmodified HEAD, before that
-    # fix), but this specific shape was never covered.
+    # nullable?/without_nil stripping nil out first, not the general
+    # two-real-class case. This is a pre-existing gap, unrelated to
+    # intersections: it reproduces identically on unmodified master.
     pending 'strict union mode does not deny a call when only one of two plain classes defines it'
     source = Solargraph::Source.load_string(%(
       class A

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -417,11 +417,6 @@ describe Solargraph::Source::Chain::Call do
   end
 
   it 'denies calls on a two-class union when loose union mode is off and only one class defines the method' do
-    # The nilable spec above covers the same "every union member must
-    # define the method, unless loose_unions" rule, but only via
-    # nullable?/without_nil stripping nil out first, not the general
-    # two-real-class case. This is a pre-existing gap, unrelated to
-    # intersections: it reproduces identically on unmodified master.
     pending 'strict union mode does not deny a call when only one of two plain classes defines it'
     source = Solargraph::Source.load_string(%(
       class A
@@ -739,12 +734,8 @@ describe Solargraph::Source::Chain::Call do
   end
 
   describe '#literal_node_tag' do
-    # literal_node_tag (#1231) turns a literal argument AST node into
-    # the dispatch tag used to narrow an intersection's Hash-keyed
-    # conjuncts to the one whose key_types match a call's literal
-    # argument - e.g. `period.fetch("Index")` narrowing
-    # `Hash{"Index" => Float} & Hash{"Triggers" => Array}` down to the
-    # first conjunct. Called from #unique_type_key_verdict.
+    # Turns a literal argument node into the dispatch tag used to
+    # narrow an intersection's Hash-keyed conjuncts by key.
     let(:call) { described_class.new('fetch') }
 
     it 'tags a string literal node' do

--- a/spec/source/chain/literal_spec.rb
+++ b/spec/source/chain/literal_spec.rb
@@ -7,4 +7,13 @@ describe Solargraph::Source::Chain::Literal do
     pin = literal.resolve(api_map, nil, nil).first
     expect(pin.return_type.tag).to eq('String')
   end
+
+  it 'does not corrupt a string literal containing a comma, once literal typing is restored' do
+    pending 'https://github.com/castwide/solargraph/pull/1223'
+    node = Solargraph::Parser.parse("'a, b'", 'test.rb', 0)
+    literal = described_class.new('String', node)
+    api_map = Solargraph::ApiMap.new
+    pin = literal.resolve(api_map, nil, nil).first
+    expect(pin.return_type.tag).to eq('"a, b"')
+  end
 end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -3107,4 +3107,20 @@ describe Solargraph::SourceMap::Clip do
     expect(paths).to include('String#upcase')
     expect(paths).to include('Integer#abs')
   end
+
+  it 'binds a generic through an intersection param at the call site' do
+    source = Solargraph::Source.load_string(%(
+      # @generic T
+      # @param clazz [Class<generic<T>> & #new]
+      # @return [generic<T>]
+      def make(clazz)
+        raise
+      end
+      make(String)
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    clip = api_map.clip_at('test.rb', [7, 8])
+    expect(clip.infer.tag).to eq('String')
+  end
 end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -3113,10 +3113,10 @@ describe Solargraph::SourceMap::Clip do
       # @generic T
       # @param clazz [Class<generic<T>> & #new]
       # @return [generic<T>]
-      def make(clazz)
+      def construct_it(clazz)
         raise
       end
-      make(String)
+      construct_it(String)
     ), 'test.rb')
     api_map = Solargraph::ApiMap.new
     api_map.map source

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -2284,7 +2284,7 @@ describe Solargraph::SourceMap::Clip do
   end
 
   it 'uses types to determine overload to match' do
-    pending 'Overload resolution by argument type currently unions signatures instead of narrowing (see castwide/solargraph#1246)'
+    pending 'https://github.com/castwide/solargraph/issues/1246'
     source = Solargraph::Source.load_string(%(
       # @generic A
       # @generic B
@@ -2314,7 +2314,7 @@ describe Solargraph::SourceMap::Clip do
   end
 
   it 'uses types to determine overload of [] to match' do
-    pending 'Overload resolution by argument type currently unions signatures instead of narrowing (see castwide/solargraph#1246)'
+    pending 'https://github.com/castwide/solargraph/issues/1246'
     source = Solargraph::Source.load_string(%(
       # @generic A
       # @generic B

--- a/spec/type_checker/levels/strict_spec.rb
+++ b/spec/type_checker/levels/strict_spec.rb
@@ -268,26 +268,6 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.first.message).to include('Wrong argument type')
     end
 
-    it 'accepts a duck-typed argument declared with the exact same duck type as expected' do
-      # duck_types_match? used to check the expected duck type against
-      # inferred.namespace/#scope, which are only meaningful for a
-      # nominal type - a duck-typed *inferred* type has no namespace
-      # of its own, so this failed to typecheck even when the two
-      # duck types were textually identical.
-      checker = type_checker(%(
-        # @param callback [#quack]
-        # @return [void]
-        def notify(callback); end
-
-        # @param x [#quack]
-        # @return [void]
-        def relay(x)
-          notify(x)
-        end
-      ))
-      expect(checker.problems).to be_empty
-    end
-
     it 'reports mismatched kwrestargs' do
       checker = type_checker(%(
         class Foo

--- a/spec/type_checker/levels/strict_spec.rb
+++ b/spec/type_checker/levels/strict_spec.rb
@@ -268,6 +268,26 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.first.message).to include('Wrong argument type')
     end
 
+    it 'accepts a duck-typed argument declared with the exact same duck type as expected' do
+      # duck_types_match? used to check the expected duck type against
+      # inferred.namespace/#scope, which are only meaningful for a
+      # nominal type - a duck-typed *inferred* type has no namespace
+      # of its own, so this failed to typecheck even when the two
+      # duck types were textually identical.
+      checker = type_checker(%(
+        # @param callback [#quack]
+        # @return [void]
+        def notify(callback); end
+
+        # @param x [#quack]
+        # @return [void]
+        def relay(x)
+          notify(x)
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
     it 'reports mismatched kwrestargs' do
       checker = type_checker(%(
         class Foo

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1018,6 +1018,47 @@ describe Solargraph::TypeChecker do
           .to include('Wrong argument type for Consumer#project_to_h: project_obj expected Asana::Resources::Project, received Mocha::Mock')
       end
 
+      it 'accepts an intersection-typed argument where the duck-typed conjunct is expected (#1231)' do
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5280196737 -
+        # ComplexType#duck_types_match? used to check the duck-typed
+        # expectation against ComplexType#namespace/#scope, which for an
+        # Intersection just delegates to its *first* conjunct
+        # (Intersection#namespace/#scope). That rejected an intersection
+        # whenever the duck-typed conjunct wasn't the first one, even
+        # though duck-typed subtyping only needs *some* conjunct to
+        # satisfy it - the same "any one conjunct" rule
+        # Intersection#conforms_to? already applies elsewhere. Fixed by
+        # checking each conjunct instead of just the first.
+        checker = type_checker(%(
+          # @param callback [#quack]
+          # @return [void]
+          def notify(callback); end
+
+          # @param x [String & #quack]
+          # @return [void]
+          def relay(x)
+            notify(x)
+          end
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'still rejects an intersection-typed argument when no conjunct satisfies the duck-typed expectation' do
+        checker = type_checker(%(
+          # @param callback [#quack]
+          # @return [void]
+          def notify(callback); end
+
+          # @param x [String & Integer]
+          # @return [void]
+          def relay(x)
+            notify(x)
+          end
+      ))
+        expect(checker.problems.map(&:message))
+          .to include('Wrong argument type for #notify: callback expected #quack, received String & Integer')
+      end
+
       it 'dispatches generic methods per-conjunct when intersecting two instantiations of the same generic class (#1231)' do
         # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
         # #fetch on Hash{K1=>V1} & Hash{K2=>V2} used to always resolve through

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1239,6 +1239,50 @@ describe Solargraph::TypeChecker do
       ))
         expect(checker.problems.map(&:message)).to be_empty
       end
+
+      # Passes with and without the conjunct resolution: an unbound
+      # generic return is accepted leniently, so this is a
+      # no-regression check. The mismatch spec below is the
+      # discriminating one.
+      it 'binds a generic declared only inside an intersection @param' do
+        checker = type_checker(%(
+          class Factory
+            # @generic T
+            # @param clazz [Class<generic<T>> & #new]
+            # @return [Class<generic<T>>]
+            def echo(clazz)
+              clazz
+            end
+
+            # @return [Class<String>]
+            def use
+              echo(String)
+            end
+          end
+        ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'reports a mismatch against the generic bound through the intersection' do
+        checker = type_checker(%(
+          class Factory
+            # @generic T
+            # @param clazz [Class<generic<T>> & #new]
+            # @return [Class<generic<T>>]
+            def echo(clazz)
+              clazz
+            end
+
+            # @return [Class<Integer>]
+            def use
+              echo(String)
+            end
+          end
+        ))
+        expect(checker.problems.map(&:message))
+          .to eq(['Declared return type ::Class<::Integer> does not match inferred type ::Class<::String> ' \
+                  'for Factory#use'])
+      end
     end
   end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1070,11 +1070,10 @@ describe Solargraph::TypeChecker do
           .to include('Wrong argument type for Consumer#project_to_h: project_obj expected Asana::Resources::Project, received Mocha::Mock')
       end
 
-      it 'accepts an intersection-typed argument where the duck-typed conjunct is expected (#1231)' do
+      it 'accepts an intersection-typed argument where the duck-typed conjunct is expected' do
         # Duck-typed subtyping needs *some* conjunct to satisfy it, not
         # specifically the first one that Intersection#namespace/#scope
-        # delegate to -
-        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5280196737
+        # delegate to.
         checker = type_checker(%(
           # @param callback [#quack]
           # @return [void]
@@ -1105,19 +1104,14 @@ describe Solargraph::TypeChecker do
           .to include('Wrong argument type for #notify: callback expected #quack, received String & Integer')
       end
 
-      it 'dispatches generic methods per-conjunct when intersecting two instantiations of the same generic class (#1231)' do
+      it 'dispatches generic methods per-conjunct when intersecting two instantiations of the same generic class' do
         # Both conjuncts resolve to a pin with the same path (Hash#fetch)
         # but different, already-resolved return types, so dispatch keys on
         # path *and* return type, then narrows to the conjunct whose key
         # matches the call's literal argument. Overload resolution can't
         # do that on its own, since it runs per conjunct and both
-        # conjuncts yield a pin with the same path -
-        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
-        #
-        # castwide/solargraph#1223 is a prerequisite: without it the literal
-        # "Index"/"Triggers" key_types widen to plain String before the
-        # narrowing can see them.
-        pending 'needs castwide/solargraph#1223'
+        # conjuncts yield a pin with the same path.
+        pending 'https://github.com/castwide/solargraph/pull/1223'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
@@ -1134,11 +1128,8 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
-      it 'dispatches generic methods per-conjunct regardless of conjunct order (#1231)' do
-        # The conjunct order of the sibling spec above, reversed: the same
-        # per-key narrowing applies either way, with the same
-        # castwide/solargraph#1223 prerequisite.
-        pending 'needs castwide/solargraph#1223'
+      it 'dispatches generic methods per-conjunct regardless of conjunct order' do
+        pending 'https://github.com/castwide/solargraph/pull/1223'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Triggers" => Array<Hash{"Name" => String}>} & Hash{"Index" => Float}]
@@ -1155,14 +1146,13 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
-      it 'dispatches generic methods per-conjunct for symbol keys (#1231)' do
-        # Symbol keys reach the same union by a different route than the
-        # string keys above: symbols already infer as literal types, so
-        # per-overload matching rejects the non-matching conjunct - but a
-        # pin whose overloads all fail to match falls through to its
-        # declared return type rather than being dropped, so only
-        # Call#key_verified_conjuncts can actually remove a conjunct.
-        pending 'needs castwide/solargraph#1223'
+      it 'dispatches generic methods per-conjunct for symbol keys' do
+        # Symbols already infer as literal types, so per-overload matching
+        # rejects the non-matching conjunct on its own here - a pin whose
+        # overloads all fail falls through to its declared return type
+        # rather than being dropped, so only Call#key_verified_conjuncts
+        # actually removes it.
+        pending 'https://github.com/castwide/solargraph/pull/1223'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{:Index => Float} & Hash{:Triggers => Array<Hash{:Name => String}>}]
@@ -1193,11 +1183,10 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
-      it 'resolves a call to a method defined on just one conjunct of an intersection-typed receiver (#1231)' do
+      it 'resolves a call to a method defined on just one conjunct of an intersection-typed receiver' do
         # Method lookup gives an intersection's conjuncts "any one is
         # enough" semantics (A & B <: A, A & B <: B), unlike a union, where
-        # every alternative has to define the method -
-        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119
+        # every alternative has to define the method.
         checker = type_checker(%(
           class A
             # @return [void]
@@ -1249,9 +1238,7 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
-      it 'resolves a conjunct method on an intersection-typed local variable, not just a call chain (#1231)' do
-        # Same fix as the sibling spec above applies to any intersection-typed
-        # value, not just method-return-value call chains.
+      it 'resolves a conjunct method on an intersection-typed local variable, not just a call chain' do
         checker = type_checker(%(
           class A
             # @return [void]
@@ -1274,8 +1261,6 @@ describe Solargraph::TypeChecker do
       end
 
       it 'resolves conjunct methods on a three-way intersection' do
-        # Same fix as the sibling specs above; each conjunct is checked
-        # independently regardless of how many there are.
         checker = type_checker(%(
           class A
             # @return [void]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1150,7 +1150,7 @@ describe Solargraph::TypeChecker do
         # Symbols already infer as literal types, so per-overload matching
         # rejects the non-matching conjunct on its own here - a pin whose
         # overloads all fail falls through to its declared return type
-        # rather than being dropped, so only Call#key_verified_conjuncts
+        # rather than being dropped, so only Call#argument_verified_conjuncts
         # actually removes it.
         pending 'https://github.com/castwide/solargraph/pull/1223'
         checker = type_checker(%(
@@ -1208,6 +1208,45 @@ describe Solargraph::TypeChecker do
 
           Factory.new.make.foo
           Factory.new.make.bar
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'dispatches to the conjunct whose parameter type actually accepts the argument' do
+        # Same problem as the Hash-record specs above, generalized:
+        # narrowing an intersection's conjuncts by argument fit isn't
+        # Hash-key-specific, it's ordinary overload matching applied
+        # per conjunct instead of per signature.
+        checker = type_checker(%(
+          class A
+            # @param x [String]
+            # @return [Integer]
+            def pick(x)
+              1
+            end
+          end
+
+          class B
+            # @param x [Symbol]
+            # @return [Float]
+            def pick(x)
+              1.0
+            end
+          end
+
+          class Factory
+            # @sg-ignore A.new duck-types as A & B for this repro
+            # @return [A & B]
+            def make
+              A.new
+            end
+          end
+
+          # @type [Integer]
+          from_a = Factory.new.make.pick("hello")
+
+          # @type [Float]
+          from_b = Factory.new.make.pick(:hello)
       ))
         expect(checker.problems.map(&:message)).to be_empty
       end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -922,6 +922,48 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to be_empty
     end
 
+    it 'always dispatches a same-class generic method through the first union member, not #1231-specific' do
+      # Not an intersection-types bug at all: a *union* of two Hash
+      # instantiations shows the identical "always the first one, regardless
+      # of order or argument" dispatch bug that the same-class intersection
+      # specs below track. Confirmed on unmodified castwide/solargraph
+      # master (8fda63384, no & or | involved) with a minimal @generic
+      # class (no Hash, no literal keys, no #1266 dependency):
+      #
+      #   # @generic T
+      #   class Box
+      #     # @return [generic<T>]
+      #     def get; end
+      #   end
+      #
+      #   # @param b [Box<Integer>, Box<String>]
+      #   b.get  # infers Integer
+      #   # @param b [Box<String>, Box<Integer>]
+      #   b.get  # infers String - order picked the type, not the call
+      #
+      # Root cause: Call#inferred_pins resolves the class's generic
+      # parameter against `self_type = name_pin.binder` - the *whole*
+      # union/intersection type - rather than per-member, so it binds
+      # against whichever member it structurally matches first.
+      #
+      # Filing this as its own issue/PR against master, independent of
+      # #1231 and #1266, so the Hash intersection specs below inherit the
+      # fix whichever order the PRs land in rather than stacking one PR on
+      # top of another.
+      pending 'Call#inferred_pins binds a generic against the first union/intersection member only'
+      checker = type_checker(%(
+        class Repro
+          # @param period [Hash{"Index" => Float}, Hash{"Triggers" => Array<Hash{"Name" => String}>}]
+          # @return [void]
+          def process(period)
+            # @type [Float]
+            index = period.fetch("Index")
+          end
+        end
+    ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     context 'with intersection types' do
       it 'accepts an intersection-typed argument where any one conjunct is expected' do
         checker = type_checker(%(

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -899,7 +899,16 @@ describe Solargraph::TypeChecker do
       # reproduces identically for a single, non-intersected generic Hash - the
       # intersection is not the trigger, so the fix for #1231 should not be expected
       # to resolve this on its own.
-      pending 'pre-existing Hash#fetch generic-parameter leak, unrelated to intersection types'
+      #
+      # Root cause: Pin::Parameter#compatible_arg? rejects Hash#fetch's exact-arity
+      # `(key: Hash::_Key) -> V` overload because Hash::_Key (an ad-hoc RBS
+      # interface) is checked nominally, not structurally, against the String
+      # argument - so it falls through to the pin's raw combined signature type,
+      # which still carries the unresolved generic X from the other overloads.
+      # Blocked on https://github.com/castwide/solargraph/pull/1266 (structurally
+      # verify RBS interface-typed expectations), which already fixes this on a
+      # different branch but isn't on master or this branch yet.
+      pending 'blocked on #1266 (structural RBS interface-typed expectation checks)'
       checker = type_checker(%(
         class Repro
           # @param period [Hash{"Index" => Float}]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -893,6 +893,26 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
 
+    it 'leaks an unresolved generic<X> from Hash#fetch even with no intersection involved' do
+      # Not #1231-specific: https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
+      # reported this against an intersection of two Hash instantiations, but it
+      # reproduces identically for a single, non-intersected generic Hash - the
+      # intersection is not the trigger, so the fix for #1231 should not be expected
+      # to resolve this on its own.
+      pending 'pre-existing Hash#fetch generic-parameter leak, unrelated to intersection types'
+      checker = type_checker(%(
+        class Repro
+          # @param period [Hash{"Index" => Float}]
+          # @return [void]
+          def process(period)
+            # @type [Float]
+            index = period.fetch("Index")
+          end
+        end
+    ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     context 'with intersection types' do
       it 'accepts an intersection-typed argument where any one conjunct is expected' do
         checker = type_checker(%(
@@ -956,6 +976,40 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
+      it 'ignores which conjunct is fetched from and always resolves via the first conjunct (#1231)' do
+        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 - ' \
+                'swapping the conjunct order flips which (still wrong) type both fetches ' \
+                'report, showing dispatch always uses the first conjunct rather than the key'
+        checker = type_checker(%(
+          class Repro
+            # @param period [Hash{"Triggers" => Array<Hash{"Name" => String}>} & Hash{"Index" => Float}]
+            # @return [void]
+            def process(period)
+              # @type [Array<Hash{"Name" => String}>]
+              triggers = period.fetch("Triggers")
+
+              # @type [Float]
+              index = period.fetch("Index")
+            end
+          end
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'resolves a non-generic method shared by both conjuncts of a same-class intersection' do
+        checker = type_checker(%(
+          class Repro
+            # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
+            # @return [void]
+            def process(period)
+              # @type [Integer]
+              n = period.size
+            end
+          end
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
       it 'resolves a call to a method defined on just one conjunct of an intersection-typed receiver (#1231)' do
         pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
                 'method-call resolution does not walk the conjuncts of an intersection-typed receiver'
@@ -980,6 +1034,91 @@ describe Solargraph::TypeChecker do
 
           Factory.new.make.foo
           Factory.new.make.bar
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'resolves a call to a method inherited from a common ancestor of both conjuncts' do
+        checker = type_checker(%(
+          class A
+            # @return [void]
+            def foo; end
+          end
+
+          class B
+            # @return [void]
+            def bar; end
+          end
+
+          class Factory
+            # @sg-ignore A.new duck-types as A & B for this repro
+            # @return [A & B]
+            def make
+              A.new
+            end
+          end
+
+          # @type [String]
+          s = Factory.new.make.to_s
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'fails to resolve a conjunct method on an intersection-typed local variable, not just a call chain (#1231)' do
+        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
+                'the gap is in resolving methods on any intersection-typed value, not specific ' \
+                'to method-return-value call chains'
+        checker = type_checker(%(
+          class A
+            # @return [void]
+            def foo; end
+          end
+
+          class B
+            # @return [void]
+            def bar; end
+          end
+
+          # @sg-ignore A.new duck-types as A & B for this repro
+          # @type [A & B]
+          value = A.new
+
+          value.foo
+          value.bar
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'fails to resolve conjunct methods on a three-way intersection' do
+        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
+                'method-call resolution does not walk conjuncts, regardless of how many there are'
+        checker = type_checker(%(
+          class A
+            # @return [void]
+            def foo; end
+          end
+
+          class B
+            # @return [void]
+            def bar; end
+          end
+
+          class C
+            # @return [void]
+            def baz; end
+          end
+
+          class Factory
+            # @sg-ignore A.new duck-types as A & B & C for this repro
+            # @return [A & B & C]
+            def make
+              A.new
+            end
+          end
+
+          Factory.new.make.foo
+          Factory.new.make.bar
+          Factory.new.make.baz
       ))
         expect(checker.problems.map(&:message)).to be_empty
       end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1019,16 +1019,10 @@ describe Solargraph::TypeChecker do
       end
 
       it 'accepts an intersection-typed argument where the duck-typed conjunct is expected (#1231)' do
-        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5280196737 -
-        # ComplexType#duck_types_match? used to check the duck-typed
-        # expectation against ComplexType#namespace/#scope, which for an
-        # Intersection just delegates to its *first* conjunct
-        # (Intersection#namespace/#scope). That rejected an intersection
-        # whenever the duck-typed conjunct wasn't the first one, even
-        # though duck-typed subtyping only needs *some* conjunct to
-        # satisfy it - the same "any one conjunct" rule
-        # Intersection#conforms_to? already applies elsewhere. Fixed by
-        # checking each conjunct instead of just the first.
+        # Duck-typed subtyping needs *some* conjunct to satisfy it, not
+        # specifically the first one that Intersection#namespace/#scope
+        # delegate to -
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5280196737
         checker = type_checker(%(
           # @param callback [#quack]
           # @return [void]
@@ -1060,45 +1054,19 @@ describe Solargraph::TypeChecker do
       end
 
       it 'dispatches generic methods per-conjunct when intersecting two instantiations of the same generic class (#1231)' do
-        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
-        # #fetch on Hash{K1=>V1} & Hash{K2=>V2} used to always resolve through
-        # the *first* conjunct's #fetch signature regardless of which key was
-        # passed. Root cause (shared with castwide/solargraph#1272): both
-        # conjuncts resolve to a pin with the same path (Hash#fetch) but
-        # different, already-correctly-resolved return types, and dedup was
-        # keying on path alone - fixed here the same way
-        # castwide/solargraph#1273 fixed it for real unions, applied to
-        # Call#method_stack_pins's Intersection branch too.
+        # Both conjuncts resolve to a pin with the same path (Hash#fetch)
+        # but different, already-resolved return types, so dispatch keys on
+        # path *and* return type, then narrows to the conjunct whose key
+        # matches the call's literal argument. RBS's own
+        # `Hash#fetch: (_Key key) -> V` can't narrow that itself - `_Key` is
+        # a structural hash/eql? interface, not literally `K`, so the key
+        # argument is never connected to the return type by ordinary
+        # overload resolution -
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
         #
-        # That made dispatch order-independent and sound (both conjuncts'
-        # possible return types show up), but not yet *precise*: it returned
-        # a union of every conjunct's result rather than narrowing to the one
-        # whose key actually matches. RBS's own `Hash#fetch: (_Key key) -> V`
-        # can't do this itself - `_Key` is a structural hash/eql? interface,
-        # not literally `K`, so the key argument is never connected to the
-        # return type by ordinary overload resolution. Call#method_stack_pins
-        # now detects any `_Key`-shaped parameter on a conjunct's method
-        # (generalizing past #fetch/#[] to #dig, #delete, etc. for free) and,
-        # when every conjunct yields a positive verdict for or against the
-        # call's own literal argument, keeps only the matching conjunct(s) -
-        # conservatively falling back to today's full union whenever even one
-        # conjunct can't be verified one way or the other.
-        #
-        # Key-parameter detection has to handle two shapes, because RBS's
-        # own core/hash.rbs changed in 4.1.0: `(_Key key)` from 4.1.0 on,
-        # `(K arg0)` before it. Pin::Signature#key_param_index recognizes
-        # both - see its comment. Without the pre-4.1 shape this spec
-        # passes on RBS >= 4.1 and fails on 3.10.x/4.0.x, which is what
-        # apiology/solargraph#49 CI was reporting before that was fixed.
-        #
-        # Still pending on this branch alone: castwide/solargraph#1223
-        # (restores literal type inference). Without it the literal
-        # "Index"/"Triggers" key_types get widened to plain String before
-        # the narrowing above ever sees them - verified directly, with just
-        # this branch's own commits the union already loses the literal keys
-        # (`Hash{String => String}`), independent of anything else. #1223 is
-        # an independent, already-scoped PR that just happens to be a
-        # prerequisite for this spec to observe the fix above working.
+        # castwide/solargraph#1223 is a prerequisite: without it the literal
+        # "Index"/"Triggers" key_types widen to plain String before the
+        # narrowing can see them.
         pending 'needs castwide/solargraph#1223'
         checker = type_checker(%(
           class Repro
@@ -1117,14 +1085,9 @@ describe Solargraph::TypeChecker do
       end
 
       it 'dispatches generic methods per-conjunct regardless of conjunct order (#1231)' do
-        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
-        # this used to demonstrate order-*dependence*: swapping the conjunct
-        # order flipped which (wrong) type both fetches reported. The
-        # dedup-key fix described in the sibling spec above makes this
-        # order-independent now - same per-key-narrowed result either way,
-        # dispatched via the same literal-key matching described there.
-        # Pending on this branch alone for the same independent,
-        # already-scoped prerequisite as that spec: castwide/solargraph#1223.
+        # The conjunct order of the sibling spec above, reversed: the same
+        # per-key narrowing applies either way, with the same
+        # castwide/solargraph#1223 prerequisite.
         pending 'needs castwide/solargraph#1223'
         checker = type_checker(%(
           class Repro
@@ -1143,18 +1106,12 @@ describe Solargraph::TypeChecker do
       end
 
       it 'dispatches generic methods per-conjunct for symbol keys (#1231)' do
-        # Symbol keys take a different path to the same bug than the string
-        # keys above: symbols already infer as literal types, so per-overload
-        # matching correctly rejects the non-matching conjunct - but a pin
-        # whose overloads all fail to match is not dropped, it just falls
-        # through to its declared return type, so the union survives anyway.
-        # Only key_verified_conjuncts can actually remove a conjunct. Before
-        # Pin::Signature#key_param_index learned RBS < 4.1's `(K arg0)`
-        # shape, this reported the union plus an unresolved generic<X> plus
-        # three spurious "Wrong argument type for Hash#fetch: arg0 expected
-        # :Index, received :Triggers" errors on RBS 3.10.x/4.0.x - the arg
-        # check was resolving against the conjunct that narrowing should
-        # have dropped.
+        # Symbol keys reach the same union by a different route than the
+        # string keys above: symbols already infer as literal types, so
+        # per-overload matching rejects the non-matching conjunct - but a
+        # pin whose overloads all fail to match falls through to its
+        # declared return type rather than being dropped, so only
+        # Call#key_verified_conjuncts can actually remove a conjunct.
         pending 'needs castwide/solargraph#1223'
         checker = type_checker(%(
           class Repro
@@ -1187,11 +1144,10 @@ describe Solargraph::TypeChecker do
       end
 
       it 'resolves a call to a method defined on just one conjunct of an intersection-typed receiver (#1231)' do
-        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 -
-        # method-call resolution used to only try the first conjunct's method
-        # stack, per unique type, and required every one of them to define the
-        # method the way a real union would. Fixed in Call#method_stack_pins by
-        # giving Intersection conjuncts "any one is enough" semantics instead.
+        # Method lookup gives an intersection's conjuncts "any one is
+        # enough" semantics (A & B <: A, A & B <: B), unlike a union, where
+        # every alternative has to define the method -
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119
         checker = type_checker(%(
           class A
             # @return [void]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -893,7 +893,6 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
 
-    # https://github.com/castwide/solargraph/issues/1229
     context 'with intersection types' do
       it 'accepts an intersection-typed argument where any one conjunct is expected' do
         checker = type_checker(%(

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -892,5 +892,50 @@ describe Solargraph::TypeChecker do
       # an error when trying to declare sub as Subclass
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
+
+    # https://github.com/castwide/solargraph/issues/1229
+    context 'with intersection types' do
+      it 'accepts an intersection-typed argument where any one conjunct is expected' do
+        checker = type_checker(%(
+          class Asana; class Resources; class Project; end; end; end
+          class Mocha; class Mock; end; end
+
+          class Consumer
+            # @param project_obj [Asana::Resources::Project]
+            # @return [void]
+            def project_to_h(project_obj); end
+          end
+
+          class MockFactory
+            # @sg-ignore Mocha::Mock configured with responds_like_instance_of
+            #   duck-types as Asana::Resources::Project at every call site.
+            # @return [Mocha::Mock & Asana::Resources::Project]
+            def make_mock
+              Mocha::Mock.new
+            end
+          end
+
+          Consumer.new.project_to_h(MockFactory.new.make_mock)
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'still rejects a plain conjunct type that does not satisfy the expected type' do
+        checker = type_checker(%(
+          class Asana; class Resources; class Project; end; end; end
+          class Mocha; class Mock; end; end
+
+          class Consumer
+            # @param project_obj [Asana::Resources::Project]
+            # @return [void]
+            def project_to_h(project_obj); end
+          end
+
+          Consumer.new.project_to_h(Mocha::Mock.new)
+      ))
+        expect(checker.problems.map(&:message))
+          .to include('Wrong argument type for Consumer#project_to_h: project_obj expected Asana::Resources::Project, received Mocha::Mock')
+      end
+    end
   end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1018,25 +1018,40 @@ describe Solargraph::TypeChecker do
         # castwide/solargraph#1273 fixed it for real unions, applied to
         # Call#method_stack_pins's Intersection branch too.
         #
-        # That makes dispatch order-independent and sound (both conjuncts'
-        # possible return types show up), but not yet *precise*: it's a union
-        # of every conjunct's result rather than narrowing to the one whose
-        # key actually matches. True per-key narrowing needs the literal key
-        # ("Index" vs "Triggers") to survive Pin::Parameter#typify, but
-        # UniqueType#qualify widens every literal type to its base class
-        # (String) via UniqueType#non_literal_name - tried gating that behind
-        # a corrected #literal? check (the existing check is unconditionally
-        # disabled by #1201, for an unrelated array/tuple-inference reason),
-        # but qualify's widening turns out to be load-bearing for other
-        # cases (RBS's `NilClass#to_s: () -> ''`, true/false -> Boolean
-        # consolidation) that use the exact same code path - see reverted
-        # attempt in this branch's history. A real fix needs qualify/transform
-        # to distinguish a Hash's key_types from a general return-type
-        # position, which they can't currently do.
+        # That made dispatch order-independent and sound (both conjuncts'
+        # possible return types show up), but not yet *precise*: it returned
+        # a union of every conjunct's result rather than narrowing to the one
+        # whose key actually matches. RBS's own `Hash#fetch: (_Key key) -> V`
+        # can't do this itself - `_Key` is a structural hash/eql? interface,
+        # not literally `K`, so the key argument is never connected to the
+        # return type by ordinary overload resolution. Call#method_stack_pins
+        # now detects any `_Key`-shaped parameter on a conjunct's method
+        # (generalizing past #fetch/#[] to #dig, #delete, etc. for free) and,
+        # when every conjunct yields a positive verdict for or against the
+        # call's own literal argument, keeps only the matching conjunct(s) -
+        # conservatively falling back to today's full union whenever even one
+        # conjunct can't be verified one way or the other.
         #
-        # Still blocked on #1266 too: the generic<X> leak is layered on top
-        # of the union.
-        pending 'blocked on #1266, plus qualify erasing literal Hash keys needed for precise per-key dispatch'
+        # Still pending on two independent prerequisites neither present on
+        # this branch:
+        #
+        # - castwide/solargraph#1223 (restores literal type inference) -
+        #   without it, the literal "Index"/"Triggers" key_types get widened
+        #   to plain String before the narrowing above ever sees them.
+        #   Verified directly: with just this branch's own commits, the
+        #   union already loses the literal keys (`Hash{String => String}`),
+        #   independent of anything else.
+        # - castwide/solargraph#1266 (structurally verifies RBS
+        #   interface-typed expectations) - needed only on RBS >= 4.1.x,
+        #   where `Hash#fetch`'s exact-arity overload gets nominally (not
+        #   structurally) rejected against `Hash::_Key` and falls through to
+        #   an unresolved `generic<X>`. Confirmed this branch alone is clean
+        #   on RBS 3.10.x but leaks `generic<X>` on RBS 4.1.x without #1266.
+        #
+        # Neither is specific to intersections or to this fix - both are
+        # independent, already-scoped PRs that just happen to be
+        # prerequisites for this spec to observe the fix above working.
+        pending 'needs castwide/solargraph#1223 and, on RBS >= 4.1.x, castwide/solargraph#1266'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
@@ -1053,16 +1068,17 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
-      it 'resolves the same (still imprecise) union regardless of conjunct order (#1231)' do
+      it 'dispatches generic methods per-conjunct regardless of conjunct order (#1231)' do
         # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
         # this used to demonstrate order-*dependence*: swapping the conjunct
         # order flipped which (wrong) type both fetches reported. The
         # dedup-key fix described in the sibling spec above makes this
-        # order-independent now - same union of both conjuncts' return types
-        # either way. Still pending for the same two reasons as that spec:
-        # the #1266-blocked generic<X> leak, and imprecise
-        # union-instead-of-narrowed-to-one-conjunct dispatch.
-        pending 'blocked on #1266, plus qualify erasing literal Hash keys needed for precise per-key dispatch'
+        # order-independent now - same per-key-narrowed result either way,
+        # dispatched via the same literal-key matching described there.
+        # Pending for the same two independent, already-scoped prerequisites
+        # as that spec: castwide/solargraph#1223 and, on RBS >= 4.1.x,
+        # castwide/solargraph#1266.
+        pending 'needs castwide/solargraph#1223 and, on RBS >= 4.1.x, castwide/solargraph#1266'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Triggers" => Array<Hash{"Name" => String}>} & Hash{"Index" => Float}]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -893,33 +893,18 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
 
-    it 'leaks an unresolved generic<X> from Hash#fetch even with no intersection involved' do
+    it 'resolves Hash#fetch on a literal-keyed Hash with no intersection involved' do
       # Not #1231-specific: https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
       # reported this against an intersection of two Hash instantiations, but it
-      # reproduces identically for a single, non-intersected generic Hash - the
-      # intersection is not the trigger, so the fix for #1231 should not be expected
-      # to resolve this on its own.
+      # reproduced identically for a single, non-intersected generic Hash.
       #
-      # Root cause: Pin::Parameter#compatible_arg? rejects Hash#fetch's exact-arity
-      # `(key: Hash::_Key) -> V` overload because Hash::_Key (an ad-hoc RBS
-      # interface) is checked nominally, not structurally, against the String
-      # argument - so it falls through to the pin's raw combined signature type,
-      # which still carries the unresolved generic X from the other overloads.
-      #
-      # https://github.com/castwide/solargraph/pull/1266 (structurally verify
-      # RBS interface-typed expectations) fixes this, but isn't merged into
-      # this branch. CI's full matrix showed this only actually leaks on
-      # RBS >= 4.1.0 - `rspec (3.1, 3.10.0)` unexpectedly passed here (an
-      # RSpec "pending example fixed" failure, since a bare `pending` assumed
-      # it leaked on every RBS version). Matches the same RBS 4.1.0 cutover
-      # already tracked in spec/rbs_map/conversions_spec.rb,
-      # spec/convention/activesupport_concern_spec.rb, and the mirror image
-      # of this same version-aware pattern applied on branch 2026-08-04
-      # (which does have #1266) in commit ac4eb27c5.
-      require 'rbs'
-      if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
-        pending 'blocked on #1266 (structural RBS interface-typed expectation checks), not yet merged into this branch'
-      end
+      # On RBS >= 4.1.0, Pin::Parameter#compatible_arg? rejected Hash#fetch's
+      # exact-arity `(key: Hash::_Key) -> V` overload, because Hash::_Key is
+      # checked nominally rather than structurally against the String argument,
+      # and fell through to the pin's raw combined signature type, which still
+      # carries an unresolved generic X from the other overloads. RbsTranslator
+      # now stubs Hash::_Key back to K (see RBS_INTERFACE_TO_GENERIC), so the
+      # nominal check succeeds and no interface is left to resolve structurally.
       checker = type_checker(%(
         class Repro
           # @param period [Hash{"Index" => Float}]
@@ -1057,11 +1042,9 @@ describe Solargraph::TypeChecker do
         # Both conjuncts resolve to a pin with the same path (Hash#fetch)
         # but different, already-resolved return types, so dispatch keys on
         # path *and* return type, then narrows to the conjunct whose key
-        # matches the call's literal argument. RBS's own
-        # `Hash#fetch: (_Key key) -> V` can't narrow that itself - `_Key` is
-        # a structural hash/eql? interface, not literally `K`, so the key
-        # argument is never connected to the return type by ordinary
-        # overload resolution -
+        # matches the call's literal argument. Overload resolution can't
+        # do that on its own, since it runs per conjunct and both
+        # conjuncts yield a pin with the same path -
         # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
         #
         # castwide/solargraph#1223 is a prerequisite: without it the literal

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -966,9 +966,18 @@ describe Solargraph::TypeChecker do
       end
 
       it 'dispatches generic methods per-conjunct when intersecting two instantiations of the same generic class (#1231)' do
-        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 - ' \
-                '#fetch on Hash{K1=>V1} & Hash{K2=>V2} leaks an unresolved generic<X> ' \
-                'and returns the same wrong type regardless of which key is passed'
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
+        # #fetch on Hash{K1=>V1} & Hash{K2=>V2} leaks an unresolved generic<X> and
+        # returns the same wrong type regardless of which key is passed.
+        #
+        # Confirmed (by running this same repro against a branch with #1266
+        # merged) that this is two separate bugs layered together: #1266 fixes
+        # the generic<X> leak, but the call still resolves through the *first*
+        # conjunct's #fetch signature regardless of which key was passed - see
+        # the sibling 'ignores which conjunct is fetched from' spec below, which
+        # isolates that second bug. So landing #1266 alone will not flip this
+        # spec to passing; it needs its own per-conjunct dispatch fix too.
+        pending 'blocked on #1266, plus a separate first-conjunct-only dispatch bug'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
@@ -986,9 +995,14 @@ describe Solargraph::TypeChecker do
       end
 
       it 'ignores which conjunct is fetched from and always resolves via the first conjunct (#1231)' do
-        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 - ' \
-                'swapping the conjunct order flips which (still wrong) type both fetches ' \
-                'report, showing dispatch always uses the first conjunct rather than the key'
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
+        # swapping the conjunct order flips which (still wrong) type both fetches
+        # report, showing dispatch always uses the first conjunct rather than the
+        # key. This bug survives #1266 (confirmed by running this repro against a
+        # branch with #1266 merged: the generic<X> leak is gone, but the
+        # first-conjunct-only behavior is unchanged) - it needs its own
+        # per-conjunct dispatch fix, independent of #1266.
+        pending 'first-conjunct-only dispatch, independent of #1266'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Triggers" => Array<Hash{"Name" => String}>} & Hash{"Index" => Float}]
@@ -1020,8 +1034,16 @@ describe Solargraph::TypeChecker do
       end
 
       it 'resolves a call to a method defined on just one conjunct of an intersection-typed receiver (#1231)' do
-        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
-                'method-call resolution does not walk the conjuncts of an intersection-typed receiver'
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 -
+        # method-call resolution does not walk the conjuncts of an
+        # intersection-typed receiver. Confirmed independent of #1266: running
+        # this repro against a branch with #1266 merged reproduces identically -
+        # #1266's interface-conformance fix doesn't touch Chain::Call#resolve's
+        # method-stack lookup (lib/solargraph/source/chain/call.rb:61-64), which
+        # only takes the first unique type's method stack and never walks the
+        # other conjuncts of an Intersection. Needs its own fix regardless of
+        # #1266's fate.
+        pending 'method-call resolution does not walk intersection conjuncts (unrelated to #1266)'
         checker = type_checker(%(
           class A
             # @return [void]
@@ -1074,9 +1096,10 @@ describe Solargraph::TypeChecker do
       end
 
       it 'fails to resolve a conjunct method on an intersection-typed local variable, not just a call chain (#1231)' do
-        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
-                'the gap is in resolving methods on any intersection-typed value, not specific ' \
-                'to method-return-value call chains'
+        # Same root cause and #1266-independence as the sibling spec above; the
+        # gap is in resolving methods on any intersection-typed value, not
+        # specific to method-return-value call chains.
+        pending 'method-call resolution does not walk intersection conjuncts (unrelated to #1266)'
         checker = type_checker(%(
           class A
             # @return [void]
@@ -1099,8 +1122,10 @@ describe Solargraph::TypeChecker do
       end
 
       it 'fails to resolve conjunct methods on a three-way intersection' do
-        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
-                'method-call resolution does not walk conjuncts, regardless of how many there are'
+        # Same root cause and #1266-independence as the sibling specs above;
+        # method-call resolution does not walk conjuncts, regardless of how
+        # many there are.
+        pending 'method-call resolution does not walk intersection conjuncts (unrelated to #1266)'
         checker = type_checker(%(
           class A
             # @return [void]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -935,6 +935,54 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message))
           .to include('Wrong argument type for Consumer#project_to_h: project_obj expected Asana::Resources::Project, received Mocha::Mock')
       end
+
+      it 'dispatches generic methods per-conjunct when intersecting two instantiations of the same generic class (#1231)' do
+        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 - ' \
+                '#fetch on Hash{K1=>V1} & Hash{K2=>V2} leaks an unresolved generic<X> ' \
+                'and returns the same wrong type regardless of which key is passed'
+        checker = type_checker(%(
+          class Repro
+            # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
+            # @return [void]
+            def process(period)
+              # @type [Float]
+              index = period.fetch("Index")
+
+              # @type [Array<Hash{"Name" => String}>]
+              triggers = period.fetch("Triggers")
+            end
+          end
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'resolves a call to a method defined on just one conjunct of an intersection-typed receiver (#1231)' do
+        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
+                'method-call resolution does not walk the conjuncts of an intersection-typed receiver'
+        checker = type_checker(%(
+          class A
+            # @return [void]
+            def foo; end
+          end
+
+          class B
+            # @return [void]
+            def bar; end
+          end
+
+          class Factory
+            # @sg-ignore A.new duck-types as A & B for this repro
+            # @return [A & B]
+            def make
+              A.new
+            end
+          end
+
+          Factory.new.make.foo
+          Factory.new.make.bar
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
     end
   end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1035,15 +1035,10 @@ describe Solargraph::TypeChecker do
 
       it 'resolves a call to a method defined on just one conjunct of an intersection-typed receiver (#1231)' do
         # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 -
-        # method-call resolution does not walk the conjuncts of an
-        # intersection-typed receiver. Confirmed independent of #1266: running
-        # this repro against a branch with #1266 merged reproduces identically -
-        # #1266's interface-conformance fix doesn't touch Chain::Call#resolve's
-        # method-stack lookup (lib/solargraph/source/chain/call.rb:61-64), which
-        # only takes the first unique type's method stack and never walks the
-        # other conjuncts of an Intersection. Needs its own fix regardless of
-        # #1266's fate.
-        pending 'method-call resolution does not walk intersection conjuncts (unrelated to #1266)'
+        # method-call resolution used to only try the first conjunct's method
+        # stack, per unique type, and required every one of them to define the
+        # method the way a real union would. Fixed in Call#method_stack_pins by
+        # giving Intersection conjuncts "any one is enough" semantics instead.
         checker = type_checker(%(
           class A
             # @return [void]
@@ -1095,11 +1090,9 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
-      it 'fails to resolve a conjunct method on an intersection-typed local variable, not just a call chain (#1231)' do
-        # Same root cause and #1266-independence as the sibling spec above; the
-        # gap is in resolving methods on any intersection-typed value, not
-        # specific to method-return-value call chains.
-        pending 'method-call resolution does not walk intersection conjuncts (unrelated to #1266)'
+      it 'resolves a conjunct method on an intersection-typed local variable, not just a call chain (#1231)' do
+        # Same fix as the sibling spec above applies to any intersection-typed
+        # value, not just method-return-value call chains.
         checker = type_checker(%(
           class A
             # @return [void]
@@ -1121,11 +1114,9 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
-      it 'fails to resolve conjunct methods on a three-way intersection' do
-        # Same root cause and #1266-independence as the sibling specs above;
-        # method-call resolution does not walk conjuncts, regardless of how
-        # many there are.
-        pending 'method-call resolution does not walk intersection conjuncts (unrelated to #1266)'
+      it 'resolves conjunct methods on a three-way intersection' do
+        # Same fix as the sibling specs above; each conjunct is checked
+        # independently regardless of how many there are.
         checker = type_checker(%(
           class A
             # @return [void]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -999,17 +999,6 @@ describe Solargraph::TypeChecker do
     end
 
     it 'resolves Hash#fetch on a literal-keyed Hash with no intersection involved' do
-      # Not #1231-specific: https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
-      # reported this against an intersection of two Hash instantiations, but it
-      # reproduced identically for a single, non-intersected generic Hash.
-      #
-      # On RBS >= 4.1.0, Pin::Parameter#compatible_arg? rejected Hash#fetch's
-      # exact-arity `(key: Hash::_Key) -> V` overload, because Hash::_Key is
-      # checked nominally rather than structurally against the String argument,
-      # and fell through to the pin's raw combined signature type, which still
-      # carries an unresolved generic X from the other overloads. RbsTranslator
-      # now stubs Hash::_Key back to K (see RBS_INTERFACE_TO_GENERIC), so the
-      # nominal check succeeds and no interface is left to resolve structurally.
       checker = type_checker(%(
         class Repro
           # @param period [Hash{"Index" => Float}]
@@ -1023,34 +1012,7 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to be_empty
     end
 
-    it 'always dispatches a same-class generic method through the first union member, not #1231-specific' do
-      # Not an intersection-types bug at all: a *union* of two Hash
-      # instantiations shows the identical "always the first one, regardless
-      # of order or argument" dispatch bug that the same-class intersection
-      # specs below track. Confirmed on unmodified castwide/solargraph
-      # master (8fda63384, no & or | involved) with a minimal @generic
-      # class (no Hash, no literal keys, no #1266 dependency):
-      #
-      #   # @generic T
-      #   class Box
-      #     # @return [generic<T>]
-      #     def get; end
-      #   end
-      #
-      #   # @param b [Box<Integer>, Box<String>]
-      #   b.get  # infers Integer
-      #   # @param b [Box<String>, Box<Integer>]
-      #   b.get  # infers String - order picked the type, not the call
-      #
-      # Root cause: Call#inferred_pins resolves the class's generic
-      # parameter against `self_type = name_pin.binder` - the *whole*
-      # union/intersection type - rather than per-member, so it binds
-      # against whichever member it structurally matches first.
-      #
-      # Filing this as its own issue/PR against master, independent of
-      # #1231 and #1266, so the Hash intersection specs below inherit the
-      # fix whichever order the PRs land in rather than stacking one PR on
-      # top of another.
+    it 'always dispatches a same-class generic method through the first union member' do
       pending 'Call#inferred_pins binds a generic against the first union/intersection member only'
       checker = type_checker(%(
         class Repro

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -905,10 +905,21 @@ describe Solargraph::TypeChecker do
       # interface) is checked nominally, not structurally, against the String
       # argument - so it falls through to the pin's raw combined signature type,
       # which still carries the unresolved generic X from the other overloads.
-      # Blocked on https://github.com/castwide/solargraph/pull/1266 (structurally
-      # verify RBS interface-typed expectations), which already fixes this on a
-      # different branch but isn't on master or this branch yet.
-      pending 'blocked on #1266 (structural RBS interface-typed expectation checks)'
+      #
+      # https://github.com/castwide/solargraph/pull/1266 (structurally verify
+      # RBS interface-typed expectations) fixes this, but isn't merged into
+      # this branch. CI's full matrix showed this only actually leaks on
+      # RBS >= 4.1.0 - `rspec (3.1, 3.10.0)` unexpectedly passed here (an
+      # RSpec "pending example fixed" failure, since a bare `pending` assumed
+      # it leaked on every RBS version). Matches the same RBS 4.1.0 cutover
+      # already tracked in spec/rbs_map/conversions_spec.rb,
+      # spec/convention/activesupport_concern_spec.rb, and the mirror image
+      # of this same version-aware pattern applied on branch 2026-08-04
+      # (which does have #1266) in commit ac4eb27c5.
+      require 'rbs'
+      if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
+        pending 'blocked on #1266 (structural RBS interface-typed expectation checks), not yet merged into this branch'
+      end
       checker = type_checker(%(
         class Repro
           # @param period [Hash{"Index" => Float}]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1084,26 +1084,22 @@ describe Solargraph::TypeChecker do
         # conservatively falling back to today's full union whenever even one
         # conjunct can't be verified one way or the other.
         #
-        # Still pending on two independent prerequisites neither present on
-        # this branch:
+        # Key-parameter detection has to handle two shapes, because RBS's
+        # own core/hash.rbs changed in 4.1.0: `(_Key key)` from 4.1.0 on,
+        # `(K arg0)` before it. Pin::Signature#key_param_index recognizes
+        # both - see its comment. Without the pre-4.1 shape this spec
+        # passes on RBS >= 4.1 and fails on 3.10.x/4.0.x, which is what
+        # apiology/solargraph#49 CI was reporting before that was fixed.
         #
-        # - castwide/solargraph#1223 (restores literal type inference) -
-        #   without it, the literal "Index"/"Triggers" key_types get widened
-        #   to plain String before the narrowing above ever sees them.
-        #   Verified directly: with just this branch's own commits, the
-        #   union already loses the literal keys (`Hash{String => String}`),
-        #   independent of anything else.
-        # - castwide/solargraph#1266 (structurally verifies RBS
-        #   interface-typed expectations) - needed only on RBS >= 4.1.x,
-        #   where `Hash#fetch`'s exact-arity overload gets nominally (not
-        #   structurally) rejected against `Hash::_Key` and falls through to
-        #   an unresolved `generic<X>`. Confirmed this branch alone is clean
-        #   on RBS 3.10.x but leaks `generic<X>` on RBS 4.1.x without #1266.
-        #
-        # Neither is specific to intersections or to this fix - both are
-        # independent, already-scoped PRs that just happen to be
-        # prerequisites for this spec to observe the fix above working.
-        pending 'needs castwide/solargraph#1223 and, on RBS >= 4.1.x, castwide/solargraph#1266'
+        # Still pending on this branch alone: castwide/solargraph#1223
+        # (restores literal type inference). Without it the literal
+        # "Index"/"Triggers" key_types get widened to plain String before
+        # the narrowing above ever sees them - verified directly, with just
+        # this branch's own commits the union already loses the literal keys
+        # (`Hash{String => String}`), independent of anything else. #1223 is
+        # an independent, already-scoped PR that just happens to be a
+        # prerequisite for this spec to observe the fix above working.
+        pending 'needs castwide/solargraph#1223'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
@@ -1127,10 +1123,9 @@ describe Solargraph::TypeChecker do
         # dedup-key fix described in the sibling spec above makes this
         # order-independent now - same per-key-narrowed result either way,
         # dispatched via the same literal-key matching described there.
-        # Pending for the same two independent, already-scoped prerequisites
-        # as that spec: castwide/solargraph#1223 and, on RBS >= 4.1.x,
-        # castwide/solargraph#1266.
-        pending 'needs castwide/solargraph#1223 and, on RBS >= 4.1.x, castwide/solargraph#1266'
+        # Pending on this branch alone for the same independent,
+        # already-scoped prerequisite as that spec: castwide/solargraph#1223.
+        pending 'needs castwide/solargraph#1223'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Triggers" => Array<Hash{"Name" => String}>} & Hash{"Index" => Float}]
@@ -1141,6 +1136,36 @@ describe Solargraph::TypeChecker do
 
               # @type [Float]
               index = period.fetch("Index")
+            end
+          end
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'dispatches generic methods per-conjunct for symbol keys (#1231)' do
+        # Symbol keys take a different path to the same bug than the string
+        # keys above: symbols already infer as literal types, so per-overload
+        # matching correctly rejects the non-matching conjunct - but a pin
+        # whose overloads all fail to match is not dropped, it just falls
+        # through to its declared return type, so the union survives anyway.
+        # Only key_verified_conjuncts can actually remove a conjunct. Before
+        # Pin::Signature#key_param_index learned RBS < 4.1's `(K arg0)`
+        # shape, this reported the union plus an unresolved generic<X> plus
+        # three spurious "Wrong argument type for Hash#fetch: arg0 expected
+        # :Index, received :Triggers" errors on RBS 3.10.x/4.0.x - the arg
+        # check was resolving against the conjunct that narrowing should
+        # have dropped.
+        pending 'needs castwide/solargraph#1223'
+        checker = type_checker(%(
+          class Repro
+            # @param period [Hash{:Index => Float} & Hash{:Triggers => Array<Hash{:Name => String}>}]
+            # @return [void]
+            def process(period)
+              # @type [Float]
+              index = period.fetch(:Index)
+
+              # @type [Array<Hash{:Name => String}>]
+              triggers = period.fetch(:Triggers)
             end
           end
       ))

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1009,17 +1009,34 @@ describe Solargraph::TypeChecker do
 
       it 'dispatches generic methods per-conjunct when intersecting two instantiations of the same generic class (#1231)' do
         # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
-        # #fetch on Hash{K1=>V1} & Hash{K2=>V2} leaks an unresolved generic<X> and
-        # returns the same wrong type regardless of which key is passed.
+        # #fetch on Hash{K1=>V1} & Hash{K2=>V2} used to always resolve through
+        # the *first* conjunct's #fetch signature regardless of which key was
+        # passed. Root cause (shared with castwide/solargraph#1272): both
+        # conjuncts resolve to a pin with the same path (Hash#fetch) but
+        # different, already-correctly-resolved return types, and dedup was
+        # keying on path alone - fixed here the same way
+        # castwide/solargraph#1273 fixed it for real unions, applied to
+        # Call#method_stack_pins's Intersection branch too.
         #
-        # Confirmed (by running this same repro against a branch with #1266
-        # merged) that this is two separate bugs layered together: #1266 fixes
-        # the generic<X> leak, but the call still resolves through the *first*
-        # conjunct's #fetch signature regardless of which key was passed - see
-        # the sibling 'ignores which conjunct is fetched from' spec below, which
-        # isolates that second bug. So landing #1266 alone will not flip this
-        # spec to passing; it needs its own per-conjunct dispatch fix too.
-        pending 'blocked on #1266, plus a separate first-conjunct-only dispatch bug'
+        # That makes dispatch order-independent and sound (both conjuncts'
+        # possible return types show up), but not yet *precise*: it's a union
+        # of every conjunct's result rather than narrowing to the one whose
+        # key actually matches. True per-key narrowing needs the literal key
+        # ("Index" vs "Triggers") to survive Pin::Parameter#typify, but
+        # UniqueType#qualify widens every literal type to its base class
+        # (String) via UniqueType#non_literal_name - tried gating that behind
+        # a corrected #literal? check (the existing check is unconditionally
+        # disabled by #1201, for an unrelated array/tuple-inference reason),
+        # but qualify's widening turns out to be load-bearing for other
+        # cases (RBS's `NilClass#to_s: () -> ''`, true/false -> Boolean
+        # consolidation) that use the exact same code path - see reverted
+        # attempt in this branch's history. A real fix needs qualify/transform
+        # to distinguish a Hash's key_types from a general return-type
+        # position, which they can't currently do.
+        #
+        # Still blocked on #1266 too: the generic<X> leak is layered on top
+        # of the union.
+        pending 'blocked on #1266, plus qualify erasing literal Hash keys needed for precise per-key dispatch'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
@@ -1036,15 +1053,16 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
-      it 'ignores which conjunct is fetched from and always resolves via the first conjunct (#1231)' do
+      it 'resolves the same (still imprecise) union regardless of conjunct order (#1231)' do
         # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
-        # swapping the conjunct order flips which (still wrong) type both fetches
-        # report, showing dispatch always uses the first conjunct rather than the
-        # key. This bug survives #1266 (confirmed by running this repro against a
-        # branch with #1266 merged: the generic<X> leak is gone, but the
-        # first-conjunct-only behavior is unchanged) - it needs its own
-        # per-conjunct dispatch fix, independent of #1266.
-        pending 'first-conjunct-only dispatch, independent of #1266'
+        # this used to demonstrate order-*dependence*: swapping the conjunct
+        # order flipped which (wrong) type both fetches reported. The
+        # dedup-key fix described in the sibling spec above makes this
+        # order-independent now - same union of both conjuncts' return types
+        # either way. Still pending for the same two reasons as that spec:
+        # the #1266-blocked generic<X> leak, and imprecise
+        # union-instead-of-narrowed-to-one-conjunct dispatch.
+        pending 'blocked on #1266, plus qualify erasing literal Hash keys needed for precise per-key dispatch'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Triggers" => Array<Hash{"Name" => String}>} & Hash{"Index" => Float}]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -101,6 +101,32 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to be_empty
     end
 
+    it 'does not leak an unbound generic from an unmatched Hash#fetch overload' do
+      checker = type_checker(%(
+        class A
+          # @param b [Hash{String => Integer}]
+          # @return [Integer]
+          def a b
+            b.fetch('x')
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
+    it 'infers nil as part of Hash#[] on a plainly-typed Hash' do
+      checker = type_checker(%(
+        class A
+          # @param b [Hash{String => Integer}]
+          # @return [Integer, nil]
+          def a b
+            b['x']
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     it 'respects pin visibility in if/nil? pattern' do
       checker = type_checker(%(
         class Foo

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'rbs'
-
 describe Solargraph::TypeChecker do
   context 'with level set to strong' do
     def type_checker code
@@ -104,9 +102,6 @@ describe Solargraph::TypeChecker do
     end
 
     it 'does not leak an unbound generic from an unmatched Hash#fetch overload' do
-      # Hash#fetch only takes its key as the _Key interface (rather than
-      # the generic K) as of RBS 4.1.0 - see ruby/rbs core/hash.rbs.
-      pending 'https://github.com/castwide/solargraph/pull/1266' if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
       checker = type_checker(%(
         class A
           # @param b [Hash{String => Integer}]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -102,6 +102,7 @@ describe Solargraph::TypeChecker do
     end
 
     it 'does not leak an unbound generic from an unmatched Hash#fetch overload' do
+      pending 'https://github.com/castwide/solargraph/pull/1266'
       checker = type_checker(%(
         class A
           # @param b [Hash{String => Integer}]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rbs'
+
 describe Solargraph::TypeChecker do
   context 'with level set to strong' do
     def type_checker code
@@ -102,7 +104,9 @@ describe Solargraph::TypeChecker do
     end
 
     it 'does not leak an unbound generic from an unmatched Hash#fetch overload' do
-      pending 'https://github.com/castwide/solargraph/pull/1266'
+      # Hash#fetch only takes its key as the _Key interface (rather than
+      # the generic K) as of RBS 4.1.0 - see ruby/rbs core/hash.rbs.
+      pending 'https://github.com/castwide/solargraph/pull/1266' if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
       checker = type_checker(%(
         class A
           # @param b [Hash{String => Integer}]


### PR DESCRIPTION
## Summary

Adds intersection types (`A & B`) to Solargraph, in both plain YARD tags (`@param`/`@return`/`@type`) and inline RBS signatures (`#: () -> (A & B)`). Also adds the `|` union operator and `[...]` grouping brackets, matching https://github.com/lsegal/yard/pull/1700.

A value typed `A & B` is one that satisfies both — assignable wherever *either* is expected, and offering the methods of both. The individual members are its *conjuncts*. Previously `ComplexType` had no way to hold one, so RBS `A & B` was flattened to the union `A, B` (the reverse relationship), and YARD `A & B` parsed as a single namespace by that literal name. #1229 shows the flattening in the error text:

```
Wrong argument type for Consumer#project_to_h: project_obj expected Asana::Resources::Project, received Mocha::Mock, Asana::Resources::Project
```

Fixes https://github.com/castwide/solargraph/issues/1229. YARD has no official intersection syntax (https://github.com/lsegal/yard/issues/1644), so the tag form is a Solargraph extension pending upstream guidance.

## What changed

- **`ComplexType::UniqueType::Intersection`**, with `conforms_to?` correct both ways — any one conjunct as inferred, every conjunct as expected. `ComplexType.parse` gains top-level `&`, `|` (binds looser) and `[...]` grouping at RBS/YARD precedence, and `RbsTranslator` now builds composite types as an object graph rather than joining strings, so nested unions inside intersections round-trip.
- **Dispatch on intersection receivers.** `Call#method_stack_pins` needs only one conjunct to define a method, and dedupes candidates by `[path, return_type.tag]` rather than path alone, so `Box<Integer> & Box<String>` no longer collapses to whichever resolved first. Generics inside conjuncts now resolve too: `Intersection` inherited a `resolve_generics_from_context` that searches `#subtypes`/`#key_types`, which an intersection doesn't use, so `Class<generic<T>> & #new` never bound `T` — and an unresolved generic satisfies every conformance check, so a wrong `@return` was accepted silently.
- **`narrow_with`/`narrowed_return_type`**, renamed from #1119's `intersect_with`/`intersection_return_type` to free the name, and now building a real `Intersection` instead of discarding a mix-in narrowing when one side is a confirmed module.

## Precise Hash "record" dispatch

Two single-key Hash types intersected — `Hash{"Index" => Float} & Hash{"Triggers" => Array<...>}` — now dispatch like TypeScript's `{ Index: Float } & { Triggers: Array<...> }`: `#fetch`/`#[]`, and any other RBS method with a `_Key`-shaped parameter (`#dig`, `#delete`, detected structurally rather than by a hardcoded list), narrow to the conjunct whose key matches the call's literal argument instead of returning a union of every conjunct's return type. RBS's own `Hash#fetch: (_Key key) -> V` cannot do this — `_Key` is a structural `hash`/`eql?` interface, not literally `K`, so the key argument is never connected to the return type.

A conjunct is only narrowed away when *every* conjunct produces a positive verdict against a `_Key`-shaped parameter and the literal argument, falling back to the full union whenever even one cannot be verified either way.

The two specs demonstrating this stay `pending`, citing two independent unmerged prerequisites: castwide/solargraph#1223 (literal type inference, needed for the `"Index"`/`"Triggers"` key types to survive to be compared) and, on RBS >= 4.1.x, castwide/solargraph#1266 (structural RBS interface conformance, so `Hash#fetch`'s own overload resolution doesn't leak `generic<X>`). Neither gap is specific to intersections.

This PR was written by Claude Code on behalf of @apiology.
