### PR TITLE
Fix Chain#nullable? leaking nil from earlier &. into later calls

### DIFF
--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -168,7 +168,7 @@ module Solargraph
           return ComplexType::UNDEFINED
         end
         type = infer_from_definitions(pins, links.last.last_context, api_map, locals)
-        out = maybe_nil(type)
+        out = maybe_nil(type, api_map)
         logger.debug do
           "Chain#infer_uncached(links=#{links.map(&:desc)}, locals=#{locals.map(&:desc)}, " \
             "name_pin=#{name_pin}, name_pin.closure=#{name_pin&.closure&.inspect}, " \
@@ -199,11 +199,38 @@ module Solargraph
         @splat
       end
 
-      # @sg-ignore return type could not be inferred
+      # Whether this chain's inferred type should have nil added to it
+      # because a `&.` earlier in the chain might have short-circuited
+      # evaluation to nil.
+      #
+      # A `&.` only makes the *immediate* call nil-or-normal-result; a
+      # later, non-safe-navigated call in the same chain is still
+      # invoked on whatever that produced. If receiver is nil at that
+      # point, Ruby calls the method on nil itself instead of skipping
+      # it - so nil only continues to flow through subsequent links
+      # that NilClass defines as returning `self` (e.g., #tap,
+      # #itself). Any other subsequent call resolves to a concrete,
+      # non-nil-including type (e.g. NilClass#== returns Boolean), and
+      # nil no longer needs to be tracked past that point (unless a
+      # later `&.` reintroduces it).
+      #
+      # @param api_map [ApiMap]
       # @return [Boolean]
-      def nullable?
-        # @sg-ignore Need to add nil check here
-        links.last.nullable?
+      def nullable? api_map
+        currently_nullable = false
+        links.each do |link|
+          if link.nullable?
+            currently_nullable = true
+            next
+          end
+          next unless currently_nullable
+          next unless link.is_a?(Chain::Call)
+
+          pin = api_map.get_method_stack('NilClass', link.word, scope: :instance).first
+          # @sg-ignore Need to add nil check here
+          currently_nullable = pin.nil? || pin.return_type.tag == 'self'
+        end
+        currently_nullable
       end
 
       include Logging
@@ -289,10 +316,11 @@ module Solargraph
       end
 
       # @param type [ComplexType, ComplexType::UniqueType]
+      # @param api_map [ApiMap]
       # @return [ComplexType, ComplexType::UniqueType]
-      def maybe_nil type
+      def maybe_nil type, api_map
         return type if type.undefined? || type.void? || type.nullable?
-        return type unless nullable?
+        return type unless nullable?(api_map)
         ComplexType.new(type.items + [ComplexType::NIL])
       end
 

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -199,8 +199,11 @@ module Solargraph
         @splat
       end
 
+      # @sg-ignore return type could not be inferred
+      # @return [Boolean]
       def nullable?
-        links.any?(&:nullable?)
+        # @sg-ignore Need to add nil check here
+        links.last.nullable?
       end
 
       include Logging

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -154,6 +154,32 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).not_to be_empty
     end
 
+    it 'still flags nil leaking through a self-returning call after an earlier &.' do
+      checker = type_checker(%(
+        class Repro
+          # @param x [String, nil]
+          # @return [String]
+          def process(x)
+            x&.to_s.itself
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).not_to be_empty
+    end
+
+    it 'does not flag a call after &. whose result on NilClass is a fixed non-nil type' do
+      checker = type_checker(%(
+        class Repro
+          # @param x [String, nil]
+          # @return [Integer]
+          def process(x)
+            x&.to_s.to_i
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     it 'is able to probe type over an assignment' do
       checker = type_checker(%(
         # @return [String]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -128,6 +128,32 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to be_empty
     end
 
+    it 'does not leak nil from an earlier &. into an unrelated later call in the same chain' do
+      checker = type_checker(%(
+        class Repro
+          # @param x [String, nil]
+          # @return [Boolean]
+          def process(x)
+            x&.to_s == '1'
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
+    it 'still flags a chain ending in a safe navigation call as nullable' do
+      checker = type_checker(%(
+        class Repro
+          # @param x [String, nil]
+          # @return [String]
+          def process(x)
+            x&.to_s
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).not_to be_empty
+    end
+
     it 'is able to probe type over an assignment' do
       checker = type_checker(%(
         # @return [String]


### PR DESCRIPTION
## Summary

`Chain#nullable?` decided whether to add `nil` to a chain's inferred type based on whether *any* link in the chain used safe navigation (`&.`), rather than whether nil could actually still be flowing by the time the chain finishes evaluating. This caused `nil` to be appended to the inferred type of a trailing call (e.g. `==`) even when that call is guaranteed to return a non-nilable type, as long as an earlier `&.` appeared anywhere in the same chain.

```ruby
class Repro
  # @param x [String, nil]
  # @return [Boolean]
  def process(x)
    x&.to_s == '1'
  end
end
```

Before: `solargraph typecheck --level strong` reported `Declared return type ::Boolean does not match inferred type ::Boolean, nil for Repro#process`. After: no problem reported.

### Fix

`&.` only short-circuits the *immediate* call - a later, non-safe-navigated call in the same chain still runs on whatever the `&.` call produced. If that's `nil`, Ruby calls the method on `nil` itself (rather than skipping it), so `nil` only continues to flow forward through subsequent calls that `NilClass` itself defines as returning `self` (e.g. `#tap`, `#itself`). Any other subsequent call resolves to a concrete, non-nil-including type (e.g. `NilClass#==` returns `Boolean`), so `nil` no longer needs to be tracked past that point - unless a later `&.` reintroduces it.

An earlier version of this fix just checked the chain's *last* link, which is unsound: it silently stopped flagging chains like `x&.to_s.itself` or `x&.to_s.tap { }`, where `nil` genuinely does propagate to the end since `tap`/`itself` return their receiver unchanged. The current fix walks the whole chain, tracking nil-flow link by link and consulting `NilClass`'s own method definitions (via `ApiMap#get_method_stack`) to decide whether each subsequent call resets or preserves it.

Fixes https://github.com/castwide/solargraph/issues/1270

## Test plan

- [x] Regression specs in `spec/type_checker/levels/strong_spec.rb` covering: the issue's `==` false positive, a chain still correctly flagged when it ends in `&.`, the `tap`/`itself` false-negative case, and a fixed-return-type call (`to_i`) after `&.` correctly clearing nullability
- [x] `bundle exec rspec spec/type_checker/ spec/source/chain_spec.rb spec/source/chain/` passes
- [x] `bundle exec rspec` (full suite) - same single pre-existing unrelated failure with and without this change (`spec/pin/method_spec.rb:526`)
- [x] `bundle exec rubocop` clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XRSe8diudqUUud4dNkV6MD
