### PR TITLE
Structurally verify RBS interface-typed expectations

### DIFF
--- a/.github/workflows/rspec.yml
+++ b/.github/workflows/rspec.yml
@@ -25,14 +25,12 @@ jobs:
         #   It currently 404s ("Unavailable version head for ruby"), failing CI:
         #   https://github.com/castwide/solargraph/actions/runs/25863741955/job/76000137015?pr=1187
         ruby-version: ['3.1', '3.2', '3.3', '3.4', '4.0']
-        rbs-version: ['3.10.0', '4.0.0', '4.0.1', '4.0.2']
+        rbs-version: ['3.10.0', '4.0.3', '4.1.1']
         exclude:
           - ruby-version: '3.1'
-            rbs-version: '4.0.0'
+            rbs-version: '4.0.3'
           - ruby-version: '3.1'
-            rbs-version: '4.0.1'
-          - ruby-version: '3.1'
-            rbs-version: '4.0.2'
+            rbs-version: '4.1.1'
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -447,9 +447,9 @@ module Solargraph
     #
     # @param rooted_tag [String] The fully qualified namespace/interface to search for methods
     # @param scope [Symbol] :class or :instance
-    # @return [Array<Solargraph::Pin::Method>]
+    # @return [Enumerable<Solargraph::Pin::Method>]
     def get_own_methods rooted_tag, scope: :instance
-      get_methods(rooted_tag, scope: scope).select { |pin| pin.closure&.path == rooted_tag }
+      store.get_methods(ComplexType.try_parse(rooted_tag).namespace, scope: scope)
     end
 
     # Get an array of methods available in a particular context.

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -442,12 +442,9 @@ module Solargraph
       store.pins_by_class(Pin::Block)
     end
 
-    # Get the methods a namespace (e.g. an RBS interface) declares
-    # directly on itself, excluding ones inherited from Object,
-    # superclasses, or mixins. Useful for structural (duck-type)
-    # checks against an interface's own contract, e.g. whether some
-    # other type implements every method `Hash::_Key` itself declares
-    # (`#hash`, `#eql?`), independent of the interface's name.
+    # Methods a namespace declares directly on itself, excluding ones
+    # inherited from Object, superclasses, or mixins - e.g. the two
+    # methods `Hash::_Key` itself requires (`#hash`, `#eql?`).
     #
     # @param rooted_tag [String] The fully qualified namespace/interface to search for methods
     # @param scope [Symbol] :class or :instance

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -442,6 +442,20 @@ module Solargraph
       store.pins_by_class(Pin::Block)
     end
 
+    # Get the methods a namespace (e.g. an RBS interface) declares
+    # directly on itself, excluding ones inherited from Object,
+    # superclasses, or mixins. Useful for structural (duck-type)
+    # checks against an interface's own contract, e.g. whether some
+    # other type implements every method `Hash::_Key` itself declares
+    # (`#hash`, `#eql?`), independent of the interface's name.
+    #
+    # @param rooted_tag [String] The fully qualified namespace/interface to search for methods
+    # @param scope [Symbol] :class or :instance
+    # @return [Array<Solargraph::Pin::Method>]
+    def get_own_methods rooted_tag, scope: :instance
+      get_methods(rooted_tag, scope: scope).select { |pin| pin.closure&.path == rooted_tag }
+    end
+
     # Get an array of methods available in a particular context.
     #
     # @param rooted_tag [String] The fully qualified namespace to search for methods

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -443,8 +443,7 @@ module Solargraph
     end
 
     # Methods a namespace declares directly on itself, excluding ones
-    # inherited from Object, superclasses, or mixins - e.g. the two
-    # methods `Hash::_Key` itself requires (`#hash`, `#eql?`).
+    # inherited from Object, superclasses, or mixins.
     #
     # @param rooted_tag [String] The fully qualified namespace/interface to search for methods
     # @param scope [Symbol] :class or :instance

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -442,16 +442,6 @@ module Solargraph
       store.pins_by_class(Pin::Block)
     end
 
-    # Methods a namespace declares directly on itself, excluding ones
-    # inherited from Object, superclasses, or mixins.
-    #
-    # @param rooted_tag [String] The fully qualified namespace/interface to search for methods
-    # @param scope [Symbol] :class or :instance
-    # @return [Enumerable<Solargraph::Pin::Method>]
-    def get_own_methods rooted_tag, scope: :instance
-      store.get_methods(ComplexType.try_parse(rooted_tag).namespace, scope: scope)
-    end
-
     # Get an array of methods available in a particular context.
     #
     # @param rooted_tag [String] The fully qualified namespace to search for methods

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -138,9 +138,6 @@ module Solargraph
         true
       end
 
-      # The methods `expected` declares directly on itself, excluding ones
-      # inherited from `Object` and other ancestors.
-      #
       # @return [Array<Pin::Method>]
       def required_interface_methods
         api_map.get_own_methods(expected.name)

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -41,7 +41,7 @@ module Solargraph
           # :nocov:
         end
 
-        return true if ignore_interface?
+        return true if ignore_unmatchable_interface?
         return true if conforms_via_reverse_match?
 
         downcast_inferred = inferred.downcast_to_literal_if_possible
@@ -86,9 +86,14 @@ module Solargraph
         with_new_types(inferred, expected.erase_parameters).conforms_to_unique_type?
       end
 
-      def ignore_interface?
-        (expected.any?(&:interface?) && rules.include?(:allow_unmatched_interface)) ||
-          (inferred.interface? && rules.include?(:allow_unmatched_interface))
+      # An interface-typed expectation is verified structurally in
+      # #erased_type_conforms?. There's no equivalent structural check when
+      # the *inferred* type is itself an abstract interface (e.g., a method
+      # returns `_ToAry`), since Solargraph doesn't know which concrete type
+      # will show up at runtime, so :allow_unmatched_interface remains a
+      # blanket escape hatch for that direction only.
+      def ignore_unmatchable_interface?
+        inferred.interface? && rules.include?(:allow_unmatched_interface)
       end
 
       def can_strip_expected_parameters?
@@ -104,6 +109,8 @@ module Solargraph
       end
 
       def erased_type_conforms?
+        return true if expected.interface? && interface_conforms?
+
         case variance
         when :invariant
           return false unless inferred.name == expected.name
@@ -125,6 +132,43 @@ module Solargraph
           # :nocov:
         end
         true
+      end
+
+      # Whether `inferred` satisfies the `expected` RBS interface (e.g.
+      # `Hash::_Key`, `_ToAry`). Prefers real duck-type verification —
+      # `inferred` conforms if its method stack has every method the
+      # interface itself declares (methods it inherits from `Object` are
+      # ignored, since practically everything provides those) — and only
+      # falls back to the blanket :allow_unmatched_interface rule when no
+      # verdict could be reached, e.g. the interface pin isn't in the
+      # ApiMap.
+      #
+      # @return [Boolean]
+      def interface_conforms?
+        verdict = structural_interface_verdict
+        return verdict unless verdict.nil?
+
+        rules.include?(:allow_unmatched_interface)
+      end
+
+      # The methods `expected` declares directly on itself, excluding ones
+      # inherited from `Object` and other ancestors.
+      #
+      # @return [Array<Pin::Method>]
+      def required_interface_methods
+        api_map.get_methods(expected.name, scope: :instance)
+               .select { |pin| pin.closure&.path == expected.name }
+      end
+
+      # @return [Boolean, nil] true or false if `expected`'s directly
+      #   declared methods could be checked against `inferred`'s method
+      #   stack, or nil if no verdict could be reached (e.g., the interface
+      #   has no pin, or declares no methods of its own)
+      def structural_interface_verdict
+        required = required_interface_methods
+        return nil if required.empty?
+
+        required.all? { |pin| !api_map.get_method_stack(inferred.name, pin.name, scope: :instance).empty? }
       end
 
       def key_types_conform?

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -41,8 +41,8 @@ module Solargraph
           # :nocov:
         end
 
-        conformance = interface_conformance
-        return conformance unless conformance.nil?
+        return conforms_via_interface? if interface_declares_methods?
+        return true if expected.interface? && rules.include?(:allow_unmatched_interface)
 
         return true if conforms_via_reverse_match?
 
@@ -88,18 +88,10 @@ module Solargraph
         with_new_types(inferred, expected.erase_parameters).conforms_to_unique_type?
       end
 
-      # Settles conformance when `expected` is an RBS interface:
+      # Whether `expected` is an RBS interface declaring methods of its own:
       # https://github.com/ruby/rbs/blob/master/docs/syntax.md#interface-declaration
-      # Does not verify interface type params: https://github.com/castwide/solargraph/issues/1267
-      # @return [Boolean, nil] nil when no interface, or nothing here decides
-      def interface_conformance
-        return nil unless expected.interface?
-
-        structural = structural_interface_conformance
-        return structural unless structural.nil?
-        return true if rules.include?(:allow_unmatched_interface)
-
-        nil
+      def interface_declares_methods?
+        expected.interface? && !required_interface_methods.empty?
       end
 
       def can_strip_expected_parameters?
@@ -140,16 +132,13 @@ module Solargraph
 
       # @return [Array<Pin::Method>]
       def required_interface_methods
-        api_map.get_own_methods(expected.name)
+        @required_interface_methods ||= api_map.get_own_methods(expected.name)
       end
 
-      # @return [Boolean, nil] whether `inferred` implements every method the
-      #   interface declares, or nil if it has no pin or declares none
-      def structural_interface_conformance
-        required = required_interface_methods
-        return nil if required.empty?
-
-        required.all? { |pin| !api_map.get_method_stack(inferred.name, pin.name, scope: :instance).empty? }
+      # Whether `inferred` implements every method the interface declares; their
+      # signatures go unchecked: https://github.com/castwide/solargraph/issues/1267
+      def conforms_via_interface?
+        required_interface_methods.all? { |pin| !api_map.get_method_stack(inferred.name, pin.name, scope: :instance).empty? }
       end
 
       def key_types_conform?

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -88,25 +88,14 @@ module Solargraph
         with_new_types(inferred, expected.erase_parameters).conforms_to_unique_type?
       end
 
-      # Resolves interface-typed conformance before any parameter/subtype
-      # comparisons run, the same way the old blanket
-      # :allow_unmatched_interface bypass did. That's deliberate: RBS
-      # interfaces can have their own type parameters (e.g. `_Each[Elem]`),
-      # and this doesn't verify those (see
-      # https://github.com/castwide/solargraph/issues/1267), so once the
-      # interface question is settled, comparing `expected`'s subtypes
-      # against `inferred`'s would either be meaningless or wrong.
+      # Settles interface conformance before parameter/subtype checks,
+      # which don't apply once an interface is involved and whose own
+      # type parameters (e.g. `_Each[Elem]`) this doesn't verify:
+      # https://github.com/castwide/solargraph/issues/1267.
+      # :allow_unmatched_interface is the fallback when `inferred`
+      # itself is an interface, since its runtime type is unknown.
       #
-      # There's no structural check when the *inferred* type is itself an
-      # abstract interface (e.g., a method returns `_ToAry`), since
-      # Solargraph doesn't know which concrete type will show up at
-      # runtime, so :allow_unmatched_interface remains a blanket escape
-      # hatch for that direction.
-      #
-      # @return [Boolean, nil] true/false if the interface question
-      #   settles conformance outright, nil if there's no interface
-      #   involved (or no verdict could be reached and no fallback rule
-      #   applies), meaning normal conformance checking should proceed
+      # @return [Boolean, nil] settled verdict, or nil to fall through
       def interface_bypass_verdict
         return true if inferred.interface? && rules.include?(:allow_unmatched_interface)
         return nil unless expected.interface?
@@ -162,10 +151,8 @@ module Solargraph
         api_map.get_own_methods(expected.name)
       end
 
-      # @return [Boolean, nil] true or false if `expected`'s directly
-      #   declared methods could be checked against `inferred`'s method
-      #   stack, or nil if no verdict could be reached (e.g., the interface
-      #   has no pin, or declares no methods of its own)
+      # @return [Boolean, nil] verdict against `inferred`'s method stack,
+      #   or nil if the interface has no pin or declares no methods
       def structural_interface_verdict
         required = required_interface_methods
         return nil if required.empty?

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -88,13 +88,9 @@ module Solargraph
         with_new_types(inferred, expected.erase_parameters).conforms_to_unique_type?
       end
 
-      # Settles interface conformance before parameter/subtype checks,
-      # which don't apply once an interface is involved and whose own
-      # type parameters (e.g. `_Each[Elem]`) this doesn't verify:
-      # https://github.com/castwide/solargraph/issues/1267.
-      # :allow_unmatched_interface is the fallback when `inferred`
-      # itself is an interface, since its runtime type is unknown.
-      #
+      # Settles interface conformance before subtype checks (which don't
+      # apply once an interface is involved); doesn't verify an
+      # interface's own type params, see https://github.com/castwide/solargraph/issues/1267
       # @return [Boolean, nil] settled verdict, or nil to fall through
       def interface_bypass_verdict
         return true if inferred.interface? && rules.include?(:allow_unmatched_interface)

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -41,8 +41,8 @@ module Solargraph
           # :nocov:
         end
 
-        interface_verdict = interface_bypass_verdict
-        return interface_verdict unless interface_verdict.nil?
+        conformance = interface_conformance
+        return conformance unless conformance.nil?
 
         return true if conforms_via_reverse_match?
 
@@ -88,15 +88,18 @@ module Solargraph
         with_new_types(inferred, expected.erase_parameters).conforms_to_unique_type?
       end
 
-      # Settles interface conformance before subtype checks (which don't
-      # apply once an interface is involved); doesn't verify an
-      # interface's own type params, see https://github.com/castwide/solargraph/issues/1267
-      # @return [Boolean, nil] settled verdict, or nil to fall through
-      def interface_bypass_verdict
+      # Settles conformance when `expected` is an RBS interface, before
+      # subtype checks (which don't apply once an interface is involved);
+      # doesn't verify the interface's own type params, see
+      # https://github.com/castwide/solargraph/issues/1267
+      # https://github.com/ruby/rbs/blob/master/docs/syntax.md#interface-declaration
+      # @return [Boolean, nil] nil when `expected` is not an interface, or
+      #   when nothing here decides and the normal path should run
+      def interface_conformance
         return nil unless expected.interface?
 
-        verdict = structural_interface_verdict
-        return verdict unless verdict.nil?
+        structural = structural_interface_conformance
+        return structural unless structural.nil?
         return true if rules.include?(:allow_unmatched_interface)
 
         nil
@@ -143,9 +146,9 @@ module Solargraph
         api_map.get_own_methods(expected.name)
       end
 
-      # @return [Boolean, nil] verdict against `inferred`'s method stack,
-      #   or nil if the interface has no pin or declares no methods
-      def structural_interface_verdict
+      # @return [Boolean, nil] whether `inferred` implements every method the
+      #   interface declares, or nil if it has no pin or declares none
+      def structural_interface_conformance
         required = required_interface_methods
         return nil if required.empty?
 

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -93,7 +93,6 @@ module Solargraph
       # interface's own type params, see https://github.com/castwide/solargraph/issues/1267
       # @return [Boolean, nil] settled verdict, or nil to fall through
       def interface_bypass_verdict
-        return true if inferred.interface? && rules.include?(:allow_unmatched_interface)
         return nil unless expected.interface?
 
         verdict = structural_interface_verdict

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -91,7 +91,7 @@ module Solargraph
       # Whether `expected` is an RBS interface declaring methods of its own:
       # https://github.com/ruby/rbs/blob/master/docs/syntax.md#interface-declaration
       def interface_declares_methods?
-        expected.interface? && !required_interface_methods.empty?
+        expected.interface? && required_interface_methods.any?
       end
 
       def can_strip_expected_parameters?
@@ -130,7 +130,7 @@ module Solargraph
         true
       end
 
-      # @return [Array<Pin::Method>]
+      # @return [Enumerable<Pin::Method>]
       def required_interface_methods
         @required_interface_methods ||= api_map.get_own_methods(expected.name)
       end

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -88,13 +88,10 @@ module Solargraph
         with_new_types(inferred, expected.erase_parameters).conforms_to_unique_type?
       end
 
-      # Settles conformance when `expected` is an RBS interface, before
-      # subtype checks (which don't apply once an interface is involved);
-      # doesn't verify the interface's own type params, see
-      # https://github.com/castwide/solargraph/issues/1267
+      # Settles conformance when `expected` is an RBS interface:
       # https://github.com/ruby/rbs/blob/master/docs/syntax.md#interface-declaration
-      # @return [Boolean, nil] nil when `expected` is not an interface, or
-      #   when nothing here decides and the normal path should run
+      # Does not verify interface type params: https://github.com/castwide/solargraph/issues/1267
+      # @return [Boolean, nil] nil when no interface, or nothing here decides
       def interface_conformance
         return nil unless expected.interface?
 

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -41,7 +41,9 @@ module Solargraph
           # :nocov:
         end
 
-        return true if ignore_unmatchable_interface?
+        interface_verdict = interface_bypass_verdict
+        return interface_verdict unless interface_verdict.nil?
+
         return true if conforms_via_reverse_match?
 
         downcast_inferred = inferred.downcast_to_literal_if_possible
@@ -86,14 +88,34 @@ module Solargraph
         with_new_types(inferred, expected.erase_parameters).conforms_to_unique_type?
       end
 
-      # An interface-typed expectation is verified structurally in
-      # #erased_type_conforms?. There's no equivalent structural check when
-      # the *inferred* type is itself an abstract interface (e.g., a method
-      # returns `_ToAry`), since Solargraph doesn't know which concrete type
-      # will show up at runtime, so :allow_unmatched_interface remains a
-      # blanket escape hatch for that direction only.
-      def ignore_unmatchable_interface?
-        inferred.interface? && rules.include?(:allow_unmatched_interface)
+      # Resolves interface-typed conformance before any parameter/subtype
+      # comparisons run, the same way the old blanket
+      # :allow_unmatched_interface bypass did. That's deliberate: RBS
+      # interfaces can have their own type parameters (e.g. `_Each[Elem]`),
+      # and this doesn't verify those (see
+      # https://github.com/castwide/solargraph/issues/1267), so once the
+      # interface question is settled, comparing `expected`'s subtypes
+      # against `inferred`'s would either be meaningless or wrong.
+      #
+      # There's no structural check when the *inferred* type is itself an
+      # abstract interface (e.g., a method returns `_ToAry`), since
+      # Solargraph doesn't know which concrete type will show up at
+      # runtime, so :allow_unmatched_interface remains a blanket escape
+      # hatch for that direction.
+      #
+      # @return [Boolean, nil] true/false if the interface question
+      #   settles conformance outright, nil if there's no interface
+      #   involved (or no verdict could be reached and no fallback rule
+      #   applies), meaning normal conformance checking should proceed
+      def interface_bypass_verdict
+        return true if inferred.interface? && rules.include?(:allow_unmatched_interface)
+        return nil unless expected.interface?
+
+        verdict = structural_interface_verdict
+        return verdict unless verdict.nil?
+        return true if rules.include?(:allow_unmatched_interface)
+
+        nil
       end
 
       def can_strip_expected_parameters?
@@ -109,8 +131,6 @@ module Solargraph
       end
 
       def erased_type_conforms?
-        return true if expected.interface? && interface_conforms?
-
         case variance
         when :invariant
           return false unless inferred.name == expected.name
@@ -132,23 +152,6 @@ module Solargraph
           # :nocov:
         end
         true
-      end
-
-      # Whether `inferred` satisfies the `expected` RBS interface (e.g.
-      # `Hash::_Key`, `_ToAry`). Prefers real duck-type verification —
-      # `inferred` conforms if its method stack has every method the
-      # interface itself declares (methods it inherits from `Object` are
-      # ignored, since practically everything provides those) — and only
-      # falls back to the blanket :allow_unmatched_interface rule when no
-      # verdict could be reached, e.g. the interface pin isn't in the
-      # ApiMap.
-      #
-      # @return [Boolean]
-      def interface_conforms?
-        verdict = structural_interface_verdict
-        return verdict unless verdict.nil?
-
-        rules.include?(:allow_unmatched_interface)
       end
 
       # The methods `expected` declares directly on itself, excluding ones

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -159,8 +159,7 @@ module Solargraph
       #
       # @return [Array<Pin::Method>]
       def required_interface_methods
-        api_map.get_methods(expected.name, scope: :instance)
-               .select { |pin| pin.closure&.path == expected.name }
+        api_map.get_own_methods(expected.name)
       end
 
       # @return [Boolean, nil] true or false if `expected`'s directly

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -41,8 +41,10 @@ module Solargraph
           # :nocov:
         end
 
-        return conforms_via_interface? if interface_declares_methods?
-        return true if expected.interface? && rules.include?(:allow_unmatched_interface)
+        if expected.interface?
+          return conforms_via_interface? if required_interface_methods.any?
+          return true if rules.include?(:allow_unmatched_interface)
+        end
 
         return true if conforms_via_reverse_match?
 
@@ -88,12 +90,6 @@ module Solargraph
         with_new_types(inferred, expected.erase_parameters).conforms_to_unique_type?
       end
 
-      # Whether `expected` is an RBS interface declaring methods of its own:
-      # https://github.com/ruby/rbs/blob/master/docs/syntax.md#interface-declaration
-      def interface_declares_methods?
-        expected.interface? && required_interface_methods.any?
-      end
-
       def can_strip_expected_parameters?
         expected.parameters? && !inferred.parameters? && rules.include?(:allow_empty_params)
       end
@@ -130,9 +126,11 @@ module Solargraph
         true
       end
 
+      # The methods the RBS interface declares itself:
+      # https://github.com/ruby/rbs/blob/master/docs/syntax.md#interface-declaration
       # @return [Enumerable<Pin::Method>]
       def required_interface_methods
-        @required_interface_methods ||= api_map.get_own_methods(expected.name)
+        @required_interface_methods ||= api_map.get_methods(expected.name, scope: :instance, deep: false)
       end
 
       # Whether `inferred` implements every method the interface declares; their

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -81,7 +81,6 @@ describe Solargraph::ComplexType do
   end
 
   it 'handles singleton types compared against their literals' do
-    pending 'https://github.com/castwide/solargraph/issues/1196'
     pending 'https://github.com/castwide/solargraph/pull/1223'
     exp = Solargraph::ComplexType::UniqueType.new('nil', rooted: true)
     inf = Solargraph::ComplexType::UniqueType.new('NilClass', rooted: true)

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -283,11 +283,7 @@ describe Solargraph::ComplexType do
     end
 
     it 'rejects a same-named method with the wrong return type' do
-      # https://github.com/castwide/solargraph/issues/1267
-      #
-      # The structural check only confirms a `to_ary` method exists; it
-      # doesn't verify it actually returns an Array.
-      pending 'structural interface conformance does not yet check method return types (issue #1267)'
+      pending 'https://github.com/castwide/solargraph/issues/1267'
       source = Solargraph::Source.load_string(%(
         class BadToAry
           # @return [String]
@@ -304,11 +300,7 @@ describe Solargraph::ComplexType do
     end
 
     it 'rejects a same-named method with the wrong arity' do
-      # https://github.com/castwide/solargraph/issues/1267
-      #
-      # The structural check only confirms an `eql?` method exists; it
-      # doesn't verify it accepts the argument Hash::_Key#eql? requires.
-      pending 'structural interface conformance does not yet check method parameters (issue #1267)'
+      pending 'https://github.com/castwide/solargraph/issues/1267'
       source = Solargraph::Source.load_string(%(
         class BadKey
           def eql?

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -275,6 +275,51 @@ describe Solargraph::ComplexType do
       expect(inf.conforms_to?(api_map, exp, :method_call, [:allow_unmatched_interface])).to be(true)
       expect(inf.conforms_to?(api_map, exp, :method_call)).to be(false)
     end
+
+    it 'rejects a same-named method with the wrong return type' do
+      # https://github.com/castwide/solargraph/issues/1267
+      #
+      # The structural check only confirms a `to_ary` method exists; it
+      # doesn't verify it actually returns an Array.
+      pending 'structural interface conformance does not yet check method return types (issue #1267)'
+      source = Solargraph::Source.load_string(%(
+        class BadToAry
+          # @return [String]
+          def to_ary
+            'not an array'
+          end
+        end
+      ))
+      api_map.map source
+      exp = described_class.parse('_ToAry')
+      inf = described_class.parse('BadToAry')
+      match = inf.conforms_to?(api_map, exp, :method_call)
+      expect(match).to be(false)
+    end
+
+    it 'rejects a same-named method with the wrong arity' do
+      # https://github.com/castwide/solargraph/issues/1267
+      #
+      # The structural check only confirms an `eql?` method exists; it
+      # doesn't verify it accepts the argument Hash::_Key#eql? requires.
+      pending 'structural interface conformance does not yet check method parameters (issue #1267)'
+      source = Solargraph::Source.load_string(%(
+        class BadKey
+          def eql?
+            true
+          end
+
+          def hash
+            1
+          end
+        end
+      ))
+      api_map.map source
+      exp = described_class.parse('Hash::_Key')
+      inf = described_class.parse('BadKey')
+      match = inf.conforms_to?(api_map, exp, :method_call)
+      expect(match).to be(false)
+    end
   end
 
   context 'with inheritance relationship in allow_reverse_match mode' do

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -81,13 +81,8 @@ describe Solargraph::ComplexType do
   end
 
   it 'handles singleton types compared against their literals' do
-    # https://github.com/castwide/solargraph/issues/1196
-    #
-    # `nil` doesn't yet simplify to `NilClass` the way other literals
-    # simplify to their class name. Fixed by
-    # https://github.com/castwide/solargraph/pull/1223 (stacked:
-    # https://github.com/apiology/solargraph/pull/40).
-    pending 'nil does not yet simplify to NilClass (issue #1196, fixed by PR #1223)'
+    pending 'https://github.com/castwide/solargraph/issues/1196'
+    pending 'https://github.com/castwide/solargraph/pull/1223'
     exp = Solargraph::ComplexType::UniqueType.new('nil', rooted: true)
     inf = Solargraph::ComplexType::UniqueType.new('NilClass', rooted: true)
     match = inf.conforms_to?(api_map, exp, :method_call)

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -81,7 +81,13 @@ describe Solargraph::ComplexType do
   end
 
   it 'handles singleton types compared against their literals' do
-    pending 'side of effect of inference changes'
+    # https://github.com/castwide/solargraph/issues/1196
+    #
+    # `nil` doesn't yet simplify to `NilClass` the way other literals
+    # simplify to their class name. Fixed by
+    # https://github.com/castwide/solargraph/pull/1223 (stacked:
+    # https://github.com/apiology/solargraph/pull/40).
+    pending 'nil does not yet simplify to NilClass (issue #1196, fixed by PR #1223)'
     exp = Solargraph::ComplexType::UniqueType.new('nil', rooted: true)
     inf = Solargraph::ComplexType::UniqueType.new('NilClass', rooted: true)
     match = inf.conforms_to?(api_map, exp, :method_call)

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -240,6 +240,43 @@ describe Solargraph::ComplexType do
     end
   end
 
+  context 'with RBS interface types' do
+    it 'structurally validates a type that satisfies the interface, without any rule' do
+      exp = described_class.parse('Hash::_Key')
+      inf = described_class.parse('Symbol')
+      match = inf.conforms_to?(api_map, exp, :method_call)
+      expect(match).to be(true)
+    end
+
+    it 'structurally invalidates a type that does not satisfy the interface, even with allow_unmatched_interface' do
+      exp = described_class.parse('_ToAry')
+      inf = described_class.parse('Integer')
+      match = inf.conforms_to?(api_map, exp, :method_call, [:allow_unmatched_interface])
+      expect(match).to be(false)
+    end
+
+    it 'rejects a type that does not satisfy the interface when the rule is absent' do
+      exp = described_class.parse('_ToAry')
+      inf = described_class.parse('Integer')
+      match = inf.conforms_to?(api_map, exp, :method_call)
+      expect(match).to be(false)
+    end
+
+    it 'validates a type that satisfies the interface via a core fill include' do
+      exp = described_class.parse('_ToAry')
+      inf = described_class.parse('Array')
+      match = inf.conforms_to?(api_map, exp, :method_call)
+      expect(match).to be(true)
+    end
+
+    it 'falls back to allow_unmatched_interface when the interface pin cannot be found' do
+      exp = described_class::UniqueType.new('_NoSuchInterface', rooted: true)
+      inf = described_class.parse('Integer')
+      expect(inf.conforms_to?(api_map, exp, :method_call, [:allow_unmatched_interface])).to be(true)
+      expect(inf.conforms_to?(api_map, exp, :method_call)).to be(false)
+    end
+  end
+
   context 'with inheritance relationship in allow_reverse_match mode' do
     let(:api_map) { Solargraph::ApiMap.new }
     let(:sup) { described_class.parse('String') }

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -241,29 +241,74 @@ describe Solargraph::ComplexType do
   end
 
   context 'with RBS interface types' do
+    around do |example|
+      require 'tmpdir'
+      Dir.mktmpdir('rspec-solargraph-') do |dir|
+        @temp_dir = dir
+        example.run
+      end
+    end
+
+    attr_reader :temp_dir
+
+    # Declared here rather than reused from core RBS, whose interfaces vary by version.
+    let(:rbs) do
+      <<~RBS
+        interface _MyKey
+          def hash: () -> Integer
+          def eql?: (untyped) -> bool
+        end
+
+        interface _MyToAry
+          def to_ary: () -> Array[untyped]
+        end
+
+        class MyKeyImpl
+          def hash: () -> Integer
+          def eql?: (untyped) -> bool
+        end
+
+        class BadToAry
+          def to_ary: () -> String
+        end
+
+        class BadKey
+          def eql?: () -> bool
+          def hash: () -> Integer
+        end
+      RBS
+    end
+
+    let(:api_map) do
+      File.write(File.join(temp_dir, 'interfaces.rbs'), rbs)
+      loader = RBS::EnvironmentLoader.new(core_root: nil, repository: RBS::Repository.new(no_stdlib: false))
+      loader.add(path: Pathname(temp_dir))
+      Solargraph::ApiMap.new.index(Solargraph::RbsMap::Conversions.new(loader: loader).pins)
+    end
+
     it 'structurally validates a type that satisfies the interface, without any rule' do
-      exp = described_class.parse('Hash::_Key')
-      inf = described_class.parse('Symbol')
+      exp = described_class.parse('_MyKey')
+      inf = described_class.parse('MyKeyImpl')
       match = inf.conforms_to?(api_map, exp, :method_call)
       expect(match).to be(true)
     end
 
     it 'structurally invalidates a type that does not satisfy the interface, even with allow_unmatched_interface' do
-      exp = described_class.parse('_ToAry')
+      exp = described_class.parse('_MyToAry')
       inf = described_class.parse('Integer')
       match = inf.conforms_to?(api_map, exp, :method_call, [:allow_unmatched_interface])
       expect(match).to be(false)
     end
 
     it 'rejects a type that does not satisfy the interface when the rule is absent' do
-      exp = described_class.parse('_ToAry')
+      exp = described_class.parse('_MyToAry')
       inf = described_class.parse('Integer')
       match = inf.conforms_to?(api_map, exp, :method_call)
       expect(match).to be(false)
     end
 
     it 'validates a type that satisfies the interface via a core fill include' do
-      exp = described_class.parse('_ToAry')
+      exp = described_class.parse('_MyToAry')
       inf = described_class.parse('Array')
       match = inf.conforms_to?(api_map, exp, :method_call)
       expect(match).to be(true)
@@ -278,16 +323,7 @@ describe Solargraph::ComplexType do
 
     it 'rejects a same-named method with the wrong return type' do
       pending 'https://github.com/castwide/solargraph/issues/1267'
-      source = Solargraph::Source.load_string(%(
-        class BadToAry
-          # @return [String]
-          def to_ary
-            'not an array'
-          end
-        end
-      ))
-      api_map.map source
-      exp = described_class.parse('_ToAry')
+      exp = described_class.parse('_MyToAry')
       inf = described_class.parse('BadToAry')
       match = inf.conforms_to?(api_map, exp, :method_call)
       expect(match).to be(false)
@@ -295,19 +331,7 @@ describe Solargraph::ComplexType do
 
     it 'rejects a same-named method with the wrong arity' do
       pending 'https://github.com/castwide/solargraph/issues/1267'
-      source = Solargraph::Source.load_string(%(
-        class BadKey
-          def eql?
-            true
-          end
-
-          def hash
-            1
-          end
-        end
-      ))
-      api_map.map source
-      exp = described_class.parse('Hash::_Key')
+      exp = described_class.parse('_MyKey')
       inf = described_class.parse('BadKey')
       match = inf.conforms_to?(api_map, exp, :method_call)
       expect(match).to be(false)

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -321,6 +321,27 @@ describe Solargraph::ComplexType do
       expect(inf.conforms_to?(api_map, exp, :method_call)).to be(false)
     end
 
+    it 'validates against a union whose interface member is satisfied' do
+      exp = described_class.parse('_MyToAry, Integer')
+      inf = described_class.parse('Array')
+      match = inf.conforms_to?(api_map, exp, :method_call)
+      expect(match).to be(true)
+    end
+
+    it 'validates regardless of where the interface sits in the union' do
+      exp = described_class.parse('Integer, _MyToAry')
+      inf = described_class.parse('Array')
+      match = inf.conforms_to?(api_map, exp, :method_call)
+      expect(match).to be(true)
+    end
+
+    it 'invalidates against a union when no member is satisfied' do
+      exp = described_class.parse('_MyToAry, Integer')
+      inf = described_class.parse('String')
+      match = inf.conforms_to?(api_map, exp, :method_call)
+      expect(match).to be(false)
+    end
+
     it 'rejects a same-named method with the wrong return type' do
       pending 'https://github.com/castwide/solargraph/issues/1267'
       exp = described_class.parse('_MyToAry')

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -997,5 +997,26 @@ describe Solargraph::TypeChecker do
       # an error when trying to declare sub as Subclass
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
+
+    it "picks Hash#fetch's Hash::_Key-typed overload for a Symbol key instead of merging in the block form's generic" do
+      checker = type_checker(%(
+        class Foo; end
+
+        class Holder
+          # @return [Hash{Symbol => Class<Foo>}]
+          def registry
+            { x: Foo }
+          end
+
+          # @return [Foo]
+          def use_it
+            # @type [Class<Foo>]
+            clazz = registry.fetch(:x)
+            clazz.new
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq([])
+    end
   end
 end


### PR DESCRIPTION
*🤖 Filed by Claude, not Vince — acting on his behalf via his GitHub credentials.*

## Problem

RBS 4.1 broke hash lookups in Solargraph.

```ruby
# @param registry [Hash{Symbol => Array<String>}]
# @return [Integer]
def count(registry)
  # #count return type could not be inferred
  registry.fetch(:x).length
end
```

4.1 loosened `Hash`'s key lookups from the class parameter `K` to the structural interface `Hash::_Key`. Solargraph has rough workarounds for a few existing interfaces and no general way to satisfy one, so `Symbol` fails to match the parameter, every `#[]` and `#fetch` overload is rejected as a non-match, and the caller is left with no usable type.

```rbs
class Hash[unchecked out K, unchecked out V]
  # rbs 4.0.3
  def fetch: (K arg0) -> V

  # rbs 4.1.3 — no K anywhere in the signature
  def fetch: (_Key key) -> V

  interface _Key
    def hash: () -> Integer
    def eql?: (untyped rhs) -> boolish
  end
end
```

## Solution

Match interfaces structurally: an inferred type conforms to an interface-typed expectation if its own method stack has every method the interface declares. `Symbol` has `#hash` and `#eql?`, so it satisfies `Hash::_Key` without anyone declaring an `include`.

`:allow_unmatched_interface` now applies only where the expected interface has no methods Solargraph can see, leaving nothing to check.

Limitation: generic interfaces (`_Each[Elem]`) are checked by method name only, not parameter or return types, since they get turned into YARD `#duck_types`.

Fixes https://github.com/castwide/solargraph/issues/1232
