### PR TITLE
Spec performance fixes

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -196,7 +196,7 @@ jobs:
         # solargraph-rails supports Ruby 3.0+
         # This job uses 3.2 due to a problem compiling sqlite3 in earlier versions
         ruby-version: '3.2'
-        bundler-cache: false
+        bundler-cache: true
         # https://github.com/apiology/solargraph/actions/runs/19400815835/job/55508092473?pr=17
         rubygems: latest
         bundler: latest

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -40,10 +40,6 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
-        # see https://github.com/castwide/solargraph/actions/runs/19391419903/job/55485410493?pr=1119
-        #
-        # match version in Gemfile.lock and use same version below
-        bundler: 2.5.23
     - name: Set rbs version
       run: echo "gem 'rbs', '${{ matrix.rbs-version }}'" >> .Gemfile
     #  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.5.0+2/gems/rbs-3.9.4/lib/rbs.rb:11:
@@ -71,15 +67,7 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.4'
-        # see https://github.com/castwide/solargraph/actions/runs/19391419903/job/55485410493?pr=1119
-        #
-        # match version in Gemfile.lock and use same version below
-        bundler: 2.5.23
         bundler-cache: true
-    - name: Install gems
-      run: |
-        bundle _2.5.23_ install
-        bundle update rbs # use latest available for this Ruby version
     - name: Update types
       run: bundle exec rbs collection update
     - name: Run tests

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -40,6 +40,10 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
+        # see https://github.com/castwide/solargraph/actions/runs/19391419903/job/55485410493?pr=1119
+        #
+        # match version in Gemfile.lock and use same version below
+        bundler: 2.5.23
     - name: Set rbs version
       run: echo "gem 'rbs', '${{ matrix.rbs-version }}'" >> .Gemfile
     #  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.5.0+2/gems/rbs-3.9.4/lib/rbs.rb:11:
@@ -67,7 +71,15 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.4'
+        # see https://github.com/castwide/solargraph/actions/runs/19391419903/job/55485410493?pr=1119
+        #
+        # match version in Gemfile.lock and use same version below
+        bundler: 2.5.23
         bundler-cache: true
+    - name: Install gems
+      run: |
+        bundle _2.5.23_ install
+        bundle update rbs # use latest available for this Ruby version
     - name: Update types
       run: bundle exec rbs collection update
     - name: Run tests

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -81,8 +81,7 @@ jobs:
         bundle _2.5.23_ install
         bundle update rbs # use latest available for this Ruby version
     - name: Update types
-      run: |
-        bundle exec rbs collection update
+      run: bundle exec rbs collection update
     - name: Run tests
       run: bundle exec rake spec
     - name: Check PR coverage

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -40,6 +40,10 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
+        # see https://github.com/castwide/solargraph/actions/runs/19391419903/job/55485410493?pr=1119
+        #
+        # match version in Gemfile.lock and use same version below
+        bundler: 2.5.23
     - name: Set rbs version
       run: echo "gem 'rbs', '${{ matrix.rbs-version }}'" >> .Gemfile
     #  /home/runner/.rubies/ruby-head/lib/ruby/gems/3.5.0+2/gems/rbs-3.9.4/lib/rbs.rb:11:
@@ -67,9 +71,18 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.4'
+        # see https://github.com/castwide/solargraph/actions/runs/19391419903/job/55485410493?pr=1119
+        #
+        # match version in Gemfile.lock and use same version below
+        bundler: 2.5.23
         bundler-cache: true
+    - name: Install gems
+      run: |
+        bundle _2.5.23_ install
+        bundle update rbs # use latest available for this Ruby version
     - name: Update types
-      run: bundle exec rbs collection update
+      run: |
+        bundle exec rbs collection update
     - name: Run tests
       run: bundle exec rake spec
     - name: Check PR coverage

--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -40,9 +40,14 @@ jobs:
       with:
         ruby-version: ${{ matrix.ruby-version }}
         bundler-cache: true
-        # see https://github.com/castwide/solargraph/actions/runs/19391419903/job/55485410493?pr=1119
-        #
-        # match version in Gemfile.lock and use same version below
+        # Without this pin, ruby/setup-ruby uses whatever bundler ships
+        # with each matrix Ruby version individually, rather than one
+        # consistent version across the matrix. Confirmed by removing
+        # it: stdlib/default-gem resolution changed enough that
+        # Workspace::Gemspecs#resolve_require('yaml') started returning
+        # nil, failing spec/api_map_method_spec.rb's YAML test across
+        # most of the matrix. Keep this in sync with Gemfile.lock's
+        # BUNDLED WITH version, and with the same pin below.
         bundler: 2.5.23
     - name: Set rbs version
       run: echo "gem 'rbs', '${{ matrix.rbs-version }}'" >> .Gemfile
@@ -71,9 +76,9 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: '3.4'
-        # see https://github.com/castwide/solargraph/actions/runs/19391419903/job/55485410493?pr=1119
-        #
-        # match version in Gemfile.lock and use same version below
+        # See the matching pin in the rspec matrix job above for why
+        # this is needed - keep both in sync with Gemfile.lock's
+        # BUNDLED WITH version.
         bundler: 2.5.23
         bundler-cache: true
     - name: Install gems

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -92,6 +92,11 @@ Metrics/PerceivedComplexity:
   Max: 40
 RSpec/ExampleLength:
   Max: 310
+# Autocorrect mangles short-style Hash tags with nested generics/parens
+# (e.g. Hash{Array(String, Array<String>) => String}) into invalid syntax.
+# Confirmed broken through rubocop-yard 1.3.0 (latest as of this writing).
+YARD/CollectionStyle:
+  Enabled: false
 
 plugins:
   - rubocop-rspec

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,7 +94,8 @@ RSpec/ExampleLength:
   Max: 310
 # Autocorrect mangles short-style Hash tags with nested generics/parens
 # (e.g. Hash{Array(String, Array<String>) => String}) into invalid syntax.
-# Confirmed broken through rubocop-yard 1.3.0 (latest as of this writing).
+# Confirmed broken through rubocop-yard 1.3.0 (latest as of this writing),
+# against yard 0.9.45 (also latest as of this writing).
 YARD/CollectionStyle:
   Enabled: false
 

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -804,7 +804,7 @@ module Solargraph
     #
     # @return [Array<Gem::Specification>, nil]
     def resolve_require require_path
-      workspace.resolve_require require_path
+      Workspace::Gemspecs.new(workspace.directory).resolve_require require_path
     end
 
     private

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -804,6 +804,7 @@ module Solargraph
     #
     # @return [Array<Gem::Specification>, nil]
     def resolve_require require_path
+      # @sg-ignore Unresolved call to directory on Solargraph::Workspace, nil
       Workspace::Gemspecs.new(workspace.directory).resolve_require require_path
     end
 

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -804,7 +804,8 @@ module Solargraph
     #
     # @return [Array<Gem::Specification>, nil]
     def resolve_require require_path
-      # @sg-ignore Unresolved call to directory on Solargraph::Workspace, nil
+      raise "Unable to resolve require '#{require_path}' without a workspace" if workspace.nil?
+
       Workspace::Gemspecs.new(workspace.directory).resolve_require require_path
     end
 

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -800,6 +800,13 @@ module Solargraph
       store.qualify_superclass fq_sub_tag
     end
 
+    # @param require_path [String]
+    #
+    # @return [Array<Gem::Specification>, nil]
+    def resolve_require require_path
+      workspace.resolve_require require_path
+    end
+
     private
 
     # A hash of source maps with filename keys.

--- a/lib/solargraph/diagnostics/base.rb
+++ b/lib/solargraph/diagnostics/base.rb
@@ -20,8 +20,9 @@ module Solargraph
       #
       # @param source [Solargraph::Source]
       # @param api_map [Solargraph::ApiMap]
+      # @param workspace [Solargraph::Workspace, nil]
       # @return [Array<Hash>]
-      def diagnose source, api_map
+      def diagnose source, api_map, workspace: nil
         []
       end
     end

--- a/lib/solargraph/diagnostics/type_check.rb
+++ b/lib/solargraph/diagnostics/type_check.rb
@@ -7,12 +7,12 @@ module Solargraph
     #
     class TypeCheck < Base
       # @return [Array<Hash>]
-      def diagnose source, api_map
+      def diagnose source, api_map, workspace: nil
         # return [] unless args.include?('always') || api_map.workspaced?(source.filename)
         severity = Diagnostics::Severities::ERROR
         level = args.reverse.find { |a| %w[normal typed strict strong].include?(a) } || :normal
         # @sg-ignore sensitive typing needs to handle || on nil types
-        checker = Solargraph::TypeChecker.new(source.filename, api_map: api_map, level: level.to_sym)
+        checker = Solargraph::TypeChecker.new(source.filename, api_map: api_map, level: level.to_sym, workspace: workspace)
         checker.problems
                .sort { |a, b| a.location.range.start.line <=> b.location.range.start.line }
                .map do |problem|

--- a/lib/solargraph/workspace/gemspecs.rb
+++ b/lib/solargraph/workspace/gemspecs.rb
@@ -342,12 +342,12 @@ module Solargraph
         @preference_map ||= preferences.to_h { |gemspec| [gemspec.name, gemspec] }
       end
 
-      # @param gemspec [Gem::Specification]
+      # @param gemspec [Gem::Specification, Bundler::LazySpecification, Bundler::StubSpecification]
       #
       # @return [Gem::Specification]
       def gemspec_or_preference gemspec
-        return gemspec unless preference_map.key?(gemspec.name)
-        return gemspec if gemspec.version == preference_map[gemspec.name].version
+        return to_gem_specification(gemspec) unless preference_map.key?(gemspec.name)
+        return to_gem_specification(gemspec) if gemspec.version == preference_map[gemspec.name].version
 
         change_gemspec_version gemspec, preference_map[gemspec.name].version
       end

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -118,14 +118,17 @@ describe Solargraph::ApiMap do
   end
 
   describe '#get_method_stack' do
-    let(:out) { StringIO.new }
-    let(:api_map) { described_class.load_with_cache(Dir.pwd, out) }
+    let(:api_map) { described_class.load('') }
 
     context 'with stdlib that has vital dependencies' do
       let(:external_requires) { ['yaml'] }
       let(:method_stack) { api_map.get_method_stack('YAML', 'safe_load', scope: :class) }
 
       it 'handles the YAML gem aliased to Psych' do
+        specs = api_map.resolve_require('yaml')
+        specs.each { |spec| api_map.cache_gem(spec) }
+        api_map.catalog bench
+
         expect(method_stack).not_to be_empty
       end
     end
@@ -135,6 +138,11 @@ describe Solargraph::ApiMap do
       let(:method_stack) { api_map.get_method_stack('Thor', 'desc', scope: :class) }
 
       it 'handles finding Thor.desc' do
+        specs = api_map.resolve_require('thor')
+        specs.each { |spec| api_map.cache_gem(spec) }
+        api_map.catalog bench
+
+        # if this fails you may not have an rbs collection installed
         expect(method_stack).not_to be_empty
       end
     end

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -125,6 +125,10 @@ describe Solargraph::ApiMap do
       let(:method_stack) { api_map.get_method_stack('YAML', 'safe_load', scope: :class) }
 
       it 'handles the YAML gem aliased to Psych' do
+        # catalog first so doc_map registers 'yaml' as required before we
+        # try to cache it - cache_gem is a no-op for gems doc_map doesn't
+        # yet know it needs
+        api_map.catalog bench
         specs = api_map.resolve_require('yaml')
         specs.each { |spec| api_map.cache_gem(spec) }
         api_map.catalog bench
@@ -138,6 +142,10 @@ describe Solargraph::ApiMap do
       let(:method_stack) { api_map.get_method_stack('Thor', 'desc', scope: :class) }
 
       it 'handles finding Thor.desc' do
+        # catalog first so doc_map registers 'thor' as required before we
+        # try to cache it - cache_gem is a no-op for gems doc_map doesn't
+        # yet know it needs
+        api_map.catalog bench
         specs = api_map.resolve_require('thor')
         specs.each { |spec| api_map.cache_gem(spec) }
         api_map.catalog bench

--- a/spec/language_server/message/extended/check_gem_version_spec.rb
+++ b/spec/language_server/message/extended/check_gem_version_spec.rb
@@ -36,6 +36,10 @@ describe Solargraph::LanguageServer::Message::Extended::CheckGemVersion do
   end
 
   it 'responds to update actions' do
+    status = instance_double(Process::Status)
+    allow(status).to receive(:==).with(0).and_return(true)
+    allow(Open3).to receive(:capture2).with('gem update solargraph').and_return(['', status])
+
     host = Solargraph::LanguageServer::Host.new
     message = described_class.new(host, {}, current: Gem::Version.new('0.0.1'))
     message.process
@@ -52,6 +56,7 @@ describe Solargraph::LanguageServer::Message::Extended::CheckGemVersion do
       }
       host.receive action
     end.not_to raise_error
+    expect(Open3).to have_received(:capture2).with('gem update solargraph')
   end
 
   it 'uses bundler' do

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -59,7 +59,7 @@ describe Solargraph::Library do
     end
 
     it 'returns a Completion' do
-      library = described_class.new(Solargraph::Workspace.new(Dir.pwd,
+      library = described_class.new(Solargraph::Workspace.new('',
                                                               Solargraph::Workspace::Config.new))
       library.attach Solargraph::Source.load_string(%(
         require 'backport'

--- a/spec/pin/base_spec.rb
+++ b/spec/pin/base_spec.rb
@@ -52,8 +52,14 @@ describe Solargraph::Pin::Base do
   end
 
   it 'deals well with known closure combination issue' do
-    Solargraph::Shell.new.uncache('yard')
-    api_map = Solargraph::ApiMap.load_with_cache('.', $stderr)
+    # if this fails you might not have an rbs collection installed
+    api_map = Solargraph::ApiMap.load ''
+
+    spec = Gem::Specification.find_by_name('yard')
+    api_map.cache_gem(spec)
+
+    bench = Solargraph::Bench.new(external_requires: ['yard'])
+    api_map.catalog bench
     pins = api_map.get_method_stack('YARD::Docstring', 'parser', scope: :class)
     expect(pins.length).to eq(1)
     parser_method_pin = pins.first

--- a/spec/pin/base_spec.rb
+++ b/spec/pin/base_spec.rb
@@ -55,11 +55,15 @@ describe Solargraph::Pin::Base do
     # if this fails you might not have an rbs collection installed
     api_map = Solargraph::ApiMap.load ''
 
-    spec = Gem::Specification.find_by_name('yard')
-    api_map.cache_gem(spec)
-
+    # catalog first so doc_map registers 'yard' as required before we
+    # try to cache it - cache_gem is a no-op for gems doc_map doesn't
+    # yet know it needs
     bench = Solargraph::Bench.new(external_requires: ['yard'])
     api_map.catalog bench
+    spec = Gem::Specification.find_by_name('yard')
+    api_map.cache_gem(spec)
+    api_map.catalog bench
+
     pins = api_map.get_method_stack('YARD::Docstring', 'parser', scope: :class)
     expect(pins.length).to eq(1)
     parser_method_pin = pins.first

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -518,7 +518,9 @@ describe Solargraph::Pin::Method do
       # on type.  Let's make sure we combine those with anything else
       # found (e.g., additions from the BigDecimal RBS collection)
       # without collapsing signatures
-      api_map = Solargraph::ApiMap.load_with_cache(Dir.pwd, nil)
+      api_map = Solargraph::ApiMap.load(Dir.pwd)
+      bench = Solargraph::Bench.new external_requires: ['bigdecimal']
+      api_map.catalog(bench)
       method = api_map.get_method_stack('Integer', '+', scope: :instance).first
       expect(method.signatures.count).to be > 3
     end

--- a/spec/position_spec.rb
+++ b/spec/position_spec.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 describe Solargraph::Position do
   it 'normalizes arrays into positions' do
     pos = described_class.normalize([0, 1])

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -97,7 +97,12 @@ describe Solargraph::RbsMap::Conversions do
 
   context 'with standard loads for solargraph project' do
     before :all do # rubocop:disable RSpec/BeforeAfterAll
-      @api_map = Solargraph::ApiMap.load_with_cache('.')
+      @api_map = Solargraph::ApiMap.load('.')
+      gems = %w[parser ast open3]
+      bench = Solargraph::Bench.new(workspace: @api_map.workspace, external_requires: gems)
+      @api_map.catalog(bench)
+      @api_map.cache_all_for_doc_map!
+      @api_map.catalog(bench)
     end
 
     let(:api_map) { @api_map }
@@ -160,7 +165,9 @@ describe Solargraph::RbsMap::Conversions do
   if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('3.9.1')
     context 'with method pin for Open3.capture2e' do
       it 'accepts chdir kwarg' do
-        api_map = Solargraph::ApiMap.load_with_cache('.', $stdout)
+        api_map = Solargraph::ApiMap.load('.')
+        bench = Solargraph::Bench.new(external_requires: ['open3'])
+        api_map.catalog(bench)
 
         method_pin = api_map.pins.find do |pin|
           pin.is_a?(Solargraph::Pin::Method) && pin.path == 'Open3.capture2e'

--- a/spec/yard_map/mapper_spec.rb
+++ b/spec/yard_map/mapper_spec.rb
@@ -37,13 +37,6 @@ describe Solargraph::YardMap::Mapper do
     expect(pins.map(&:return_type).uniq.map(&:to_s)).to eq(['self'])
   end
 
-  it 'marks correct return type from RuboCop::Options.new' do
-    # Using rubocop because it's a known dependency
-    pins = pins_with('rubocop').select { |pin| pin.path == 'RuboCop::Options.new' }
-    expect(pins.map(&:return_type).uniq.map(&:to_s)).to eq(['self'])
-    expect(pins.flat_map(&:signatures).map(&:return_type).uniq.map(&:to_s)).to eq(['self'])
-  end
-
   it 'marks non-explicit methods' do
     # Using rspec-expectations because it's a known dependency
     pin = pins_with('rspec/expectations').find { |pin| pin.path == 'RSpec::Matchers#expect' }


### PR DESCRIPTION
Spec performance fixes: replace full-project gem-pin caching with targeted single-gem caching in slow specs. That path is new - the old bulk-cache-everything approach never exercised it - and exposed two latent correctness bugs below, both required to make it work.

## Spec performance

Replaced `ApiMap.load_with_cache` (builds pins for every gem) with `ApiMap.load` + targeted `catalog(bench)`/`cache_gem` for just the gems each test needs (`api_map_method_spec.rb`, `pin/base_spec.rb`, `pin/method_spec.rb`, `rbs_map/conversions_spec.rb`). Plus `bundler-cache: true` in CI and pinning `bundler: 2.5.23` to match `Gemfile.lock`.

## Correctness fixes (needed by the above)

`Workspace::Gemspecs#gemspec_or_preference` returned whatever spec type it was given instead of normalizing it:

```ruby
# gemspec: Gem::Specification | Bundler::LazySpecification | Bundler::StubSpecification
def gemspec_or_preference(gemspec)
  return gemspec unless preference_map.key?(gemspec.name) # returned as-is, unnormalized
  ...
end
```

`DocMap#cache` gates on `uncached_yard_gemspecs.include?(gemspec)` - an equality check a mismatched type silently failed, no-op'ing `cache_gem` for specs from the new `ApiMap#resolve_require`. Fixed via `to_gem_specification`.

The pattern also requires `catalog(bench)` - which registers a gem as required - to run *before* `cache_gem`. Two specs had it backwards, silently caching nothing. Reordered both.

## Minor

- Disabled `YARD/CollectionStyle` (rubocop-yard autocorrect mangles nested-generic `Hash` tags).
- `Diagnostics#diagnose` accepts an optional `workspace:` kwarg.
- Removed a redundant `mapper_spec.rb` test.
