### PR TITLE
Fix exponential blowup in Pin::Method#combine_same_type_arity_signatures

### DIFF
--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -509,11 +509,6 @@ module Solargraph
       #
       # @return [Array<Pin::Signature>]
       def combine_same_type_arity_signatures same_type_arity_signatures
-        # @todo Stubbing this method while we debug an infinite loop bug in Ruby 3.x.
-        #   The body below is intentionally preserved for when the stub is removed.
-        return same_type_arity_signatures
-
-        # rubocop:disable Lint/UnreachableCode
         # This is an O(n^2) operation, so bail out if n is not small
         return same_type_arity_signatures if same_type_arity_signatures.length > 10
 
@@ -521,7 +516,9 @@ module Solargraph
         # @param new_signature [Pin::Signature]
         same_type_arity_signatures.reduce([]) do |old_signatures, new_signature|
           next old_signatures + [new_signature] if old_signatures.empty?
-          old_signatures.flat_map do |old_signature|
+
+          merged = false
+          combined = old_signatures.map do |old_signature|
             potential_new_signature = old_signature.combine_with(new_signature)
 
             if potential_new_signature.type_arity == old_signature.type_arity
@@ -534,13 +531,14 @@ module Solargraph
               # based on types, not just arity, allowing for type
               # information describing how methods behave based on
               # their input types)
-              old_signatures - [old_signature] + [potential_new_signature]
+              merged = true
+              potential_new_signature
             else
-              old_signatures + [new_signature]
+              old_signature
             end
           end
+          merged ? combined : old_signatures + [new_signature]
         end
-        # rubocop:enable Lint/UnreachableCode
       end
 
       # @param name [String]

--- a/spec/pin/combine_with_spec.rb
+++ b/spec/pin/combine_with_spec.rb
@@ -9,7 +9,6 @@ describe Solargraph::Pin::Base, '#combine_with' do
   end
 
   it 'combines return types with another method without type parameters' do
-    pending 'See Pin::Method#combine_same_type_arity_signatures'
     pin1 = Solargraph::Pin::Method.new(name: 'foo', parameters: [], comments: '@return [Array<String>]')
     pin2 = Solargraph::Pin::Method.new(name: 'foo', parameters: [], comments: '@return [Array]')
     combined = pin1.combine_with(pin2)
@@ -30,13 +29,11 @@ describe Solargraph::Pin::Base, '#combine_with' do
     let(:normal_pin) { Solargraph::Pin::Method.new(name: 'foo', parameters: [], comments: '@return [self]') }
 
     it 'combines a dodgy return type with a valid one' do
-      pending 'See Pin::Method#combine_same_type_arity_signatures'
       combined = dodgy_location_pin.combine_with(normal_pin)
       expect(combined.return_type.to_s).to eq('self')
     end
 
     it 'combines a valid return type with a dodgy one' do
-      pending 'See Pin::Method#combine_same_type_arity_signatures'
       combined = normal_pin.combine_with(dodgy_location_pin)
       expect(combined.return_type.to_s).to eq('self')
     end
@@ -58,13 +55,11 @@ describe Solargraph::Pin::Base, '#combine_with' do
     let(:selfy_pin) { Solargraph::Pin::Method.new(name: 'foo', closure: closure, parameters: [], comments: '@return [self]') }
 
     it 'combines a selfy return type with a likely-selfy one' do
-      pending 'See Pin::Method#combine_same_type_arity_signatures'
       combined = likely_selfy_pin.combine_with(selfy_pin)
       expect(combined.return_type.to_s).to eq('self')
     end
 
     it 'combines a likely-selfy return type with a selfy one' do
-      pending 'See Pin::Method#combine_same_type_arity_signatures'
       combined = selfy_pin.combine_with(likely_selfy_pin)
       expect(combined.return_type.to_s).to eq('self')
     end

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -118,6 +118,16 @@ describe Solargraph::Pin::Method do
     expect(pin.return_type).to be_undefined
   end
 
+  it 'combines many non-mergeable same-type-arity signatures without exponential blowup' do
+    pin = described_class.new(name: 'foo')
+    signatures = (1..8).map { |_i| instance_double(Solargraph::Pin::Signature, type_arity: ['same']) }
+    signatures.each do |sig|
+      allow(sig).to receive(:combine_with).and_return(instance_double(Solargraph::Pin::Signature, type_arity: ['different']))
+    end
+    result = pin.send(:combine_same_type_arity_signatures, signatures)
+    expect(result.length).to eq(signatures.length)
+  end
+
   it 'does not merge with changes in parameters' do
     # @todo Method pin parameters are pins now
     pin1 = described_class.new(name: 'bar', parameters: %w[one two])


### PR DESCRIPTION
Fixes an O(n^2)-turned-exponential bug in `Pin::Method#combine_same_type_arity_signatures`: the non-merging branch of the inner `flat_map` returned the *entire* accumulator array plus the new signature, instead of just that element's own contribution. Since `flat_map` concatenates every branch's return value, N non-merging existing signatures blow the result up to N*(N+1) elements instead of N+1, and that larger array becomes the next reduce step's accumulator -- so it compounds multiplicatively.

The existing "bail out if n is not small" guard only checks the length of the *initial* input array, so it doesn't catch this blowup, which happens incrementally inside the reduce.

This PR previously also carried a large stack of `Typecheck cleanup batch N` commits clearing the `solargraph typecheck --level strong` backlog. Those have been split out into a separate, dedicated PR consolidating non-essential type-annotation cleanup across several open PRs, so this PR stays scoped to the actual bug fix.