### PR TITLE
Stop dropping union members that differ only by type parameter

### DIFF
--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -70,7 +70,7 @@ module Solargraph
           # been resolved to different return types for their
           # respective context. Dedup on both so we don't silently
           # drop every member but the first.
-          # @param p [Pin::Base]
+          # @sg-ignore uniq's block param isn't inferred from the receiver's element type (Array#first is)
           pins = pin_groups.flatten.uniq { |p| [p.path, p.return_type.tag] }
           return [] if pins.empty?
           inferred_pins(pins, api_map, name_pin, locals)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -64,10 +64,10 @@ module Solargraph
             [stack.first].compact
           end
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:empty?)
-          # Union members resolve the same method path against different
-          # contexts, so pins can share a path yet return different types;
-          # keying on path alone would drop all but the first from the union.
-          # @sg-ignore uniq's block param isn't inferred from the receiver's element type
+          # Dedup on path and resolved return type. Union members resolve the
+          # same path against different contexts, so pins can share a path yet
+          # return different types; keying on path alone drops all but the first.
+          # @sg-ignore Array#flatten returns a bare Array, so uniq's block param has no element type to infer from
           pins = pin_groups.flatten.uniq { |p| [p.path, p.return_type.rooted_tags] }
           return [] if pins.empty?
           inferred_pins(pins, api_map, name_pin, locals)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -64,7 +64,14 @@ module Solargraph
             [stack.first].compact
           end
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:empty?)
-          pins = pin_groups.flatten.uniq(&:path)
+          # Different union members can resolve to pins that share a
+          # path (e.g. the same generic method looked up against
+          # `Box<Integer>` and `Box<String>`) but that have already
+          # been resolved to different return types for their
+          # respective context. Dedup on both so we don't silently
+          # drop every member but the first.
+          # @param p [Pin::Base]
+          pins = pin_groups.flatten.uniq { |p| [p.path, p.return_type.tag] }
           return [] if pins.empty?
           inferred_pins(pins, api_map, name_pin, locals)
         end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -64,14 +64,11 @@ module Solargraph
             [stack.first].compact
           end
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:empty?)
-          # Different union members can resolve to pins that share a
-          # path (e.g. the same generic method looked up against
-          # `Box<Integer>` and `Box<String>`) but that have already
-          # been resolved to different return types for their
-          # respective context. Dedup on both so we don't silently
-          # drop every member but the first.
-          # @sg-ignore uniq's block param isn't inferred from the receiver's element type (Array#first is)
-          pins = pin_groups.flatten.uniq { |p| [p.path, p.return_type.tag] }
+          # Union members resolve the same method path against different
+          # contexts, so pins can share a path yet return different types;
+          # keying on path alone would drop all but the first from the union.
+          # @sg-ignore uniq's block param isn't inferred from the receiver's element type
+          pins = pin_groups.flatten.uniq { |p| [p.path, p.return_type.rooted_tags] }
           return [] if pins.empty?
           inferred_pins(pins, api_map, name_pin, locals)
         end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -65,7 +65,7 @@ module Solargraph
           end
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:empty?)
           # Several union members can end up with the same pin and return type.
-          # @sg-ignore Array#flatten returns a bare Array, so uniq's block param has no element type to infer from
+          # @sg-ignore Array#flatten returns a bare Array
           pins = pin_groups.flatten.uniq { |p| [p.path, p.return_type.rooted_tags] }
           return [] if pins.empty?
           inferred_pins(pins, api_map, name_pin, locals)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -64,9 +64,7 @@ module Solargraph
             [stack.first].compact
           end
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:empty?)
-          # Dedup on path and resolved return type. Union members resolve the
-          # same path against different contexts, so pins can share a path yet
-          # return different types; keying on path alone drops all but the first.
+          # Several union members can end up with the same pin and return type.
           # @sg-ignore Array#flatten returns a bare Array, so uniq's block param has no element type to infer from
           pins = pin_groups.flatten.uniq { |p| [p.path, p.return_type.rooted_tags] }
           return [] if pins.empty?

--- a/lib/solargraph/type_checker/rules.rb
+++ b/lib/solargraph/type_checker/rules.rb
@@ -75,7 +75,7 @@ module Solargraph
       # @todo 22: Translate to something flow sensitive typing understands
       # @todo 3: Need a downcast here
       #
-      # flow sensitive typing could handle (96):
+      # flow sensitive typing could handle (97):
       #
       # @todo 36: flow sensitive typing needs to handle attrs
       # @todo 29: flow sensitive typing should be able to handle redefinition
@@ -113,6 +113,7 @@ module Solargraph
       # @todo 1: flow sensitive typing needs to create separate ranges for postfix if
       # @todo 1: flow sensitive typing needs to handle constants
       # @todo 1: flow sensitive typing needs to eliminate literal from union with return if foo == :bar
+      # @todo 1: Array#flatten returns a bare Array
       def require_all_unique_types_match_expected?
         report?(:require_all_unique_types_match_expected, :strong)
       end

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -374,6 +374,30 @@ describe Solargraph::Source::Chain::Call do
     expect(type.tag).to eq('String')
   end
 
+  it 'resolves same-class generics from a union independently of declaration order' do
+    # https://github.com/castwide/solargraph/issues/1272
+    ['Box<Integer>, Box<String>', 'Box<String>, Box<Integer>'].each do |union_tag|
+      source = Solargraph::Source.load_string(%(
+        # @generic T
+        class Box
+          # @return [generic<T>]
+          def get; end
+        end
+
+        # @type [#{union_tag}]
+        b = boxed
+        c = b.get
+        c
+      ), 'test.rb')
+      api_map = Solargraph::ApiMap.new
+      api_map.map source
+
+      chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(10, 7))
+      type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+      expect(type.items.map(&:tag).sort).to eq(%w[Integer String])
+    end
+  end
+
   it 'denies calls off of nilable objects when loose union mode is off' do
     source = Solargraph::Source.load_string(%(
       # @type [String, nil]

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -402,7 +402,6 @@ describe Solargraph::Source::Chain::Call do
   end
 
   it 'resolves same-class generics from a union independently of declaration order' do
-    # https://github.com/castwide/solargraph/issues/1272
     ['Box<Integer>, Box<String>', 'Box<String>, Box<Integer>'].each do |union_tag|
       source = Solargraph::Source.load_string(%(
         # @generic T


### PR DESCRIPTION
**Problem:** A method called on a variable typed as two instantiations of the same generic class returns only one of them — the rest of the union is silently dropped.

```ruby
# @generic T
class Box
  # @return [generic<T>]
  def get; end
end

# @param b [Box<Integer>, Box<String>]
def one_order(b)
  b.get  # => Integer   (expected Integer, String)
end

# @param b [Box<String>, Box<Integer>]
def other_order(b)
  b.get  # => String    (expected Integer, String)
end
```

Every union of same-class generics is affected, no declaration order returns the full union, and the truncated result reads as a legitimate concrete type rather than an error.

**Solution:** Dedup the per-member method pins on both `path` and `return_type.rooted_tags` instead of `path` alone, using `rooted_tags` rather than `tag` because `ComplexType` defines no `#tag` and so falls through to its first union member.

Fixes castwide/solargraph#1272.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
