### PR TITLE
Fix raise/fail nil guards, root-scoped is_a?, case/when, ||=, and namespace-scope narrowing in flow-sensitive typing

### DIFF
--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -243,6 +243,42 @@ module Solargraph
         end
       end
 
+      # @param or_asgn_node [Parser::AST::Node]
+      # @param presence [Range]
+      #
+      # @return [void]
+      def process_or_asgn or_asgn_node, presence
+        return if or_asgn_node.type != :or_asgn
+
+        #
+        # 'x ||= value' only actually assigns when x is falsy (nil or
+        # false), so if x was already truthy, it keeps whatever
+        # non-nil type it already had. Narrow the existing pin by
+        # excluding nil, scoped to the rest of the enclosing closure.
+        #
+        # [3] pry(main)> Parser::CurrentRuby.parse("x ||= 1")
+        # => s(:or_asgn,
+        #   s(:lvasgn, :x),
+        #   s(:int, 1))
+        # [4] pry(main)>
+        lhs = or_asgn_node.children[0]
+        # @sg-ignore Need to add nil check here
+        return unless %i[lvasgn ivasgn].include?(lhs.type)
+
+        # @sg-ignore Need to add nil check here
+        variable_name = lhs.children[0].to_s
+        # @sg-ignore Need to add nil check here
+        return if variable_name.empty?
+
+        # @sg-ignore Need to add nil check here
+        position = Range.from_node(or_asgn_node).start
+        pin = find_var(variable_name, position)
+        return unless pin
+
+        facts = { pin => [{ not_type: ComplexType::NIL }] }
+        process_facts(facts, [presence])
+      end
+
       class << self
         include Logging
       end

--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -262,16 +262,18 @@ module Solargraph
         #   s(:int, 1))
         # [4] pry(main)>
         lhs = or_asgn_node.children[0]
-        # @sg-ignore Need to add nil check here
+        # @sg-ignore Parser::AST::Node#children is declared to return a bare Array, losing its element type here
         return unless %i[lvasgn ivasgn].include?(lhs.type)
 
-        # @sg-ignore Need to add nil check here
+        # @sg-ignore Parser::AST::Node#children is declared to return a bare Array, losing its element type here
         variable_name = lhs.children[0].to_s
-        # @sg-ignore Need to add nil check here
+        # @sg-ignore Parser::AST::Node#children is declared to return a bare Array, losing its element type here
         return if variable_name.empty?
 
-        # @sg-ignore Need to add nil check here
-        position = Range.from_node(or_asgn_node).start
+        range = Range.from_node(or_asgn_node)
+        return if range.nil?
+
+        position = range.start
         pin = find_var(variable_name, position)
         return unless pin
 

--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -462,7 +462,15 @@ module Solargraph
       # @param clause_node [Parser::AST::Node, nil]
       def always_leaves_compound_statement? clause_node
         # https://docs.ruby-lang.org/en/2.2.0/keywords_rdoc.html
-        %i[return raise next redo retry].include?(clause_node&.type)
+        return true if %i[return next redo retry].include?(clause_node&.type)
+        return false if clause_node.nil?
+        return false unless clause_node.type == :send
+
+        # Unlike return/next/redo/retry, `raise` and `fail` are plain
+        # method calls to the parser - `raise 'msg'` parses as
+        # s(:send, nil, :raise, s(:str, "msg")), not a dedicated node
+        # type - so they need to be recognized by shape instead of type.
+        clause_node.children[0].nil? && %i[raise fail].include?(clause_node.children[1])
       end
 
       attr_reader :locals, :ivars, :enclosing_breakable_pin, :enclosing_compound_statement_pin

--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -555,20 +555,6 @@ module Solargraph
         clause_node&.type == :break
       end
 
-      # @param clause_node [Parser::AST::Node, nil]
-      def always_leaves_compound_statement? clause_node
-        # https://docs.ruby-lang.org/en/2.2.0/keywords_rdoc.html
-        return true if %i[return next redo retry].include?(clause_node&.type)
-        return false if clause_node.nil?
-        return false unless clause_node.type == :send
-
-        # Unlike return/next/redo/retry, `raise` and `fail` are plain
-        # method calls to the parser - `raise 'msg'` parses as
-        # s(:send, nil, :raise, s(:str, "msg")), not a dedicated node
-        # type - so they need to be recognized by shape instead of type.
-        clause_node.children[0].nil? && %i[raise fail].include?(clause_node.children[1])
-      end
-
       attr_reader :locals, :ivars, :enclosing_breakable_pin, :enclosing_compound_statement_pin
     end
   end

--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -446,6 +446,11 @@ module Solargraph
         class_node = node.children[1]
 
         return class_node.to_s if module_node.nil?
+        # e.g., ::Baz parses as s(:const, s(:cbase), :Baz) - the
+        # leading :cbase marks root-namespace resolution and isn't
+        # itself a :const node, so it needs to be recognized here
+        # rather than falling into the generic recursive case below.
+        return "::#{class_node}" if module_node.type == :cbase
 
         module_type_name = type_name(module_node)
         return unless module_type_name

--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -190,6 +190,59 @@ module Solargraph
         process_expression(conditional_node, true_ranges, false_ranges)
       end
 
+      # @param case_node [Parser::AST::Node]
+      #
+      # @return [void]
+      def process_case case_node
+        return if case_node.type != :case
+
+        #
+        # See if we can narrow the subject's type inside each 'when'
+        # branch based on the classes tested for in that branch
+        #
+        # [3] pry(main)> Parser::CurrentRuby.parse("case a; when B; c; end")
+        # => s(:case,
+        #   s(:send, nil, :a),
+        #   s(:when,
+        #     s(:const, nil, :B),
+        #     s(:send, nil, :c)), nil)
+        # [4] pry(main)>
+        subject_node = case_node.children[0]
+        return if subject_node.nil?
+        # @sg-ignore Need to add nil check here
+        return unless %i[lvar ivar].include?(subject_node.type)
+
+        # @sg-ignore flow sensitive typing needs to handle attrs
+        variable_name = parse_variable(subject_node)
+        return if variable_name.nil?
+
+        # @sg-ignore Need to add nil check here
+        subject_position = Range.from_node(subject_node).start
+        pin = find_var(variable_name, subject_position)
+        return unless pin
+
+        # @sg-ignore Need to add nil check here
+        when_nodes = case_node.children[1..].compact.select { |child| child.type == :when }
+        # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
+        when_nodes.each do |when_node|
+          *value_nodes, body_node = when_node.children
+          next if body_node.nil?
+
+          type_names = value_nodes.map { |value_node| type_name(value_node) }
+          # Only narrow if every value in this 'when' clause is a
+          # simple constant reference - a splat, range, regexp, etc.
+          # isn't a type we can express as a downcast.
+          next if type_names.any?(&:nil?)
+
+          before_body_loc = body_node.location.expression.adjust(begin_pos: -1)
+          before_body_pos = Position.new(before_body_loc.line, before_body_loc.column)
+          presence = Range.new(before_body_pos, get_node_end_position(body_node))
+
+          facts = { pin => [{ type: ComplexType.parse(*type_names) }] }
+          process_facts(facts, [presence])
+        end
+      end
+
       class << self
         include Logging
       end

--- a/lib/solargraph/parser/node_processor.rb
+++ b/lib/solargraph/parser/node_processor.rb
@@ -40,9 +40,16 @@ module Solargraph
       # @return [Array(Array<Pin::Base>, Array<Pin::LocalVariable>, Array<Pin::InstanceVariable>)]
       def self.process node, region = Region.new, pins = [], locals = [], ivars = []
         if pins.empty?
+          # node: is required so flow-sensitive typing can find the
+          # end of this compound statement (see
+          # FlowSensitiveTyping#process_if) - without it, an
+          # is_a?/nil? guard at the top level of a file never
+          # narrows, because enclosing_compound_statement_pin.node
+          # is always nil.
           pins.push Pin::Namespace.new(
             location: region.source.location,
             name: '',
+            node: node,
             source: :parser
           )
         end

--- a/lib/solargraph/parser/node_processor.rb
+++ b/lib/solargraph/parser/node_processor.rb
@@ -40,9 +40,6 @@ module Solargraph
       # @return [Array(Array<Pin::Base>, Array<Pin::LocalVariable>, Array<Pin::InstanceVariable>)]
       def self.process node, region = Region.new, pins = [], locals = [], ivars = []
         if pins.empty?
-          # node: lets flow-sensitive typing find this statement's
-          # end (FlowSensitiveTyping#process_if); without it,
-          # top-level is_a?/nil? guards never narrow.
           pins.push Pin::Namespace.new(
             location: region.source.location,
             name: '',

--- a/lib/solargraph/parser/node_processor.rb
+++ b/lib/solargraph/parser/node_processor.rb
@@ -40,12 +40,9 @@ module Solargraph
       # @return [Array(Array<Pin::Base>, Array<Pin::LocalVariable>, Array<Pin::InstanceVariable>)]
       def self.process node, region = Region.new, pins = [], locals = [], ivars = []
         if pins.empty?
-          # node: is required so flow-sensitive typing can find the
-          # end of this compound statement (see
-          # FlowSensitiveTyping#process_if) - without it, an
-          # is_a?/nil? guard at the top level of a file never
-          # narrows, because enclosing_compound_statement_pin.node
-          # is always nil.
+          # node: lets flow-sensitive typing find this statement's
+          # end (FlowSensitiveTyping#process_if); without it,
+          # top-level is_a?/nil? guards never narrow.
           pins.push Pin::Namespace.new(
             location: region.source.location,
             name: '',

--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -107,9 +107,13 @@ module Solargraph
             # s(:or_asgn,
             #   s(:ivasgn, :@bar),
             #   s(:int, 123))
+            or_asgn_rhs_node = n.children[1] # s(:int, 123)
             lhs_chain = NodeChainer.chain n.children[0] # s(:ivasgn, :@bar)
-            rhs_chain = NodeChainer.chain n.children[1] # s(:int, 123)
-            or_link = Chain::Or.new([lhs_chain, rhs_chain])
+            # @sg-ignore Need to add nil check here
+            rhs_chain = NodeChainer.chain or_asgn_rhs_node
+            # @sg-ignore Need to add nil check here
+            or_asgn_rhs_never_returns = always_leaves_compound_statement?(or_asgn_rhs_node)
+            or_link = Chain::Or.new([lhs_chain, rhs_chain], rhs_never_returns: or_asgn_rhs_never_returns)
             # this is just for a call chain, so we don't need to record the assignment
             result.push(or_link)
           elsif %i[class module def defs].include?(n.type)
@@ -118,8 +122,14 @@ module Solargraph
           elsif n.type == :and
             result.concat generate_links(n.children.last)
           elsif n.type == :or
-            result.push Chain::Or.new([NodeChainer.chain(n.children[0], @filename),
-                                       NodeChainer.chain(n.children[1], @filename, n)])
+            or_rhs_node = n.children[1]
+            # @sg-ignore Need to add nil check here
+            or_lhs_chain = NodeChainer.chain(n.children[0], @filename)
+            # @sg-ignore Need to add nil check here
+            or_rhs_chain = NodeChainer.chain(or_rhs_node, @filename, n)
+            # @sg-ignore Need to add nil check here
+            or_rhs_never_returns = always_leaves_compound_statement?(or_rhs_node)
+            result.push Chain::Or.new([or_lhs_chain, or_rhs_chain], rhs_never_returns: or_rhs_never_returns)
           elsif n.type == :if
             then_clause = if n.children[1]
                             NodeChainer.chain(n.children[1], @filename, n)

--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -108,10 +108,11 @@ module Solargraph
             #   s(:ivasgn, :@bar),
             #   s(:int, 123))
             or_asgn_rhs_node = n.children[1] # s(:int, 123)
+            raise "Or-assignment node missing right-hand side: #{n}" if or_asgn_rhs_node.nil?
+
             lhs_chain = NodeChainer.chain n.children[0] # s(:ivasgn, :@bar)
-            # @sg-ignore Need to add nil check here
+            # @sg-ignore flow sensitive typing needs to handle 'raise if'
             rhs_chain = NodeChainer.chain or_asgn_rhs_node
-            # @sg-ignore Need to add nil check here
             or_asgn_rhs_never_returns = always_leaves_compound_statement?(or_asgn_rhs_node)
             or_link = Chain::Or.new([lhs_chain, rhs_chain], rhs_never_returns: or_asgn_rhs_never_returns)
             # this is just for a call chain, so we don't need to record the assignment

--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -107,11 +107,8 @@ module Solargraph
             # s(:or_asgn,
             #   s(:ivasgn, :@bar),
             #   s(:int, 123))
-            or_asgn_rhs_node = n.children[1] # s(:int, 123)
-            raise "Or-assignment node missing right-hand side: #{n}" if or_asgn_rhs_node.nil?
-
-            lhs_chain = NodeChainer.chain n.children[0] # s(:ivasgn, :@bar)
-            # @sg-ignore flow sensitive typing needs to handle 'raise if'
+            or_asgn_rhs_node = n.children.fetch(1) # s(:int, 123)
+            lhs_chain = NodeChainer.chain n.children.fetch(0) # s(:ivasgn, :@bar)
             rhs_chain = NodeChainer.chain or_asgn_rhs_node
             or_asgn_rhs_never_returns = always_leaves_compound_statement?(or_asgn_rhs_node)
             or_link = Chain::Or.new([lhs_chain, rhs_chain], rhs_never_returns: or_asgn_rhs_never_returns)
@@ -123,12 +120,9 @@ module Solargraph
           elsif n.type == :and
             result.concat generate_links(n.children.last)
           elsif n.type == :or
-            or_rhs_node = n.children[1]
-            # @sg-ignore Need to add nil check here
-            or_lhs_chain = NodeChainer.chain(n.children[0], @filename)
-            # @sg-ignore Need to add nil check here
+            or_rhs_node = n.children.fetch(1)
+            or_lhs_chain = NodeChainer.chain(n.children.fetch(0), @filename)
             or_rhs_chain = NodeChainer.chain(or_rhs_node, @filename, n)
-            # @sg-ignore Need to add nil check here
             or_rhs_never_returns = always_leaves_compound_statement?(or_rhs_node)
             result.push Chain::Or.new([or_lhs_chain, or_rhs_chain], rhs_never_returns: or_rhs_never_returns)
           elsif n.type == :if

--- a/lib/solargraph/parser/parser_gem/node_methods.rb
+++ b/lib/solargraph/parser/parser_gem/node_methods.rb
@@ -181,12 +181,8 @@ module Solargraph
           result
         end
 
-        # Determines whether a clause necessarily leaves its
-        # enclosing compound statement (method body, block, etc.) -
-        # e.g., via an explicit 'return', a loop-control keyword, or
-        # a raise/fail call - so code that depends on execution
-        # actually reaching the statements after it can treat those
-        # statements as unreachable from this clause.
+        # Whether clause_node necessarily leaves its enclosing
+        # compound statement (return/loop-control/raise/fail).
         #
         # @param clause_node [Parser::AST::Node, nil]
         # @return [Boolean]
@@ -195,18 +191,12 @@ module Solargraph
           return true if %i[return next redo retry].include?(clause_node&.type)
           return false if clause_node.nil?
 
-          # A clause with more than one statement (e.g., a raise
-          # preceded by other statements building the error message)
-          # parses as a :begin node - only its last child determines
-          # whether the clause leaves.
+          # A multi-statement clause parses as :begin; only its last child leaves.
           return always_leaves_compound_statement?(clause_node.children.last) if clause_node.type == :begin
 
           return false unless clause_node.type == :send
 
-          # Unlike return/next/redo/retry, `raise` and `fail` are plain
-          # method calls to the parser - `raise 'msg'` parses as
-          # s(:send, nil, :raise, s(:str, "msg")), not a dedicated node
-          # type - so they need to be recognized by shape instead of type.
+          # raise/fail are plain :send calls, not a dedicated node type.
           clause_node.children[0].nil? && %i[raise fail].include?(clause_node.children[1])
         end
 

--- a/lib/solargraph/parser/parser_gem/node_methods.rb
+++ b/lib/solargraph/parser/parser_gem/node_methods.rb
@@ -181,8 +181,7 @@ module Solargraph
           result
         end
 
-        # Whether clause_node necessarily leaves its enclosing
-        # compound statement (return/loop-control/raise/fail).
+        # Whether clause_node necessarily leaves its enclosing compound statement.
         #
         # @param clause_node [Parser::AST::Node, nil]
         # @return [Boolean]

--- a/lib/solargraph/parser/parser_gem/node_methods.rb
+++ b/lib/solargraph/parser/parser_gem/node_methods.rb
@@ -181,6 +181,35 @@ module Solargraph
           result
         end
 
+        # Determines whether a clause necessarily leaves its
+        # enclosing compound statement (method body, block, etc.) -
+        # e.g., via an explicit 'return', a loop-control keyword, or
+        # a raise/fail call - so code that depends on execution
+        # actually reaching the statements after it can treat those
+        # statements as unreachable from this clause.
+        #
+        # @param clause_node [Parser::AST::Node, nil]
+        # @return [Boolean]
+        def always_leaves_compound_statement? clause_node
+          # https://docs.ruby-lang.org/en/2.2.0/keywords_rdoc.html
+          return true if %i[return next redo retry].include?(clause_node&.type)
+          return false if clause_node.nil?
+
+          # A clause with more than one statement (e.g., a raise
+          # preceded by other statements building the error message)
+          # parses as a :begin node - only its last child determines
+          # whether the clause leaves.
+          return always_leaves_compound_statement?(clause_node.children.last) if clause_node.type == :begin
+
+          return false unless clause_node.type == :send
+
+          # Unlike return/next/redo/retry, `raise` and `fail` are plain
+          # method calls to the parser - `raise 'msg'` parses as
+          # s(:send, nil, :raise, s(:str, "msg")), not a dedicated node
+          # type - so they need to be recognized by shape instead of type.
+          clause_node.children[0].nil? && %i[raise fail].include?(clause_node.children[1])
+        end
+
         # @param node [Parser::AST::Node]
         def splatted_hash? node
           Parser.is_ast_node?(node.children[0]) && node.children[0].type == :kwsplat

--- a/lib/solargraph/parser/parser_gem/node_processors.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors.rb
@@ -7,6 +7,7 @@ module Solargraph
     module ParserGem
       module NodeProcessors
         autoload :BeginNode,     'solargraph/parser/parser_gem/node_processors/begin_node'
+        autoload :CaseNode,      'solargraph/parser/parser_gem/node_processors/case_node'
         autoload :DefNode,       'solargraph/parser/parser_gem/node_processors/def_node'
         autoload :DefsNode,      'solargraph/parser/parser_gem/node_processors/defs_node'
         autoload :SendNode,      'solargraph/parser/parser_gem/node_processors/send_node'
@@ -40,6 +41,7 @@ module Solargraph
       register :kwbegin,      ParserGem::NodeProcessors::BeginNode
       register :rescue,       ParserGem::NodeProcessors::BeginNode
       register :resbody,      ParserGem::NodeProcessors::ResbodyNode
+      register :case,         ParserGem::NodeProcessors::CaseNode
       register :def,          ParserGem::NodeProcessors::DefNode
       register :defs,         ParserGem::NodeProcessors::DefsNode
       register :if,           ParserGem::NodeProcessors::IfNode

--- a/lib/solargraph/parser/parser_gem/node_processors/case_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/case_node.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Solargraph
+  module Parser
+    module ParserGem
+      module NodeProcessors
+        class CaseNode < Parser::NodeProcessor::Base
+          include ParserGem::NodeMethods
+
+          def process
+            FlowSensitiveTyping.new(locals,
+                                    ivars,
+                                    enclosing_breakable_pin,
+                                    enclosing_compound_statement_pin).process_case(node)
+            process_children
+            true
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
@@ -24,6 +24,10 @@ module Solargraph
               comments: comments,
               visibility: :public,
               gates: region.closure.gates.freeze,
+              # node: lets flow-sensitive typing find the end of this
+              # class/module body - see the same node: in
+              # NodeProcessor.process's root namespace pin.
+              node: node,
               source: :parser
             )
             pins.push nspin

--- a/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
@@ -24,9 +24,6 @@ module Solargraph
               comments: comments,
               visibility: :public,
               gates: region.closure.gates.freeze,
-              # node: lets flow-sensitive typing find the end of this
-              # class/module body - see the same node: in
-              # NodeProcessor.process's root namespace pin.
               node: node,
               source: :parser
             )

--- a/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
@@ -9,11 +9,13 @@ module Solargraph
 
           # @return [void]
           def process
-            here = get_node_start_position(node)
-            # @sg-ignore Need to add nil check here
-            presence = Range.new(here, region.closure.location.range.ending)
-            FlowSensitiveTyping.new(locals, ivars, enclosing_breakable_pin,
-                                    enclosing_compound_statement_pin).process_or_asgn(node, presence)
+            closure_location = region.closure.location
+            if closure_location
+              here = get_node_start_position(node)
+              presence = Range.new(here, closure_location.range.ending)
+              FlowSensitiveTyping.new(locals, ivars, enclosing_breakable_pin,
+                                      enclosing_compound_statement_pin).process_or_asgn(node, presence)
+            end
 
             new_node = node.updated(node.children[0].type, node.children[0].children + [node.children[1]])
             NodeProcessor.process(new_node, region, pins, locals, ivars)

--- a/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/orasgn_node.rb
@@ -5,8 +5,16 @@ module Solargraph
     module ParserGem
       module NodeProcessors
         class OrasgnNode < Parser::NodeProcessor::Base
+          include ParserGem::NodeMethods
+
           # @return [void]
           def process
+            here = get_node_start_position(node)
+            # @sg-ignore Need to add nil check here
+            presence = Range.new(here, region.closure.location.range.ending)
+            FlowSensitiveTyping.new(locals, ivars, enclosing_breakable_pin,
+                                    enclosing_compound_statement_pin).process_or_asgn(node, presence)
+
             new_node = node.updated(node.children[0].type, node.children[0].children + [node.children[1]])
             NodeProcessor.process(new_node, region, pins, locals, ivars)
           end

--- a/lib/solargraph/pin/namespace.rb
+++ b/lib/solargraph/pin/namespace.rb
@@ -16,6 +16,9 @@ module Solargraph
       # qualified
       attr_reader :closure
 
+      # node: (see CompoundStatement) carries this namespace body, which
+      # flow-sensitive typing scans to bound where a narrowed type holds.
+      #
       # @param type [::Symbol] :class or :module
       # @param visibility [::Symbol] :public or :private
       # @param gates [::Array<String>]

--- a/lib/solargraph/source/chain/or.rb
+++ b/lib/solargraph/source/chain/or.rb
@@ -40,7 +40,7 @@ module Solargraph
 
         protected
 
-        # @sg-ignore Fix "Not enough arguments to Module#protected"
+        # @sg-ignore return type could not be inferred
         def equality_fields
           # @sg-ignore literal arrays in this module turn into ::Solargraph::Source::Chain::Array
           super + [@links, @rhs_never_returns]

--- a/lib/solargraph/source/chain/or.rb
+++ b/lib/solargraph/source/chain/or.rb
@@ -31,7 +31,6 @@ module Solargraph
 
           combined_type = Solargraph::ComplexType.new(types)
           unless types.all?(&:nullable?)
-            # @sg-ignore flow sensitive typing should be able to handle redefinition
             combined_type = combined_type.without_nil
           end
 
@@ -40,7 +39,7 @@ module Solargraph
 
         protected
 
-        # @sg-ignore return type could not be inferred
+        # @sg-ignore literal arrays in this module turn into ::Solargraph::Source::Chain::Array
         def equality_fields
           # @sg-ignore literal arrays in this module turn into ::Solargraph::Source::Chain::Array
           super + [@links, @rhs_never_returns]

--- a/lib/solargraph/source/chain/or.rb
+++ b/lib/solargraph/source/chain/or.rb
@@ -7,14 +7,28 @@ module Solargraph
         attr_reader :links
 
         # @param links [::Array<Chain>]
-        def initialize links
+        # @param rhs_never_returns [Boolean] true if the right-hand side
+        #   necessarily leaves the enclosing compound statement (e.g.,
+        #   `x || raise('missing')`) - it never contributes a value to
+        #   this expression's result, so continuing past this
+        #   expression implies the left-hand side was truthy
+        def initialize links, rhs_never_returns: false
           super('<or>')
 
           @links = links
+          @rhs_never_returns = rhs_never_returns
         end
 
         def resolve api_map, name_pin, locals
           types = @links.map { |link| link.infer(api_map, name_pin, locals) }
+
+          if @rhs_never_returns
+            lhs_type = types.first
+            return [Solargraph::Pin::ProxyType.anonymous(Solargraph::ComplexType::UNDEFINED, source: :chain)] if lhs_type.nil?
+
+            return [Solargraph::Pin::ProxyType.anonymous(lhs_type.without_nil, source: :chain)]
+          end
+
           combined_type = Solargraph::ComplexType.new(types)
           unless types.all?(&:nullable?)
             # @sg-ignore flow sensitive typing should be able to handle redefinition
@@ -22,6 +36,14 @@ module Solargraph
           end
 
           [Solargraph::Pin::ProxyType.anonymous(combined_type, source: :chain)]
+        end
+
+        protected
+
+        # @sg-ignore Fix "Not enough arguments to Module#protected"
+        def equality_fields
+          # @sg-ignore literal arrays in this module turn into ::Solargraph::Source::Chain::Array
+          super + [@links, @rhs_never_returns]
         end
       end
     end

--- a/lib/solargraph/type_checker/rules.rb
+++ b/lib/solargraph/type_checker/rules.rb
@@ -71,21 +71,21 @@ module Solargraph
       #
       # pending code fixes (277):
       #
-      # @todo 281: Need to add nil check here
+      # @todo 278: Need to add nil check here
       # @todo 22: Translate to something flow sensitive typing understands
       # @todo 3: Need a downcast here
       #
       # flow sensitive typing could handle (96):
       #
       # @todo 36: flow sensitive typing needs to handle attrs
-      # @todo 29: flow sensitive typing should be able to handle redefinition
+      # @todo 28: flow sensitive typing should be able to handle redefinition
       # @todo 19: flow sensitive typing needs to narrow down type with an if is_a? check
       # @todo 13: Need to validate config
       # @todo 8: flow sensitive typing should support .class == .class
       # @todo 6: need boolish support for ? methods
       # @todo 6: flow sensitive typing needs better handling of ||= on lvars
-      # @todo 5: literal arrays in this module turn into ::Solargraph::Source::Chain::Array
-      # @todo 5: flow sensitive typing needs to handle 'raise if'
+      # @todo 6: literal arrays in this module turn into ::Solargraph::Source::Chain::Array
+      # @todo 4: flow sensitive typing needs to handle 'raise if'
       # @todo 4: flow sensitive typing needs to eliminate literal from union with [:bar].include?(foo)
       # @todo 4: nil? support in flow sensitive typing
       # @todo 3: flow sensitive typing ought to be able to handle 'when ClassName'

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -825,6 +825,38 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.rooted_tags).to eq('::Boolean')
   end
 
+  it 'uses is_a? in a return unless() at the top level of a file (no enclosing method) to refine types' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro < ReproBase; end
+      # @type [ReproBase, nil]
+      repr = Repro.new
+      return unless repr.is_a?(Repro)
+      repr
+  ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [6, 6])
+    expect(clip.infer.to_s).to eq('Repro')
+  end
+
+  it 'uses is_a? in a raise unless() at the top level of a class body (no enclosing method) to refine types' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro < ReproBase; end
+      class Container
+        # @type [ReproBase, nil]
+        repr = Repro.new
+        raise 'invalid' unless repr.is_a?(Repro)
+        repr
+      end
+  ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [7, 8])
+    expect(clip.infer.to_s).to eq('Repro')
+  end
+
   it 'uses .nil? in a raise if() to refine a type used as a call argument' do
     source = Solargraph::Source.load_string(%(
       class Foo

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -1102,6 +1102,50 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.rooted_tags).to eq('::Boolean')
   end
 
+  it 'narrows a plain ||= assignment on an lvar to eliminate nil' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro < ReproBase; end
+      # @param repr [Repro, nil]
+      # @return [void]
+      def verify_repro(repr)
+        repr ||= Repro.new
+        repr
+      end
+  ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [7, 8])
+
+    pending('flow sensitive typing needs better handling of ||= on lvars')
+
+    expect(clip.infer.to_s).to eq('Repro')
+  end
+
+  it 'narrows a ||= assignment on a keyword param to eliminate nil, with no nested nil check' do
+    source = Solargraph::Source.load_string(%(
+      class Foo
+        # @param baz [::Boolean, nil]
+        # @return [void]
+        def bar(baz: nil)
+          baz
+          baz ||= true
+          baz
+        end
+      end
+  ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [5, 10])
+    expect(clip.infer.rooted_tags).to eq('::Boolean, nil')
+
+    clip = api_map.clip_at('test.rb', [7, 10])
+
+    pending('flow sensitive typing needs better handling of ||= on lvars')
+
+    expect(clip.infer.rooted_tags).to eq('::Boolean')
+  end
+
   it 'uses .nil? in a return if() in a try / rescue / ensure to refine types using nil checks' do
     source = Solargraph::Source.load_string(%(
       class Foo

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -660,6 +660,61 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.rooted_tags).to eq('::Boolean')
   end
 
+  it 'uses .nil? in a raise if() in a method to refine types using nil checks' do
+    source = Solargraph::Source.load_string(%(
+      class Foo
+        # @param baz [::Boolean, nil]
+        # @return [void]
+        def bar(baz: nil)
+          raise 'baz required' if baz.nil?
+          baz
+        end
+      end
+    ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [6, 10])
+    expect(clip.infer.rooted_tags).to eq('::Boolean')
+  end
+
+  it 'uses .nil? in a raise if() to refine a type used as a call argument' do
+    source = Solargraph::Source.load_string(%(
+      class Foo
+        # @param baz [::Boolean, nil]
+        # @return [void]
+        def bar(baz: nil)
+          raise 'baz required' if baz.nil?
+          accepts_boolean(baz)
+        end
+
+        # @param b [::Boolean]
+        # @return [void]
+        def accepts_boolean(b); end
+      end
+    ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [6, 27])
+    expect(clip.infer.rooted_tags).to eq('::Boolean')
+  end
+
+  it 'uses .nil? in a raise if() to refine a type used as a call receiver' do
+    source = Solargraph::Source.load_string(%(
+      class Foo
+        # @param baz [String, nil]
+        # @return [void]
+        def bar(baz: nil)
+          raise 'baz required' if baz.nil?
+          baz.length
+        end
+      end
+    ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [6, 12])
+    expect(clip.infer.rooted_tags).to eq('::String')
+  end
+
   it 'uses .nil? in a return if() in a block to refine types using nil checks' do
     source = Solargraph::Source.load_string(%(
       class Foo

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -863,6 +863,26 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.rooted_tags).to eq('::String')
   end
 
+  it 'uses .nil? in a raise if() with a multi-statement branch to refine types' do
+    source = Solargraph::Source.load_string(%(
+      class Foo
+        # @param baz [String, nil]
+        # @return [void]
+        def bar(baz: nil)
+          if baz.nil?
+            valid = %w[a b c]
+            raise "baz required. Valid: \#{valid.inspect}"
+          end
+          baz.length
+        end
+      end
+    ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [9, 12])
+    expect(clip.infer.rooted_tags).to eq('::String')
+  end
+
   it 'uses .nil? in a return if() in a block to refine types using nil checks' do
     source = Solargraph::Source.load_string(%(
       class Foo

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -221,6 +221,96 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.to_s).to eq('ReproBase')
   end
 
+  it 'narrows a case/when subject to the matched class inside each branch' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro1 < ReproBase; end
+      class Repro2 < ReproBase; end
+      # @param repr [ReproBase]
+      def verify_repro(repr)
+        case repr
+        when Repro1
+          repr
+        when Repro2
+          repr
+        else
+          repr
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [8, 10])
+    expect(clip.infer.to_s).to eq('Repro1')
+
+    clip = api_map.clip_at('test.rb', [10, 10])
+    expect(clip.infer.to_s).to eq('Repro2')
+
+    clip = api_map.clip_at('test.rb', [12, 10])
+    expect(clip.infer.to_s).to eq('ReproBase')
+  end
+
+  it 'narrows a case/when subject to a union when a when clause has multiple values' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro1 < ReproBase; end
+      class Repro2 < ReproBase; end
+      class Repro3 < ReproBase; end
+      # @param repr [ReproBase]
+      def verify_repro(repr)
+        case repr
+        when Repro1, Repro2
+          repr
+        when Repro3
+          repr
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [9, 10])
+    expect(clip.infer.to_s).to eq('Repro1, Repro2')
+  end
+
+  it 'narrows a case/when subject to the matched class for an ivar subject' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro1 < ReproBase; end
+      class Foo
+        # @param repr [ReproBase]
+        def initialize(repr)
+          @repr = repr
+        end
+
+        # @return [void]
+        def verify
+          case @repr
+          when Repro1
+            @repr
+          end
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [13, 12])
+    expect(clip.infer.to_s).to eq('Repro1')
+  end
+
+  it 'does not narrow a case/when subject when a when clause value is not a simple constant' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro1 < ReproBase; end
+      # @param repr [ReproBase]
+      def verify_repro(repr)
+        case repr
+        when Repro1, some_dynamic_value
+          repr
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [7, 10])
+    expect(clip.infer.to_s).to eq('ReproBase')
+  end
+
   it 'uses is_a? in a "break unless" statement in an .each block to refine types' do
     source = Solargraph::Source.load_string(%(
       class ReproBase; end

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -1116,9 +1116,6 @@ describe Solargraph::Parser::FlowSensitiveTyping do
 
     api_map = Solargraph::ApiMap.new.map(source)
     clip = api_map.clip_at('test.rb', [7, 8])
-
-    pending('flow sensitive typing needs better handling of ||= on lvars')
-
     expect(clip.infer.to_s).to eq('Repro')
   end
 
@@ -1140,9 +1137,6 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.rooted_tags).to eq('::Boolean, nil')
 
     clip = api_map.clip_at('test.rb', [7, 10])
-
-    pending('flow sensitive typing needs better handling of ||= on lvars')
-
     expect(clip.infer.rooted_tags).to eq('::Boolean')
   end
 

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -94,6 +94,64 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.to_s).to eq('ReproBase')
   end
 
+  it 'uses is_a? in a simple if() to refine types on a root-scoped (::-prefixed) class' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      module Foo
+        class Repro < ReproBase; end
+      end
+      # @param repr [ReproBase]
+      def verify_repro(repr)
+        if repr.is_a?(::Foo::Repro)
+          repr
+        else
+          repr
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [8, 10])
+    expect(clip.infer.to_s).to eq('Foo::Repro')
+
+    clip = api_map.clip_at('test.rb', [10, 10])
+    expect(clip.infer.to_s).to eq('ReproBase')
+  end
+
+  it 'uses is_a? with a ::-prefixed class combined via && in a guard clause to refine types' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro < ReproBase; end
+      # @param repr [ReproBase]
+      # @return [void]
+      def verify_repro(repr)
+        return unless repr.is_a?(::Repro) && repr.respond_to?(:foo)
+        repr
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [7, 8])
+    expect(clip.infer.to_s).to eq('Repro')
+  end
+
+  it 'uses is_a? with a ::-prefixed class in an elsif to refine types in the branch body' do
+    source = Solargraph::Source.load_string(%(
+      class ReproBase; end
+      class Repro1 < ReproBase; end
+      class Repro2 < ReproBase; end
+      # @param repr [ReproBase]
+      def verify_repro(repr)
+        if repr.is_a?(Repro1)
+          repr
+        elsif repr.is_a?(::Repro2) && repr.respond_to?(:foo)
+          repr
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [9, 10])
+    expect(clip.infer.to_s).to eq('Repro2')
+  end
+
   it 'uses is_a? in a simple unless statement to refine types' do
     source = Solargraph::Source.load_string(%(
       class ReproBase; end

--- a/spec/source/chain/or_spec.rb
+++ b/spec/source/chain/or_spec.rb
@@ -47,6 +47,23 @@ describe Solargraph::Source::Chain::Or do
     expect(checker.problems).to be_empty
   end
 
+  it 'strips nil from the lhs type when the rhs always raises' do
+    source = Solargraph::Source.load_string(%(
+      class Example
+        # @param argv [Array<String>]
+        # @return [String]
+        def first_arg(argv)
+          x = argv[0] || raise('missing first argument')
+          x
+        end
+      end
+    ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [6, 10])
+    expect(clip.infer.simplify_literals.rooted_tags).to eq('::String')
+  end
+
   it 'infers just the lhs type when the rhs always fails via ||=' do
     source = Solargraph::Source.load_string(%(
       class Example

--- a/spec/source/chain/or_spec.rb
+++ b/spec/source/chain/or_spec.rb
@@ -80,4 +80,11 @@ describe Solargraph::Source::Chain::Or do
     checker = Solargraph::TypeChecker.new('test.rb', api_map: api_map)
     expect(checker.problems).to be_empty
   end
+
+  it 'falls back to undefined when the rhs never returns but there is no lhs type to infer' do
+    or_link = described_class.new([], rhs_never_returns: true)
+    api_map = Solargraph::ApiMap.new
+    pin = or_link.resolve(api_map, nil, []).first
+    expect(pin.return_type.tag).to eq('undefined')
+  end
 end

--- a/spec/source/chain/or_spec.rb
+++ b/spec/source/chain/or_spec.rb
@@ -30,4 +30,37 @@ describe Solargraph::Source::Chain::Or do
     clip = api_map.clip_at('test.rb', [3, 8])
     expect(clip.infer.simplify_literals.rooted_tags).to eq('::String')
   end
+
+  it 'infers just the lhs type when the rhs always raises' do
+    source = Solargraph::Source.load_string(%(
+      class Example
+        # @param argv [Array<String>]
+        # @return [String]
+        def first_arg(argv)
+          argv[0] || raise('missing first argument')
+        end
+      end
+    ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    checker = Solargraph::TypeChecker.new('test.rb', api_map: api_map)
+    expect(checker.problems).to be_empty
+  end
+
+  it 'infers just the lhs type when the rhs always fails via ||=' do
+    source = Solargraph::Source.load_string(%(
+      class Example
+        # @param name [String, nil]
+        # @return [String]
+        def resolved_name(name)
+          name ||= raise('name required')
+          name
+        end
+      end
+    ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    checker = Solargraph::TypeChecker.new('test.rb', api_map: api_map)
+    expect(checker.problems).to be_empty
+  end
 end


### PR DESCRIPTION
## Summary

Five related flow-sensitive-typing gaps, fixed together since they touch the same file and spec.

### raise/fail-based nil guards (fixes castwide/solargraph#1254)
- The parser gem parses `raise`/`fail` as a plain `:send` node, not a `:raise` node type, so `always_leaves_compound_statement?` never recognized a raise-based guard and it failed to narrow, unlike an equivalent `return`-based guard. Fix recognizes the `:send` shape (no receiver, method name `:raise`/`:fail`) alongside the existing keyword-based node types.

```ruby
x = maybe_nil        # String, nil
raise 'bad' unless x
x.upcase              # String
```

### root-scoped (::-prefixed) constants in is_a? narrowing (fixes castwide/solargraph#1251)
- `type_name` in `FlowSensitiveTyping` didn't recognize the `:cbase` node the parser gem emits for a leading `::` on a constant (`::Foo` parses as `s(:const, s(:cbase), :Foo)`), so any fully-qualified class name silently disabled `is_a?`-based narrowing. Fix recognizes `:cbase` and renders it as a leading `::`, recursing normally otherwise.

```ruby
x = value                    # Object, nil
raise unless x.is_a?(::Hash)
x.fetch(:k)                   # ::Hash
```

### case/when subject narrowing (fixes castwide/solargraph#1241)
- case/when had no flow-sensitive-typing support at all -- no NodeProcessor was registered for `:case` nodes, so a case subject kept its full (often union) static type in every branch.
- Fix adds a `CaseNode` processor and `FlowSensitiveTyping#process_case`, narrowing the subject to the union of each `when` clause's constant classes, scoped to that branch body only.

```ruby
case x                      # Foo, Bar
when Foo then x.foo_only    # Foo
end
```

### x ||= value on lvars/ivars
- `x ||= value` only assigns when `x` is falsy, so a prior non-nil value should survive -- but `OrasgnNode` rewrote it as a plain `x = value`, and plain-reassignment pins union together rather than override, so the narrowed type was lost.
- Fix adds `FlowSensitiveTyping#process_or_asgn`, reusing the same downcast-pin machinery that already powers `is_a?`/`nil?` narrowing to exclude `nil` from the prior type, scoped to the rest of the enclosing closure; no `@sg-ignore` comments remain anywhere in this fix.
- Conservative and scoped to `lvasgn`/`ivasgn` targets -- doesn't union in the RHS type when it differs from the variable's prior non-nil type.

```ruby
@x = nil     # String, nil
@x ||= compute
@x.upcase     # String
```

### is_a?/nil? guard narrowing at file and class-body scope
- `FlowSensitiveTyping#process_if` extends narrowing past a guard via `enclosing_compound_statement_pin.node`, but the root `Pin::Namespace` (`NodeProcessor.process`, one per file) and the per-class/module `Pin::Namespace` (`NamespaceNode`) never passed `node:`, so that pin's node was always `nil` and narrowing silently never applied there -- unlike `Pin::Method`/`Pin::Block`, which already pass `node:`.
- Fix passes `node:` through at both sites, matching the existing Method/Block pattern; the gap is specific to namespace-shaped compound statements (file root, class/module bodies), not "top-level" generally -- a block at the top level already narrowed correctly. Known follow-on, not fixed here: `SclassNode` (`class << self`) has the same missing `node:` (unverified), and `Pin::Base#combine_with`/`Closure#combine_with` don't carry `node:` forward across a reopened class merged from multiple files (doesn't affect this fix, since narrowing runs before combination).

```ruby
loaded = load_config          # Hash, nil
return unless loaded.is_a?(Hash)
loaded['key']                  # Hash
```
