### PR TITLE
Resolve remote constants

### DIFF
--- a/lib/solargraph/api_map/constants.rb
+++ b/lib/solargraph/api_map/constants.rb
@@ -155,7 +155,7 @@ module Solargraph
             mixin = resolve(ref.name, ref.reference_gates)
             next unless mixin
 
-            resolved = simple_resolve(name, mixin, internal)
+            resolved = resolve(name, mixin)
             return [resolved, gates[(idx + 1)..]] if resolved
           end
         end

--- a/spec/api_map/constants_spec.rb
+++ b/spec/api_map/constants_spec.rb
@@ -94,6 +94,33 @@ describe Solargraph::ApiMap::Constants do
       resolved = constants.resolve('Foo::Bar::Baz')
       expect(resolved).to eq('Foo::Bar::Baz')
     end
+
+    it 'resolves remote constants' do
+      source_map = Solargraph::SourceMap.load_string(%(
+        module Module1
+          class Foo
+          end
+        end
+
+        module Module2
+          include Module1
+          Thing = Foo
+        end
+
+        module Module3
+          include Module2
+        end
+
+        module Module4
+          include Module3
+          x = Thing.new
+        end
+      ), 'test.rb')
+      store = Solargraph::ApiMap::Store.new(source_map.pins)
+      constants = described_class.new(store)
+      constant = constants.resolve('Thing', 'Module4')
+      expect(constant).to eq('Module2::Thing')
+    end
   end
 
   describe '#dereference' do


### PR DESCRIPTION
Resolve constants that exist in transitive modules. In the following example used by this PR's spec, `Thing` should resolve to `Module2::Thing` in the context of `Module4`.

```ruby
module Module1
  class Foo
  end
end

module Module2
  include Module1
  Thing = Foo
end

module Module3
  include Module2
end

module Module4
  include Module3
  x = Thing.new
end
```
