### PR TITLE
Fix false positive: Struct.new(keyword_init: true) members are optional

### DIFF
--- a/lib/solargraph/convention/struct_definition.rb
+++ b/lib/solargraph/convention/struct_definition.rb
@@ -45,7 +45,7 @@ module Solargraph
               initialize_method_pin.parameters.push(
                 Pin::Parameter.new(
                   name: attribute_name,
-                  decl: struct_definition_node.keyword_init? ? :kwarg : :arg,
+                  decl: struct_definition_node.keyword_init? ? :kwoptarg : :arg,
                   location: get_node_location(attribute_node),
                   closure: initialize_method_pin,
                   source: :struct_definition

--- a/spec/convention/struct_definition_spec.rb
+++ b/spec/convention/struct_definition_spec.rb
@@ -23,6 +23,19 @@ describe Solargraph::Convention::StructDefinition do
       expect(param_baz.return_type.tag).to eql('Integer')
     end
 
+    it 'treats keyword args as optional, since Ruby defaults omitted members to nil' do
+      source = Solargraph::SourceMap.load_string(%(
+        # @param bar [String]
+        # @param baz [Integer]
+        Foo = Struct.new(:bar, :baz, keyword_init: true)
+      ), 'test.rb')
+
+      # @type [Array<Solargraph::Pin::Parameter>]
+      params = source.pins.find { |p| p.path == 'Foo#initialize' }.parameters
+
+      expect(params.map(&:decl)).to eql(%i[kwoptarg kwoptarg])
+    end
+
     it 'sets closure to method on assignment operator parameters' do
       source = Solargraph::SourceMap.load_string(%(
         # @param bar [String]
@@ -147,6 +160,20 @@ describe Solargraph::Convention::StructDefinition do
         Foo = Struct.new(:bar, :baz)
       ))
       expect { checker.problems }.not_to raise_error
+    end
+
+    it 'does not report a missing keyword argument when a keyword_init member is omitted' do
+      checker = type_checker(%(
+        class Watch < Struct.new(:name, :time, keyword_init: true); end
+
+        class Caller
+          # @return [Watch]
+          def go
+            Watch.new(name: 'foo')
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).not_to include(a_string_matching(/Missing keyword argument/))
     end
   end
 end

--- a/spec/convention/struct_definition_spec.rb
+++ b/spec/convention/struct_definition_spec.rb
@@ -30,7 +30,6 @@ describe Solargraph::Convention::StructDefinition do
         Foo = Struct.new(:bar, :baz, keyword_init: true)
       ), 'test.rb')
 
-      # @type [Array<Solargraph::Pin::Parameter>]
       params = source.pins.find { |p| p.path == 'Foo#initialize' }.parameters
 
       expect(params.map(&:decl)).to eql(%i[kwoptarg kwoptarg])


### PR DESCRIPTION
## Summary

`solargraph typecheck --level strong` treated every member of a `Struct.new(..., keyword_init: true)`-generated class as a *required* keyword argument, reporting a false "Missing keyword argument" error when a call site omitted one. At runtime, `keyword_init: true` Struct members default to `nil` when omitted, exactly like ordinary `Struct.new(...)` members.

`lib/solargraph/convention/struct_definition.rb` generated `Pin::Parameter` pins for keyword-init Struct members with `decl: :kwarg` (required). Changed to `decl: :kwoptarg` (optional), matching how `TypeChecker#parameterized_arity_problems_for` already distinguishes required (`:kwarg`) from optional (`:kwoptarg`) keyword parameters.

`Data.define` (`lib/solargraph/convention/data_definition.rb`) is untouched ��� its members genuinely are required at runtime, so `:kwarg` stays correct there.

```ruby
class Watch < Struct.new(:name, :time, keyword_init: true); end

class Caller
  # @return [Watch]
  def go
    Watch.new(name: 'foo') # no longer flagged as missing `time:`
  end
end
```

Fixes #1268

## Test plan
- [x] Added spec asserting keyword-init Struct parameters have `decl == :kwoptarg`
- [x] Added typecheck spec reproducing the issue's exact repro, asserting no "Missing keyword argument" problem
- [x] `bundle exec rspec` (full suite): 1626 examples, 0 failures
- [x] `bundle exec rubocop` on changed files: no offenses
- [x] Manually ran `solargraph typecheck --level strong` against the issue's repro: 0 problems found (previously reported the false positive)

���� Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TqwAY5yf6K1ZQdYoSZDkmy