### PR TITLE
Remove duplicate dead methods in RbsMap::Conversions

### DIFF
--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -159,27 +159,6 @@ module Solargraph
         RBS_TO_CLASS.fetch(ns, ns)
       end
 
-      # @param type_name [RBS::TypeName]
-      # @param type_args [Enumerable<RBS::Types::Bases::Base>]
-      # @return [ComplexType::UniqueType]
-      def build_type type_name, type_args = []
-        # we use .absolute? below to tell the type object what to
-        # expect
-        rbs_name = type_name.relative!.to_s
-        base = RBS_TO_CLASS.fetch(rbs_name, rbs_name)
-
-        params = type_args.map { |a| RbsTranslator.to_complex_type(a) }
-        # @todo Tuples are in flux
-        # tuples have their own class and are handled in other_type_to_type
-        if base == 'Hash' && params.length == 2
-          ComplexType::UniqueType.new(base, [params.first], [params.last], rooted: type_name.absolute?,
-                                                                           parameters_type: :hash)
-        else
-          ComplexType::UniqueType.new(base, [], params.reject(&:undefined?), rooted: type_name.absolute?,
-                                                                             parameters_type: :list)
-        end
-      end
-
       # @param decl [RBS::AST::Declarations::Module::Self]
       # @param closure [Pin::Namespace]
       # @return [void]
@@ -561,7 +540,8 @@ module Solargraph
       def method_def_to_sigs decl, pin
         # rubocop:disable Style/SafeNavigationChainLength
         implicit_nil = decl.overloads.first&.annotations&.map(&:string)&.include?('implicitly-returns-nil') || false
-        # rubocop:enable Style/SafeNavigationChainLength        # @param overload [RBS::AST::Members::MethodDefinition::Overload]
+        # rubocop:enable Style/SafeNavigationChainLength
+        # @param overload [RBS::AST::Members::MethodDefinition::Overload]
         decl.overloads.map do |overload|
           type_location = location_decl_to_pin_location(overload.method_type.location)
           generics = overload.method_type.type_params.map(&:name).map(&:to_s)
@@ -585,84 +565,6 @@ module Solargraph
         end_pos = Position.new(location.end_line - 1, location.end_column)
         range = Range.new(start_pos, end_pos)
         Location.new(location.name.to_s, range)
-      end
-
-      # @param type [RBS::MethodType, RBS::Types::Block]
-      # @param pin [Pin::Method]
-      # @param implicit_nil [Boolean]
-      # @return [Array(Array<Pin::Parameter>, ComplexType)]
-      def parts_of_function type, pin, implicit_nil
-        type_location = pin.type_location
-        if defined?(RBS::Types::UntypedFunction) && type.type.is_a?(RBS::Types::UntypedFunction)
-          return [
-            [Solargraph::Pin::Parameter.new(decl: :restarg, name: 'arg', closure: pin, source: :rbs,
-                                            type_location: type_location)],
-            method_type_to_type(type, implicit_nil)
-          ]
-        end
-
-        parameters = []
-        arg_num = -1
-        type.type.required_positionals.each do |param|
-          # @sg-ignore Unresolved call to name
-          name = param.name ? param.name.to_s : "arg_#{arg_num += 1}"
-          parameters.push Solargraph::Pin::Parameter.new(decl: :arg, name: name, closure: pin,
-                                                         # @sg-ignore RBS generic type understanding issue
-                                                         return_type: other_type_to_type(param.type),
-                                                         source: :rbs, type_location: type_location)
-        end
-        type.type.optional_positionals.each do |param|
-          # @sg-ignore Unresolved call to name
-          name = param.name ? param.name.to_s : "arg_#{arg_num += 1}"
-          parameters.push Solargraph::Pin::Parameter.new(decl: :optarg, name: name, closure: pin,
-                                                         # @sg-ignore RBS generic type understanding issue
-                                                         return_type: other_type_to_type(param.type),
-                                                         type_location: type_location,
-                                                         source: :rbs)
-        end
-        if type.type.rest_positionals
-          name = type.type.rest_positionals.name ? type.type.rest_positionals.name.to_s : "arg_#{arg_num += 1}"
-          inner_rest_positional_type = other_type_to_type(type.type.rest_positionals.type)
-          rest_positional_type = ComplexType::UniqueType.new('Array',
-                                                             [],
-                                                             [inner_rest_positional_type],
-                                                             rooted: true, parameters_type: :list)
-          parameters.push Solargraph::Pin::Parameter.new(decl: :restarg, name: name, closure: pin,
-                                                         source: :rbs, type_location: type_location,
-                                                         return_type: rest_positional_type)
-        end
-        type.type.trailing_positionals.each do |param|
-          # @sg-ignore Unresolved call to name
-          name = param.name ? param.name.to_s : "arg_#{arg_num += 1}"
-          parameters.push Solargraph::Pin::Parameter.new(decl: :arg, name: name, closure: pin, source: :rbs,
-                                                         type_location: type_location)
-        end
-        type.type.required_keywords.each do |orig, param|
-          # @sg-ignore Unresolved call to to_s
-          name = orig ? orig.to_s : "arg_#{arg_num += 1}"
-          parameters.push Solargraph::Pin::Parameter.new(decl: :kwarg, name: name, closure: pin,
-                                                         # @sg-ignore RBS generic type understanding issue
-                                                         return_type: other_type_to_type(param.type),
-                                                         source: :rbs, type_location: type_location)
-        end
-        type.type.optional_keywords.each do |orig, param|
-          # @sg-ignore Unresolved call to to_s
-          name = orig ? orig.to_s : "arg_#{arg_num += 1}"
-          parameters.push Solargraph::Pin::Parameter.new(decl: :kwoptarg, name: name, closure: pin,
-                                                         # @sg-ignore RBS generic type understanding issue
-                                                         return_type: other_type_to_type(param.type),
-                                                         type_location: type_location,
-                                                         source: :rbs)
-        end
-        if type.type.rest_keywords
-          name = type.type.rest_keywords.name ? type.type.rest_keywords.name.to_s : "arg_#{arg_num += 1}"
-          parameters.push Solargraph::Pin::Parameter.new(decl: :kwrestarg,
-                                                         name: type.type.rest_keywords.name.to_s, closure: pin,
-                                                         source: :rbs, type_location: type_location)
-        end
-
-        return_type = method_type_to_type(type, implicit_nil)
-        [parameters, return_type]
       end
 
       # @param type [RBS::MethodType,RBS::Types::Block]


### PR DESCRIPTION
## Why

`RbsMap::Conversions#build_type` and `#parts_of_function` are each defined twice in this file. Ruby silently uses the later definition, so the earlier one is dead code — but it's live-looking dead code: it references two helper methods (`other_type_to_type`, `method_type_to_type`) that don't exist anywhere in `lib/`, so if anything ever called the shadowed version, it would raise `NoMethodError`. Nothing currently reaches it, but it's a landmine for the next refactor that touches this file and doesn't know to check which definition actually runs.

## How

Delete the earlier (shadowed) definitions of both methods. Also fixes a merge artifact nearby: a `# rubocop:enable` comment had gotten concatenated onto the same line as the next method's docstring, breaking both the rubocop directive and the docstring.

## What's in it

- `lib/solargraph/rbs_map/conversions.rb`: -100/+2 lines, no behavior change (dead code removed).

**Testing**: `bundle exec rspec spec/rbs_map/` — 30 examples, 0 failures, 4 pending.
