### PR TITLE
Fix ENV[] typechecking

### DIFF
--- a/lib/solargraph/gem_pins.rb
+++ b/lib/solargraph/gem_pins.rb
@@ -32,6 +32,12 @@ module Solargraph
       out
     end
 
+    # `pp`'s `class << ENV ... end` (to add `pretty_print`) makes YARD
+    # misdeclare ENV as a Class, contradicting RBS's correct ENVClass instance type.
+    KNOWN_BAD_YARD_PINS = {
+      'pp' => ['ENV']
+    }.freeze
+
     # @param yard_plugins [Array<String>] The names of YARD plugins to use.
     # @param gemspec [Gem::Specification]
     # @return [Array<Pin::Base>]
@@ -39,7 +45,10 @@ module Solargraph
       Yardoc.cache(yard_plugins, gemspec) unless Yardoc.cached?(gemspec)
       return [] unless Yardoc.cached?(gemspec)
       yardoc = Yardoc.load!(gemspec)
-      YardMap::Mapper.new(yardoc, gemspec).map
+      pins = YardMap::Mapper.new(yardoc, gemspec).map
+      bad_paths = KNOWN_BAD_YARD_PINS[gemspec.name]
+      return pins unless bad_paths
+      pins.reject { |pin| bad_paths.include?(pin.path) }
     end
 
     # @param yard_pins [Array<Pin::Base>]

--- a/spec/gem_pins_spec.rb
+++ b/spec/gem_pins_spec.rb
@@ -26,6 +26,15 @@ describe Solargraph::GemPins do
     end
   end
 
+  context 'with a known-bad YARD pin' do
+    let(:path) { 'ENV' }
+    let(:requires) { ['pp'] }
+
+    it 'excludes the pin that misdeclares ENV as a Class' do
+      expect(doc_map.pins.select { |pin| pin.path == path }).to be_empty
+    end
+  end
+
   context 'with a YARD-only pin' do
     let(:requires) { ['rake'] }
     let(:path) { 'Rake::Task#prerequisites' }


### PR DESCRIPTION
## Summary

- `pp`'s `class << ENV ... end` (added to define `pretty_print`) makes YARD parse `ENV` as a `Class`, contradicting RBS's correct `ENVClass` instance type for the same path.
- Solargraph kept both pins for the `ENV` path and unioned their types at lookup time, so strong-level method resolution required `ENV` to satisfy both types simultaneously - breaking `ENV.fetch`, `ENV[]`, and `ENV[]=` wherever `pp` is loaded (i.e. almost everywhere, since `pp` ships in stdlib as of Ruby 3.x).
- Adds a small, explicit `GemPins::KNOWN_BAD_YARD_PINS` table (modeled on the existing `RbsMap::CoreFills` known-quirks pattern) so the misdeclared YARD pin is dropped before it ever enters the pin set.

```
$ bundle exec solargraph pin ENV   # before
#<Solargraph::Pin::Constant `name="ENV" ... ::RBS::Unnamed::ENVClass` ... via :rbs>
#<Solargraph::Pin::Namespace `name="ENV" ... ::Class<::ENV>` ... via :yardoc>   # contradicts RBS

$ bundle exec solargraph pin ENV   # after
#<Solargraph::Pin::Constant `name="ENV" ... ::RBS::Unnamed::ENVClass` ... via :rbs>
```

Root cause is upstream in YARD's `class << expr` handler (`class_handler.rb`), which can't distinguish "reopen the singleton class of a class/module" from "reopen the singleton class of an arbitrary object" - both produce an identical `ClassObject` registration. No YARD issue filed yet.

## Test plan

- [x] `bundle exec rspec spec/gem_pins_spec.rb` - new regression spec confirms no pin lands at path `ENV` when `pp` is required
- [x] Full suite: `bundle exec rspec` - 1625 examples, 0 failures, 60 pre-existing pending
- [x] Manual repro: `Solargraph::TypeChecker.load(..., :strong)` on a file with `ENV.fetch`/`ENV[]`/`ENV[]=` after `require 'pp'` reports no problems (previously flagged as unresolved)

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

https://claude.ai/code/session_01SPVNYNrvUNJwdH7UyAYM8A