### PR TITLE
Add specs for reverted fixes and uncovered branches

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -193,6 +193,7 @@ RSpec/DescribeClass:
     - '**/spec/system/**/*'
     - '**/spec/views/**/*'
     - 'spec/complex_type_spec.rb'
+    - 'spec/gemspec_spec.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 RSpec/ExpectActual:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -193,7 +193,6 @@ RSpec/DescribeClass:
     - '**/spec/system/**/*'
     - '**/spec/views/**/*'
     - 'spec/complex_type_spec.rb'
-    - 'spec/gemspec_spec.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
 RSpec/ExpectActual:

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -21,6 +21,20 @@ describe Solargraph::ApiMap do
   describe '#qualify' do
     let(:external_requires) { ['yaml'] }
 
+    it 'resolves a constant that aliases a namespace' do
+      source = Solargraph::Source.load_string(%(
+        class Foo; end
+
+        module Bar
+          Baz = ::Foo
+        end
+      ), 'test.rb')
+
+      api_map = described_class.new.map(source)
+
+      expect(api_map.qualify('Bar::Baz')).to eq('Foo')
+    end
+
     it 'understands alias namespaces resolving types' do
       source = Solargraph::Source.load_string(%(
         class Foo

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -925,6 +925,34 @@ describe Solargraph::ApiMap do
     expect(pins.map(&:return_type).map(&:tag)).to eq(%w[Integer Integer])
   end
 
+  it 'preserves duck type return tags in attached macros' do
+    source = Solargraph::SourceMap.load_string(%(
+      class Macro
+        # @!macro [new] duck_attr
+        #   @!method $1
+        #     @return [#quack]
+        # @param name [Symbol]
+        # @return [void]
+        def self.duck_attr(name); end
+
+        # @!macro [new] class_attr
+        #   @!method $1
+        #     @return [String]
+        # @param name [Symbol]
+        # @return [void]
+        def self.class_attr(name); end
+
+        duck_attr :ducky
+        class_attr :stringy
+      end
+    ), 'test.rb')
+    @api_map.catalog(Solargraph::Bench.new(source_maps: [source]))
+    expect(@api_map.get_path_pins('Macro#ducky').first.return_type.tag).to eq('#quack')
+    expect(@api_map.get_path_pins('Macro#stringy').first.return_type.tag).to eq('String')
+    methods = @api_map.get_complex_type_methods(Solargraph::ComplexType.parse('#quack'))
+    expect(methods.map(&:name)).to include('quack')
+  end
+
   it 'generates methods from @!attribute tag in attached dsl macros' do
     source = Solargraph::SourceMap.load_string(%(
       class Macro

--- a/spec/doc_map_spec.rb
+++ b/spec/doc_map_spec.rb
@@ -146,4 +146,21 @@ describe Solargraph::DocMap do
       Solargraph::Convention.unregister dummy_convention
     end
   end
+
+  describe '#combined_pins_in_memory' do
+    let(:pre_cache) { false }
+
+    it 'is shared across DocMap instances rather than memoized per instance' do
+      map1 = described_class.new([], workspace, out: nil)
+      map2 = described_class.new([], workspace, out: nil)
+      key = ['some-gem', Gem::Version.new('1.0.0')]
+      pins = [instance_double(Solargraph::Pin::Base)]
+
+      map1.combined_pins_in_memory[key] = pins
+
+      expect(map2.combined_pins_in_memory[key]).to equal(pins)
+    ensure
+      map1.combined_pins_in_memory.delete(key)
+    end
+  end
 end

--- a/spec/gemspec_spec.rb
+++ b/spec/gemspec_spec.rb
@@ -1,13 +1,15 @@
 # frozen_string_literal: true
 
-describe 'solargraph.gemspec' do
-  let(:spec) { Gem::Specification.load(File.expand_path('../solargraph.gemspec', __dir__)) }
+describe Gem::Specification do
+  describe 'loaded from solargraph.gemspec' do
+    let(:spec) { described_class.load(File.expand_path('../solargraph.gemspec', __dir__)) }
 
-  it 'does not package a top-level sig/ directory that RBS auto-discovers in installed gems' do
-    # A prior sig/shims directory collided with consumers' own RBS
-    # collections (see https://github.com/castwide/solargraph/issues/1144).
-    # The shims now live under rbs/shims instead, which RBS does not scan
-    # automatically.
-    expect(spec.files.grep(%r{^sig/})).to be_empty
+    it 'does not package a top-level sig/ directory that RBS auto-discovers in installed gems' do
+      # A prior sig/shims directory collided with consumers' own RBS
+      # collections (see https://github.com/castwide/solargraph/issues/1144).
+      # The shims now live under rbs/shims instead, which RBS does not scan
+      # automatically.
+      expect(spec.files.grep(%r{^sig/})).to be_empty
+    end
   end
 end

--- a/spec/gemspec_spec.rb
+++ b/spec/gemspec_spec.rb
@@ -4,11 +4,8 @@ describe Gem::Specification do
   describe 'loaded from solargraph.gemspec' do
     let(:spec) { described_class.load(File.expand_path('../solargraph.gemspec', __dir__)) }
 
-    it 'does not package a top-level sig/ directory that RBS auto-discovers in installed gems' do
-      # A prior sig/shims directory collided with consumers' own RBS
-      # collections (see https://github.com/castwide/solargraph/issues/1144).
-      # The shims now live under rbs/shims instead, which RBS does not scan
-      # automatically.
+    it "does not package a top-level sig/ directory, which RBS auto-discovers in installed gems and would collide with consumers' own RBS collections" do
+      # https://github.com/castwide/solargraph/issues/1144
       expect(spec.files.grep(%r{^sig/})).to be_empty
     end
   end

--- a/spec/gemspec_spec.rb
+++ b/spec/gemspec_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+describe 'solargraph.gemspec' do
+  let(:spec) { Gem::Specification.load(File.expand_path('../solargraph.gemspec', __dir__)) }
+
+  it 'does not package a top-level sig/ directory that RBS auto-discovers in installed gems' do
+    # A prior sig/shims directory collided with consumers' own RBS
+    # collections (see https://github.com/castwide/solargraph/issues/1144).
+    # The shims now live under rbs/shims instead, which RBS does not scan
+    # automatically.
+    expect(spec.files.grep(%r{^sig/})).to be_empty
+  end
+end

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -678,4 +678,14 @@ describe Solargraph::Library do
       expect { library.send(:sync_catalog) }.not_to raise_error
     end
   end
+
+  describe '#cache_next_gemspec' do
+    it 'does not start a new caching pass while one is already in progress' do
+      library = described_class.new
+      library.instance_variable_set(:@cache_progress, Solargraph::LanguageServer::Progress.new('Caching gem'))
+      allow(library).to receive(:report_cache_progress)
+      library.send(:cache_next_gemspec)
+      expect(library).not_to have_received(:report_cache_progress)
+    end
+  end
 end

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -497,4 +497,8 @@ describe Solargraph::Source::Chain::Call do
     clip = api_map.clip_at('test.rb', [14, 14])
     expect(clip.infer.rooted_tags).to eq('::Set<::Foo::Bar::Symbol>')
   end
+
+  it 'accepts a word with no location, for external callers that omit it' do
+    expect { described_class.new('foo') }.not_to raise_error
+  end
 end

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -111,6 +111,28 @@ describe Solargraph::Source::Chain::Call do
     expect(type.tag).to eq('String')
   end
 
+  it 'falls through a non-macro directive that names no registered macro' do
+    # @!visibility is a directive but not a macro, so `bar`'s pin has
+    # macros: [] and directives: [VisibilityDirective] - this exercises
+    # inferred_pins's directive branch, distinct from the macro branch
+    # covered above. Since no macro is registered under that directive's
+    # name, process_directive resolves nothing and falls through to
+    # ordinary body-probing, which infers String from the method body.
+    source = Solargraph::Source.load_string(%(
+      # @!visibility public
+      def bar
+        "hi"
+      end
+
+      bar
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map(source)
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(6, 9))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    expect(type.rooted_tags).to eq('::String')
+  end
+
   it 'infers generic types from Array#reverse' do
     source = Solargraph::Source.load_string(%(
       # @type [Array<String>]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -925,5 +925,36 @@ describe Solargraph::TypeChecker do
       # an error when trying to declare sub as Subclass
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
+
+    it 'still reports too few arguments through a Class<Foo<generic<T>>> receiver' do
+      checker = type_checker(%(
+        # @generic T
+        class Box
+          # @param a [generic<T>]
+          # @return [void]
+          def initialize(a); end
+        end
+
+        # @generic T
+        # @param k [Class<Box<generic<T>>>]
+        # @return [Box<generic<T>>]
+        def build(k)
+          k.new
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq(['Not enough arguments to Box.new'])
+    end
+
+    it 'checks arity against the receiver class initialize, not Class#initialize' do
+      checker = type_checker(%(
+        # @generic T
+        # @param k [Class<Array<generic<T>>>]
+        # @return [Array<generic<T>>]
+        def build(k)
+          k.new(1, 2, 3, 4)
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq(['Too many arguments to Array.new'])
+    end
   end
 end

--- a/spec/yard_map/cache_spec.rb
+++ b/spec/yard_map/cache_spec.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+describe Solargraph::YardMap::Cache do
+  let(:cache) { described_class.new }
+  let(:pins) { [Solargraph::Pin::Namespace.new(name: 'Foo')] }
+
+  it 'returns the pins previously set for a path' do
+    cache.set_path_pins('foo.rb', pins)
+    expect(cache.get_path_pins('foo.rb')).to eq(pins)
+  end
+
+  it 'returns nil for a path that was never set' do
+    expect(cache.get_path_pins('missing.rb')).to be_nil
+  end
+end

--- a/spec/yard_map/directives/domain_directive_spec.rb
+++ b/spec/yard_map/directives/domain_directive_spec.rb
@@ -1,0 +1,63 @@
+# frozen_string_literal: true
+
+describe Solargraph::YardMap::Directives::DomainDirective do
+  # @param code [String]
+  # @return [Array<Solargraph::Pin::Base>]
+  def pins_for code
+    Solargraph::SourceMap.map(Solargraph::Source.load_string(code, 'domain_directive_spec.rb')).pins
+  end
+
+  describe '.closure_at' do
+    it 'returns nil when no namespace pin contains the position' do
+      pins = pins_for(<<~RUBY)
+        class Foo
+        end
+      RUBY
+      position = Solargraph::Position.new(100, 0)
+      expect(described_class.closure_at(pins, position)).to be_nil
+    end
+
+    it 'returns the innermost namespace pin containing the position' do
+      pins = pins_for(<<~RUBY)
+        class Foo
+          class Bar
+          end
+        end
+      RUBY
+      position = Solargraph::Position.new(1, 4)
+      result = described_class.closure_at(pins, position)
+      expect(result.path).to eq('Foo::Bar')
+    end
+  end
+
+  describe '.process_directive' do
+    it 'adds the directive tag types to the enclosing namespace domains' do
+      pins = pins_for(<<~RUBY)
+        class Foo
+        end
+      RUBY
+      namespace = pins.find { |pin| pin.path == 'Foo' }
+      tag = instance_double(YARD::Tags::Tag, types: ['Bar'])
+      directive = instance_double(YARD::Tags::Directive, tag: tag)
+
+      result = described_class.process_directive(nil, pins, namespace.location.range.start, nil, directive)
+
+      expect(namespace.domains).to include('Bar')
+      expect(result).to eq([])
+    end
+
+    it 'falls back to the root pin when no namespace contains the position' do
+      pins = pins_for(<<~RUBY)
+        class Foo
+        end
+      RUBY
+      tag = instance_double(YARD::Tags::Tag, types: ['Bar'])
+      directive = instance_double(YARD::Tags::Directive, tag: tag)
+
+      result = described_class.process_directive(nil, pins, Solargraph::Position.new(100, 0), nil, directive)
+
+      expect(Solargraph::Pin::ROOT_PIN.domains).to include('Bar')
+      expect(result).to eq([])
+    end
+  end
+end


### PR DESCRIPTION
**Problem:** Several fixes in this repo have been reverted or silently re-broken with the full suite green, because no spec asserted the fixed behavior — most recently an attempt to infer through `Class<generic<T>>#new`, which degraded arity checking for any `Class<X>` with a generic anywhere inside `X`:

```ruby
# k : Class<Array<generic<T>>>
k.new(1, 2, 3, 4)
# reported: Too many arguments to Class#initialize
# expected: Too many arguments to Array.new
```

That was caught by hand and reverted, and CI would not have caught it — nor the constant-alias resolution, the `cache_next_gemspec` re-entrancy guard, the class-wide `combined_pins_in_memory`, the `Chain::Call.new` signature external callers depend on, or the gemspec packaging a top-level `sig/`.

**Solution:** Adds eight examples asserting each of those behaviors directly, plus seven covering units and branches no spec reached (`YardMap::Cache#get_path_pins`, `DomainDirective.closure_at` and `#process_directive`, and `Chain::Call`'s non-macro directive fallthrough).

Spec-only; no `lib/` change.

**Test plan:** Full suite 1661 examples, 0 failures, 67 pending. Both generic-`Class` arity specs verified to fail when the reverted change is replayed on this base.

