### PR TITLE
Improved RBS type alias support

### DIFF
--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -445,7 +445,6 @@ module Solargraph
       # @param decl [RBS::AST::Declarations::Constant]
       # @return [void]
       def constant_decl_to_pin decl
-        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
         tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls)
         pins.push create_constant(decl.name.relative!.to_s, tag, decl.comment&.string, decl)
       end
@@ -462,7 +461,6 @@ module Solargraph
           type_location: location_decl_to_pin_location(decl.location),
           source: :rbs
         )
-        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
         rooted_tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted.rooted_tags
         pin.docstring.add_tag(YARD::Tags::Tag.new(:type, '', rooted_tag))
         pins.push pin
@@ -650,7 +648,6 @@ module Solargraph
           visibility: visibility,
           source: :rbs
         )
-        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
         rooted_tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted.rooted_tags
         pin.docstring.add_tag(YARD::Tags::Tag.new(:return, '', rooted_tag))
         logger.debug do
@@ -682,13 +679,11 @@ module Solargraph
         pin.parameters <<
           Solargraph::Pin::Parameter.new(
             name: 'value',
-            # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
             return_type: RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted,
             source: :rbs,
             closure: pin,
             type_location: type_location
           )
-        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
         rooted_tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted.rooted_tags
         pin.docstring.add_tag(YARD::Tags::Tag.new(:return, '', rooted_tag))
         pins.push pin
@@ -714,7 +709,6 @@ module Solargraph
           comments: decl.comment&.string,
           source: :rbs
         )
-        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
         rooted_tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted.rooted_tags
         pin.docstring.add_tag(YARD::Tags::Tag.new(:type, '', rooted_tag))
         pins.push pin
@@ -732,7 +726,6 @@ module Solargraph
           type_location: location_decl_to_pin_location(decl.location),
           source: :rbs
         )
-        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
         rooted_tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted.rooted_tags
         pin.docstring.add_tag(YARD::Tags::Tag.new(:type, '', rooted_tag))
         pins.push pin
@@ -750,7 +743,6 @@ module Solargraph
           type_location: location_decl_to_pin_location(decl.location),
           source: :rbs
         )
-        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
         rooted_tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted.rooted_tags
         pin.docstring.add_tag(YARD::Tags::Tag.new(:type, '', rooted_tag))
         pins.push pin
@@ -831,7 +823,6 @@ module Solargraph
       # @return [ComplexType]
       # @param [Object] implicit_nil
       def extract_method_type_return_type type, implicit_nil
-        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
         tag = RbsTranslator.to_complex_type(type.type.return_type, type_alias_decls: type_alias_decls)
         return ComplexType.parse("#{tag}, nil") if tag && implicit_nil
         tag

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -95,7 +95,11 @@ module Solargraph
         # references into core won't expand in this case, but we
         # still get a nominal tag rather than failing to load the
         # library's pins at all.
-        logger.debug { "Could not build a core-aware environment for #{loader.libs}: #{e.message}" }
+        logger.warn do
+          "Could not build a core-aware environment for #{loader.libs}: #{e.message}. " \
+            'Type aliases referencing names declared in RBS core will not be expanded ' \
+            'for these libraries, and will be typed by their alias name instead.'
+        end
         fallback
       end
 
@@ -330,7 +334,6 @@ module Solargraph
         if decl.super_class
           type = build_type(decl.super_class.name, decl.super_class.args)
           generic_values = type.all_params.map(&:to_s)
-          decl.super_class.name.to_s
           pins.push Solargraph::Pin::Reference::Superclass.new(
             type_location: location_decl_to_pin_location(decl.super_class.location),
             closure: class_pin,
@@ -624,7 +627,6 @@ module Solargraph
       # @return [Array(Array<Pin::Parameter>, ComplexType)]
       def parts_of_function type, pin, implicit_nil
         [
-          # @sg-ignore Wrong argument type for to_parameter_pins: method_type expected RBS::MethodType, received RBS::MethodType, RBS::Types::Block
           RbsTranslator.to_parameter_pins(type, pin, pin.parameter_names, type_alias_decls: type_alias_decls),
           extract_method_type_return_type(type, implicit_nil).force_rooted
         ]

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -127,12 +127,11 @@ module Solargraph
                                      # @sg-ignore flow sensitive typing should support case/when
                                      "Ignoring closure #{closure.inspect} on alias type name #{decl.name}")
           end
-          # @sg-ignore Unresolved calls to name, type, type_location
+          # @sg-ignore flow sensitive typing should support case/when
           alias_return_type = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted
           pins.push(
-            # @sg-ignore Wrong argument type for Solargraph::Pin::Reference::TypeAlias.new: return_type expected Solargraph::ComplexType, received Solargraph::ComplexType::UniqueType, Solargraph::ComplexType
             Solargraph::Pin::Reference::TypeAlias.new(
-              # @sg-ignore Unresolved calls to name, type, type_location; return_type type mismatch
+              # @sg-ignore flow sensitive typing should support case/when
               name: ComplexType.try_parse(decl.name.to_s).to_s, return_type: alias_return_type, closure: closure, source: :rbs, type_location: location_decl_to_pin_location(decl.location)
             )
           )

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -37,6 +37,11 @@ module Solargraph
 
       private
 
+      # @return [Hash{String => RBS::AST::Declarations::TypeAlias}]
+      def type_alias_decls
+        @type_alias_decls ||= {}
+      end
+
       # @param loader [RBS::EnvironmentLoader]
       #
       # @return [void]
@@ -47,6 +52,12 @@ module Solargraph
                                  "#{loader.core_root.inspect}, libraries #{loader.libs} and " \
                                  "directories #{loader.dirs}"
           return
+        end
+        # Register all type aliases up front so alias expansion in
+        # RbsTranslator doesn't depend on declaration order.
+        environment.type_alias_decls.each_value do |entry|
+          # @sg-ignore Wrong argument type for Hash#[]=: value expected RBS::AST::Declarations::TypeAlias, received generic<D>
+          type_alias_decls[entry.decl.name.to_s] = entry.decl
         end
         environment.declarations.each { |decl| convert_decl_to_pin(decl, Solargraph::Pin::ROOT_PIN) }
       end
@@ -75,11 +86,13 @@ module Solargraph
                                      # @sg-ignore flow sensitive typing should support case/when
                                      "Ignoring closure #{closure.inspect} on alias type name #{decl.name}")
           end
+          # @sg-ignore Unresolved calls to name, type, type_location
+          alias_return_type = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted
           pins.push(
             # @sg-ignore Wrong argument type for Solargraph::Pin::Reference::TypeAlias.new: return_type expected Solargraph::ComplexType, received Solargraph::ComplexType::UniqueType, Solargraph::ComplexType
             Solargraph::Pin::Reference::TypeAlias.new(
               # @sg-ignore Unresolved calls to name, type, type_location; return_type type mismatch
-              name: ComplexType.try_parse(decl.name.to_s).to_s, return_type: RbsTranslator.to_complex_type(decl.type).force_rooted, closure: closure, source: :rbs, type_location: location_decl_to_pin_location(decl.location)
+              name: ComplexType.try_parse(decl.name.to_s).to_s, return_type: alias_return_type, closure: closure, source: :rbs, type_location: location_decl_to_pin_location(decl.location)
             )
           )
         when RBS::AST::Declarations::Module
@@ -253,10 +266,10 @@ module Solargraph
         # @type [Hash{String => ComplexType, ComplexType::UniqueType}]
         generic_defaults = {}
         decl.type_params.each do |param|
-          if param.default_type
-            complex_type = RbsTranslator.to_complex_type(param.default_type).force_rooted
-            generic_defaults[param.name.to_s] = complex_type
-          end
+          next unless param.default_type
+          # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes, nil
+          complex_type = RbsTranslator.to_complex_type(param.default_type, type_alias_decls: type_alias_decls).force_rooted
+          generic_defaults[param.name.to_s] = complex_type
         end
 
         class_name = fqns(decl.name)
@@ -280,7 +293,7 @@ module Solargraph
         if decl.super_class
           type = build_type(decl.super_class.name, decl.super_class.args)
           generic_values = type.all_params.map(&:to_s)
-          superclass_name = decl.super_class.name.to_s
+          decl.super_class.name.to_s
           pins.push Solargraph::Pin::Reference::Superclass.new(
             type_location: location_decl_to_pin_location(decl.super_class.location),
             closure: class_pin,
@@ -392,7 +405,8 @@ module Solargraph
       # @param decl [RBS::AST::Declarations::Constant]
       # @return [void]
       def constant_decl_to_pin decl
-        tag = RbsTranslator.to_complex_type(decl.type)
+        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
+        tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls)
         pins.push create_constant(decl.name.relative!.to_s, tag, decl.comment&.string, decl)
       end
 
@@ -408,7 +422,8 @@ module Solargraph
           type_location: location_decl_to_pin_location(decl.location),
           source: :rbs
         )
-        rooted_tag = RbsTranslator.to_complex_type(decl.type).force_rooted.rooted_tags
+        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
+        rooted_tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted.rooted_tags
         pin.docstring.add_tag(YARD::Tags::Tag.new(:type, '', rooted_tag))
         pins.push pin
       end
@@ -514,24 +529,23 @@ module Solargraph
             pin.instance_variable_set(:@return_type, ComplexType::VOID)
           end
         end
-        if decl.singleton?
-          final_scope = :class
-          name = decl.name.to_s
-          visibility = calculate_method_visibility(decl, context, closure, final_scope, name)
-          pin = Solargraph::Pin::Method.new(
-            name: name,
-            closure: closure,
-            comments: decl.comment&.string,
-            type_location: location_decl_to_pin_location(decl.location),
-            visibility: visibility,
-            scope: final_scope,
-            signatures: [],
-            generics: generics,
-            source: :rbs
-          )
-          pin.signatures.concat method_def_to_sigs(decl, pin)
-          pins.push pin
-        end
+        return unless decl.singleton?
+        final_scope = :class
+        name = decl.name.to_s
+        visibility = calculate_method_visibility(decl, context, closure, final_scope, name)
+        pin = Solargraph::Pin::Method.new(
+          name: name,
+          closure: closure,
+          comments: decl.comment&.string,
+          type_location: location_decl_to_pin_location(decl.location),
+          visibility: visibility,
+          scope: final_scope,
+          signatures: [],
+          generics: generics,
+          source: :rbs
+        )
+        pin.signatures.concat method_def_to_sigs(decl, pin)
+        pins.push pin
       end
 
       # @param decl [RBS::AST::Members::MethodDefinition]
@@ -558,7 +572,7 @@ module Solargraph
 
       # @param location [RBS::Location, nil]
       # @return [Solargraph::Location, nil]
-      def location_decl_to_pin_location(location)
+      def location_decl_to_pin_location location
         return nil if location&.name.nil?
 
         start_pos = Position.new(location.start_line - 1, location.start_column)
@@ -573,7 +587,8 @@ module Solargraph
       # @return [Array(Array<Pin::Parameter>, ComplexType)]
       def parts_of_function type, pin, implicit_nil
         [
-          RbsTranslator.to_parameter_pins(type, pin, pin.parameter_names),
+          # @sg-ignore Wrong argument type for to_parameter_pins: method_type expected RBS::MethodType, received RBS::MethodType, RBS::Types::Block
+          RbsTranslator.to_parameter_pins(type, pin, pin.parameter_names, type_alias_decls: type_alias_decls),
           extract_method_type_return_type(type, implicit_nil).force_rooted
         ]
       end
@@ -596,7 +611,8 @@ module Solargraph
           visibility: visibility,
           source: :rbs
         )
-        rooted_tag = RbsTranslator.to_complex_type(decl.type).force_rooted.rooted_tags
+        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
+        rooted_tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted.rooted_tags
         pin.docstring.add_tag(YARD::Tags::Tag.new(:return, '', rooted_tag))
         logger.debug do
           "Conversions#attr_reader_to_pin(name=#{name.inspect}, visibility=#{visibility.inspect}) => #{pin.inspect}"
@@ -627,12 +643,14 @@ module Solargraph
         pin.parameters <<
           Solargraph::Pin::Parameter.new(
             name: 'value',
-            return_type: RbsTranslator.to_complex_type(decl.type).force_rooted,
+            # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
+            return_type: RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted,
             source: :rbs,
             closure: pin,
             type_location: type_location
           )
-        rooted_tag = RbsTranslator.to_complex_type(decl.type).force_rooted.rooted_tags
+        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
+        rooted_tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted.rooted_tags
         pin.docstring.add_tag(YARD::Tags::Tag.new(:return, '', rooted_tag))
         pins.push pin
       end
@@ -657,7 +675,8 @@ module Solargraph
           comments: decl.comment&.string,
           source: :rbs
         )
-        rooted_tag = RbsTranslator.to_complex_type(decl.type).force_rooted.rooted_tags
+        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
+        rooted_tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted.rooted_tags
         pin.docstring.add_tag(YARD::Tags::Tag.new(:type, '', rooted_tag))
         pins.push pin
       end
@@ -674,7 +693,8 @@ module Solargraph
           type_location: location_decl_to_pin_location(decl.location),
           source: :rbs
         )
-        rooted_tag = RbsTranslator.to_complex_type(decl.type).force_rooted.rooted_tags
+        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
+        rooted_tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted.rooted_tags
         pin.docstring.add_tag(YARD::Tags::Tag.new(:type, '', rooted_tag))
         pins.push pin
       end
@@ -691,7 +711,8 @@ module Solargraph
           type_location: location_decl_to_pin_location(decl.location),
           source: :rbs
         )
-        rooted_tag = RbsTranslator.to_complex_type(decl.type).force_rooted.rooted_tags
+        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
+        rooted_tag = RbsTranslator.to_complex_type(decl.type, type_alias_decls: type_alias_decls).force_rooted.rooted_tags
         pin.docstring.add_tag(YARD::Tags::Tag.new(:type, '', rooted_tag))
         pins.push pin
       end
@@ -716,7 +737,7 @@ module Solargraph
       # @return [void]
       def prepend_to_pin decl, closure
         type = build_type(decl.name, decl.args)
-        generic_values = type.all_params.map(&:rooted_tags)
+        type.all_params.map(&:rooted_tags)
         pins.push Solargraph::Pin::Reference::Prepend.new(
           name: decl.name.relative!.to_s,
           type_location: location_decl_to_pin_location(decl.location),
@@ -730,7 +751,7 @@ module Solargraph
       # @return [void]
       def extend_to_pin decl, closure
         type = build_type(decl.name, decl.args)
-        generic_values = type.all_params.map(&:rooted_tags)
+        type.all_params.map(&:rooted_tags)
         pins.push Solargraph::Pin::Reference::Extend.new(
           name: decl.name.relative!.to_s,
           type_location: location_decl_to_pin_location(decl.location),
@@ -760,7 +781,7 @@ module Solargraph
         'int' => 'Integer',
         'untyped' => '',
         'NilClass' => 'nil'
-      }
+      }.freeze
       private_constant :RBS_TO_YARD_TYPE
 
       # Extract a ComplexType from a MethodType's return type.
@@ -769,18 +790,20 @@ module Solargraph
       #
       # @param type [RBS::MethodType]
       # @return [ComplexType]
+      # @param [Object] implicit_nil
       def extract_method_type_return_type type, implicit_nil
-          tag = RbsTranslator.to_complex_type(type.type.return_type)
-          return ComplexType.parse("#{tag}, nil") if tag && implicit_nil
-          tag
+        # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
+        tag = RbsTranslator.to_complex_type(type.type.return_type, type_alias_decls: type_alias_decls)
+        return ComplexType.parse("#{tag}, nil") if tag && implicit_nil
+        tag
       end
 
       # @param type_name [RBS::TypeName]
       # @param type_args [Enumerable<RBS::Types::Bases::Base>]
       # @return [ComplexType::UniqueType]
-      def build_type(type_name, type_args = [])
+      def build_type type_name, type_args = []
         base = RBS_TO_YARD_TYPE[type_name.relative!.to_s] || type_name.relative!.to_s
-        params = type_args.map { |arg| RbsTranslator.to_complex_type(arg).force_rooted }
+        params = type_args.map { |arg| RbsTranslator.to_complex_type(arg, type_alias_decls: type_alias_decls).force_rooted }
         if base == 'Hash' && params.length == 2
           ComplexType::UniqueType.new(base, [params.first], [params.last], rooted: true, parameters_type: :hash)
         else

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -55,11 +55,48 @@ module Solargraph
         end
         # Register all type aliases up front so alias expansion in
         # RbsTranslator doesn't depend on declaration order.
-        environment.type_alias_decls.each_value do |entry|
+        core_aware_environment(loader, fallback: environment).type_alias_decls.each_value do |entry|
           # @sg-ignore Wrong argument type for Hash#[]=: value expected RBS::AST::Declarations::TypeAlias, received generic<D>
           type_alias_decls[entry.decl.name.to_s] = entry.decl
         end
         environment.declarations.each { |decl| convert_decl_to_pin(decl, Solargraph::Pin::ROOT_PIN) }
+      end
+
+      # `loader` intentionally omits RBS core (`core_root: nil`) for
+      # every non-core RbsMap, so a library's pins don't re-declare
+      # what RbsMap::CoreMap already provides. But some stdlib type
+      # aliases reference a name declared in core -- e.g. fileutils.rbs's
+      # `type path = ::path` points at core's own `path` alias in
+      # builtin.rbs. With core absent from the environment,
+      # RBS::Environment#resolve_type_names can't find that target and
+      # silently rebinds the reference back onto the alias's own name
+      # instead of raising, producing a spurious self-referential alias
+      # (`FileUtils::path` "expanding to" `FileUtils::path`). Resolve
+      # type alias names against a copy of the environment that does
+      # include core, so those cross-namespace references bind
+      # correctly; pin generation still uses the core-less environment
+      # above to avoid duplicating core's pins.
+      #
+      # @param loader [RBS::EnvironmentLoader]
+      # @param fallback [RBS::Environment] the already-resolved, core-less
+      #   environment to use if a core-aware one can't be built
+      # @return [RBS::Environment]
+      def core_aware_environment loader, fallback:
+        return fallback unless loader.core_root.nil?
+
+        core_loader = RBS::EnvironmentLoader.new(repository: loader.repository)
+        loader.libs.each { |lib| core_loader.add(library: lib.name, version: lib.version) }
+        loader.dirs.each { |dir| core_loader.add(path: dir) }
+        RBS::Environment.from_loader(core_loader).resolve_type_names
+      rescue RBS::DuplicatedDeclarationError => e
+        # A declaration in `loader` (e.g. a local RBS shim) collides
+        # with something in RBS core itself. Fall back to the
+        # core-less resolution for type aliases; cross-namespace
+        # references into core won't expand in this case, but we
+        # still get a nominal tag rather than failing to load the
+        # library's pins at all.
+        logger.debug { "Could not build a core-aware environment for #{loader.libs}: #{e.message}" }
+        fallback
       end
 
       # @param decl [RBS::AST::Declarations::Base]

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -769,7 +769,7 @@ module Solargraph
       # @return [void]
       def prepend_to_pin decl, closure
         type = build_type(decl.name, decl.args)
-        type.all_params.map(&:rooted_tags)
+        generic_values = type.all_params.map(&:rooted_tags)
         pins.push Solargraph::Pin::Reference::Prepend.new(
           name: decl.name.relative!.to_s,
           type_location: location_decl_to_pin_location(decl.location),
@@ -783,7 +783,7 @@ module Solargraph
       # @return [void]
       def extend_to_pin decl, closure
         type = build_type(decl.name, decl.args)
-        type.all_params.map(&:rooted_tags)
+        generic_values = type.all_params.map(&:rooted_tags)
         pins.push Solargraph::Pin::Reference::Extend.new(
           name: decl.name.relative!.to_s,
           type_location: location_decl_to_pin_location(decl.location),

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -53,8 +53,7 @@ module Solargraph
                                  "directories #{loader.dirs}"
           return
         end
-        # Register all type aliases up front so alias expansion in
-        # RbsTranslator doesn't depend on declaration order.
+        # Register up front so expansion does not depend on declaration order.
         core_aware_environment(loader, fallback: environment).type_alias_decls.each_value do |entry|
           # @sg-ignore Wrong argument type for Hash#[]=: value expected RBS::AST::Declarations::TypeAlias, received generic<D>
           type_alias_decls[entry.decl.name.to_s] = entry.decl
@@ -62,20 +61,9 @@ module Solargraph
         environment.declarations.each { |decl| convert_decl_to_pin(decl, Solargraph::Pin::ROOT_PIN) }
       end
 
-      # `loader` intentionally omits RBS core (`core_root: nil`) for
-      # every non-core RbsMap, so a library's pins don't re-declare
-      # what RbsMap::CoreMap already provides. But some stdlib type
-      # aliases reference a name declared in core -- e.g. fileutils.rbs's
-      # `type path = ::path` points at core's own `path` alias in
-      # builtin.rbs. With core absent from the environment,
-      # RBS::Environment#resolve_type_names can't find that target and
-      # silently rebinds the reference back onto the alias's own name
-      # instead of raising, producing a spurious self-referential alias
-      # (`FileUtils::path` "expanding to" `FileUtils::path`). Resolve
-      # type alias names against a copy of the environment that does
-      # include core, so those cross-namespace references bind
-      # correctly; pin generation still uses the core-less environment
-      # above to avoid duplicating core's pins.
+      # A non-core RbsMap omits core so its pins do not re-declare CoreMap's,
+      # which leaves #resolve_type_names unable to bind an alias pointing into
+      # core. Resolve alias names against core separately; pins do not.
       #
       # @param loader [RBS::EnvironmentLoader]
       # @param fallback [RBS::Environment] the already-resolved, core-less
@@ -90,12 +78,7 @@ module Solargraph
         loader.dirs.each { |dir| core_loader.add(path: dir) }
         RBS::Environment.from_loader(core_loader).resolve_type_names
       rescue RBS::DuplicatedDeclarationError => e
-        # A declaration in `loader` (e.g. a local RBS shim) collides
-        # with something in RBS core itself. Fall back to the
-        # core-less resolution for type aliases; cross-namespace
-        # references into core won't expand in this case, but we
-        # still get a nominal tag rather than failing to load the
-        # library's pins at all.
+        # A local RBS shim may redeclare a core name; nominal tags beat no pins.
         logger.warn do
           "Could not build a core-aware environment for #{loader.libs}: #{e.message}. " \
             'Type aliases referencing names declared in RBS core will not be expanded ' \
@@ -104,9 +87,8 @@ module Solargraph
         fallback
       end
 
-      # #resolve_type_names rebinds a target it cannot find into the local
-      # namespace rather than raising, so a reference into absent core ends
-      # up naming either the alias itself or a name nothing declares.
+      # A reference into absent core survives #resolve_type_names naming
+      # either the alias itself or a name nothing declares.
       #
       # @param environment [RBS::Environment]
       # @return [Boolean]

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -83,6 +83,7 @@ module Solargraph
       # @return [RBS::Environment]
       def core_aware_environment loader, fallback:
         return fallback unless loader.core_root.nil?
+        return fallback unless rebound_alias?(fallback)
 
         core_loader = RBS::EnvironmentLoader.new(repository: loader.repository)
         loader.libs.each { |lib| core_loader.add(library: lib.name, version: lib.version) }
@@ -101,6 +102,25 @@ module Solargraph
             'for these libraries, and will be typed by their alias name instead.'
         end
         fallback
+      end
+
+      # #resolve_type_names rebinds a target it cannot find into the local
+      # namespace rather than raising, so a reference into absent core ends
+      # up naming either the alias itself or a name nothing declares.
+      #
+      # @param environment [RBS::Environment]
+      # @return [Boolean]
+      def rebound_alias? environment
+        decls = environment.type_alias_decls
+        decls.any? do |name, entry|
+          # @sg-ignore Unresolved call to decl on generic<D>
+          type = entry.decl.type
+          # @sg-ignore Unresolved call to is_a? on generic<D>
+          next false unless type.is_a?(RBS::Types::Alias)
+
+          # @sg-ignore Unresolved call to to_s on generic<D>
+          type.name.to_s == name.to_s || !decls.key?(type.name)
+        end
       end
 
       # @param decl [RBS::AST::Declarations::Base]

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -12,7 +12,7 @@ module Solargraph
       'NilClass' => 'nil'
     }.freeze
 
-    # @param type [RBS::Types::Bases::Base]
+    # @param type [RBS::Types::t]
     # @param type_alias_decls [Hash{String => RBS::AST::Declarations::TypeAlias}]
     # @return [ComplexType]
     def self.to_complex_type type, type_alias_decls: {}
@@ -32,7 +32,6 @@ module Solargraph
                     elsif decl == :kwrestarg
                       ComplexType.parse('Hash{Symbol => Object}')
                     else
-                      # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
                       RbsTranslator.to_complex_type(param_type.type, type_alias_decls: type_alias_decls)
                     end
       Solargraph::Pin::Parameter.new(decl: decl, name: name, closure: closure, return_type: return_type, source: :rbs, type_location: to_sg_location(param_type.location) || closure.type_location)
@@ -100,7 +99,6 @@ module Solargraph
       # handle those correctly
       generics = method_type.type_params.map(&:name).map(&:to_s).uniq
       parameters = to_parameter_pins(method_type, closure, parameter_names, type_alias_decls: type_alias_decls)
-      # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
       return_type = to_complex_type(method_type.type.return_type, type_alias_decls: type_alias_decls)
       block = if method_type.block
                 # @sg-ignore The `if method_type.block` guard above doesn't narrow nil out of this
@@ -142,7 +140,7 @@ module Solargraph
     class << self
       private
 
-      # @param type [RBS::Types::Bases::Base]
+      # @param type [RBS::Types::t]
       # @param type_alias_decls [Hash{String => RBS::AST::Declarations::TypeAlias}]
       # @param expanding_aliases [Array<String>] Names of aliases already
       #   being expanded in this call chain, to detect recursive aliases
@@ -158,6 +156,7 @@ module Solargraph
           # @sg-ignore flow sensitive typing should support case/when
           "Array(#{type.types.map { |t| type_to_tag(t, type_alias_decls, expanding_aliases) }.join(', ')})"
         when RBS::Types::Literal
+          # @sg-ignore flow sensitive typing should support case/when
           type.literal.inspect
         when RBS::Types::Union
           # @sg-ignore flow sensitive typing should support case/when
@@ -170,6 +169,7 @@ module Solargraph
         when RBS::Types::Bases::Void
           'void'
         when RBS::Types::Variable
+          # @sg-ignore flow sensitive typing should support case/when
           "#{Solargraph::ComplexType::GENERIC_TAG_NAME}<#{type.name}>"
         when RBS::Types::Bases::Self, RBS::Types::Bases::Instance
           'self'
@@ -199,7 +199,6 @@ module Solargraph
             # @sg-ignore flow sensitive typing should support case/when
             type_tag(type.name, type.args, type_alias_decls, expanding_aliases)
           else
-            # @sg-ignore Wrong argument type for type_to_tag: type expected RBS::Types::Bases::Base, received union of concrete subtypes
             type_to_tag(alias_decl.type, type_alias_decls, expanding_aliases + [alias_name])
           end
         when RBS::Types::ClassInstance, RBS::Types::Interface

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -10,12 +10,13 @@ module Solargraph
       'int' => 'Integer',
       'untyped' => '',
       'NilClass' => 'nil'
-    }
+    }.freeze
 
     # @param type [RBS::Types::Bases::Base]
+    # @param type_alias_decls [Hash{String => RBS::AST::Declarations::TypeAlias}]
     # @return [ComplexType]
-    def self.to_complex_type(type)
-      tag = type_to_tag(type)
+    def self.to_complex_type type, type_alias_decls: {}
+      tag = type_to_tag(type, type_alias_decls)
       ComplexType.try_parse(tag).force_rooted
     end
 
@@ -23,23 +24,26 @@ module Solargraph
     # @param name [String]
     # @param decl [Symbol]
     # @param closure [Pin::Closure]
+    # @param type_alias_decls [Hash{String => RBS::AST::Declarations::TypeAlias}]
     # @return [Pin::Parameter]
-    def self.to_parameter_pin(param_type, name, decl, closure)
+    def self.to_parameter_pin param_type, name, decl, closure, type_alias_decls: {}
       return_type = if decl == :restarg
-        ComplexType.parse('Array')
-      elsif decl == :kwrestarg
-        ComplexType.parse('Hash{Symbol => Object}')
-      else
-        RbsTranslator.to_complex_type(param_type.type)
-      end
+                      ComplexType.parse('Array')
+                    elsif decl == :kwrestarg
+                      ComplexType.parse('Hash{Symbol => Object}')
+                    else
+                      # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
+                      RbsTranslator.to_complex_type(param_type.type, type_alias_decls: type_alias_decls)
+                    end
       Solargraph::Pin::Parameter.new(decl: decl, name: name, closure: closure, return_type: return_type, source: :rbs, type_location: to_sg_location(param_type.location) || closure.type_location)
     end
 
     # @param method_type [RBS::MethodType]
     # @param closure [Pin::Closure]
     # @param parameter_names [Array<String>]
+    # @param type_alias_decls [Hash{String => RBS::AST::Declarations::TypeAlias}]
     # @return [Array<Pin::Parameter>]
-    def self.to_parameter_pins method_type, closure, parameter_names = []
+    def self.to_parameter_pins method_type, closure, parameter_names = [], type_alias_decls: {}
       if defined?(RBS::Types::UntypedFunction) && method_type.type.is_a?(RBS::Types::UntypedFunction)
         return [
           Solargraph::Pin::Parameter.new(decl: :restarg, name: 'arg', closure: closure, source: :rbs)
@@ -49,27 +53,37 @@ module Solargraph
       arg_num = 0
       params = []
       method_type.type.required_positionals.each do |param|
-        params.push RbsTranslator.to_parameter_pin(param, param.name&.to_s || parameter_names[arg_num] || "arg_#{arg_num}", :arg, closure)
+        # @sg-ignore Unresolved call to name on RBS::Types::Function::Param
+        params.push RbsTranslator.to_parameter_pin(param, param.name&.to_s || parameter_names[arg_num] || "arg_#{arg_num}", :arg, closure, type_alias_decls: type_alias_decls)
         arg_num += 1
       end
       method_type.type.optional_positionals.each do |param|
-        params.push RbsTranslator.to_parameter_pin(param, param.name&.to_s || parameter_names[arg_num] || "arg_#{arg_num}", :optarg, closure)
+        # @sg-ignore Unresolved call to name on RBS::Types::Function::Param
+        params.push RbsTranslator.to_parameter_pin(param, param.name&.to_s || parameter_names[arg_num] || "arg_#{arg_num}", :optarg, closure, type_alias_decls: type_alias_decls)
         arg_num += 1
       end
       if method_type.type.rest_positionals
-        params.push RbsTranslator.to_parameter_pin(method_type.type.rest_positionals, method_type.type.rest_positionals.name&.to_s || parameter_names[arg_num] || "arg_#{arg_num}", :restarg, closure)
+        rest_positionals = method_type.type.rest_positionals
+        # @sg-ignore Unresolved call to name on RBS::Types::Function::Param
+        rest_name = rest_positionals.name&.to_s || parameter_names[arg_num] || "arg_#{arg_num}"
+        params.push RbsTranslator.to_parameter_pin(rest_positionals, rest_name, :restarg, closure, type_alias_decls: type_alias_decls)
         arg_num += 1
       end
       method_type.type.required_keywords.each do |param|
-        params.push RbsTranslator.to_parameter_pin(param.last, param.first.to_s, :kwarg, closure)
+        # @sg-ignore Unresolved calls to last, first on generic<D>
+        params.push RbsTranslator.to_parameter_pin(param.last, param.first.to_s, :kwarg, closure, type_alias_decls: type_alias_decls)
         arg_num += 1
       end
       method_type.type.optional_keywords.each do |param|
-        params.push RbsTranslator.to_parameter_pin(param.last, param.first.to_s, :kwoptarg, closure)
+        # @sg-ignore Unresolved calls to last, first on generic<D>
+        params.push RbsTranslator.to_parameter_pin(param.last, param.first.to_s, :kwoptarg, closure, type_alias_decls: type_alias_decls)
         arg_num += 1
       end
       if method_type.type.rest_keywords
-        params.push RbsTranslator.to_parameter_pin(method_type.type.rest_keywords, method_type.type.rest_keywords.name&.to_s || parameter_names[arg_num] || "arg_#{arg_num}", :kwrestarg, closure)
+        rest_keywords = method_type.type.rest_keywords
+        # @sg-ignore Unresolved call to name on RBS::Types::Function::Param
+        rest_keywords_name = rest_keywords.name&.to_s || parameter_names[arg_num] || "arg_#{arg_num}"
+        params.push RbsTranslator.to_parameter_pin(rest_keywords, rest_keywords_name, :kwrestarg, closure, type_alias_decls: type_alias_decls)
       end
       params
     end
@@ -77,30 +91,34 @@ module Solargraph
     # @param method_type [RBS::MethodType]
     # @param closure [Pin::Closure]
     # @param parameter_names [Array<String>]
+    # @param type_alias_decls [Hash{String => RBS::AST::Declarations::TypeAlias}]
     # @return [Pin::Signature]
-    def self.to_signature method_type, closure, parameter_names = []
+    def self.to_signature method_type, closure, parameter_names = [], type_alias_decls: {}
       # There may be edge cases here around different signatures
       # having different type params / orders - we may need to match
       # this data model and have generics live in signatures to
       # handle those correctly
       generics = method_type.type_params.map(&:name).map(&:to_s).uniq
-      parameters = to_parameter_pins(method_type, closure, parameter_names)
-      return_type = to_complex_type(method_type.type.return_type)
+      parameters = to_parameter_pins(method_type, closure, parameter_names, type_alias_decls: type_alias_decls)
+      # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
+      return_type = to_complex_type(method_type.type.return_type, type_alias_decls: type_alias_decls)
       block = if method_type.block
-        block_parameters = to_parameter_pins(method_type.block, closure)
-        block_return_type = to_complex_type(method_type.block.type.return_type)
-        Pin::Signature.new(generics: generics, parameters: block_parameters, return_type: block_return_type, source: :rbs, type_location: closure.location, closure: closure)
-      end
+                # @sg-ignore Wrong argument type for to_parameter_pins: method_type expected RBS::MethodType, received RBS::MethodType, RBS::Types::Block
+                block_parameters = to_parameter_pins(method_type.block, closure, type_alias_decls: type_alias_decls)
+                block_return_type = to_complex_type(method_type.block.type.return_type, type_alias_decls: type_alias_decls)
+                Pin::Signature.new(generics: generics, parameters: block_parameters, return_type: block_return_type, source: :rbs, type_location: closure.location, closure: closure)
+              end
       Pin::Signature.new(generics: generics, parameters: parameters, return_type: return_type, block: block, source: :rbs, type_location: closure.location, closure: closure)
     end
 
     # @param type_name [RBS::TypeName]
     # @param type_args [Enumerable<RBS::Types::Bases::Base>]
+    # @param type_alias_decls [Hash{String => RBS::AST::Declarations::TypeAlias}]
     # @return [ComplexType::UniqueType]
-    def self.build_unique_type(type_name, type_args = [])
+    def self.build_unique_type type_name, type_args = [], type_alias_decls: {}
       base = RBS_TO_YARD_TYPE[type_name.relative!.to_s] || type_name.relative!.to_s
       params = type_args.map do |a|
-        RbsTranslator.to_complex_type(a)
+        RbsTranslator.to_complex_type(a, type_alias_decls: type_alias_decls)
       end
       if base == 'Hash' && params.length == 2
         ComplexType::UniqueType.new(base, [params.first], [params.last], rooted: true, parameters_type: :hash)
@@ -111,7 +129,7 @@ module Solargraph
 
     # @param location [RBS::Location, nil]
     # @return [Solargraph::Location, nil]
-    def self.to_sg_location(location)
+    def self.to_sg_location location
       return nil if location&.name.nil?
 
       start_pos = Position.new(location.start_line - 1, location.start_column)
@@ -124,19 +142,25 @@ module Solargraph
       private
 
       # @param type [RBS::Types::Bases::Base]
+      # @param type_alias_decls [Hash{String => RBS::AST::Declarations::TypeAlias}]
+      # @param expanding_aliases [Array<String>] Names of aliases already
+      #   being expanded in this call chain, to detect recursive aliases
       # @return [String]
-      def type_to_tag type
+      def type_to_tag type, type_alias_decls = {}, expanding_aliases = []
         case type
         when RBS::Types::Optional
-          "#{type_to_tag(type.type)}, nil"
+          # @sg-ignore flow sensitive typing should support case/when
+          "#{type_to_tag(type.type, type_alias_decls, expanding_aliases)}, nil"
         when RBS::Types::Bases::Bool
           'Boolean'
         when RBS::Types::Tuple
-          "Array(#{type.types.map { |t| type_to_tag(t) }.join(', ')})"
+          # @sg-ignore flow sensitive typing should support case/when
+          "Array(#{type.types.map { |t| type_to_tag(t, type_alias_decls, expanding_aliases) }.join(', ')})"
         when RBS::Types::Literal
           type.literal.inspect
         when RBS::Types::Union
-          type.types.map { |t| type_to_tag(t) }.join(', ')
+          # @sg-ignore flow sensitive typing should support case/when
+          type.types.map { |t| type_to_tag(t, type_alias_decls, expanding_aliases) }.join(', ')
         when RBS::Types::Record
           # @todo Better record support
           'Hash'
@@ -152,21 +176,40 @@ module Solargraph
           # `Top` is the most super superclass
           'BasicObject'
         when RBS::Types::Intersection
-          type.types.map { |member| type_to_tag(member) }.join(', ')
+          # @sg-ignore flow sensitive typing should support case/when
+          type.types.map { |member| type_to_tag(member, type_alias_decls, expanding_aliases) }.join(', ')
         when RBS::Types::Proc
           'Proc'
-        when RBS::Types::ClassInstance, RBS::Types::Alias, RBS::Types::Interface
-          # `Alias` is a top-level type alias, e.g., 'bool' in "type bool = true | false"
-          # @todo ensure these get resolved after processing all aliases
-          # @todo handle recursive aliases
+        when RBS::Types::Alias
+          # A top-level type alias use, e.g., 'bool' in "type bool = true | false".
           #
-          # `Interface represents a mix-in module which can be considered a
+          # Expand to the alias's underlying type so structural
+          # conformance checks (e.g., typechecking) can compare against
+          # its actual members rather than its nominal name. Fall back to
+          # the nominal tag if the alias definition isn't known, if it's
+          # recursive, or if it's generic (e.g. "type box[T] = Array[T] |
+          # nil") — expanding those would leak an unbound `generic<T>`
+          # tag, since args aren't substituted into the expansion.
+          # @sg-ignore flow sensitive typing should support case/when
+          alias_name = type.name.to_s
+          alias_decl = type_alias_decls[alias_name]
+          # @sg-ignore flow sensitive typing should support case/when
+          if alias_decl.nil? || expanding_aliases.include?(alias_name) || !type.args.empty?
+            # @sg-ignore flow sensitive typing should support case/when
+            type_tag(type.name, type.args, type_alias_decls, expanding_aliases)
+          else
+            # @sg-ignore Wrong argument type for type_to_tag: type expected RBS::Types::Bases::Base, received union of concrete subtypes
+            type_to_tag(alias_decl.type, type_alias_decls, expanding_aliases + [alias_name])
+          end
+        when RBS::Types::ClassInstance, RBS::Types::Interface
+          # `Interface` represents a mix-in module which can be considered a
           # subtype of a consumer of it
-          #
-          type_tag(type.name, type.args)
+          # @sg-ignore flow sensitive typing should support case/when
+          type_tag(type.name, type.args, type_alias_decls, expanding_aliases)
         when RBS::Types::ClassSingleton
           # e.g., singleton(String)
-          type_tag(type.name)
+          # @sg-ignore flow sensitive typing should support case/when
+          type_tag(type.name, [], type_alias_decls, expanding_aliases)
         when RBS::Types::Bases::Any, RBS::Types::Bases::Bottom
           # `Bottom`` is used in contexts where nothing will ever return
           # - e.g., it could be the return type of 'exit()' or 'raise'
@@ -182,17 +225,21 @@ module Solargraph
 
       # @param type_name [RBS::TypeName]
       # @param type_args [Enumerable<RBS::Types::Bases::Base>]
+      # @param type_alias_decls [Hash{String => RBS::AST::Declarations::TypeAlias}]
+      # @param expanding_aliases [Array<String>]
       # @return [String]
-      def type_tag(type_name, type_args = [])
-        build_type(type_name, type_args).tags
+      def type_tag type_name, type_args = [], type_alias_decls = {}, expanding_aliases = []
+        build_type(type_name, type_args, type_alias_decls, expanding_aliases).tags
       end
 
       # @param type_name [RBS::TypeName]
       # @param type_args [Enumerable<RBS::Types::Bases::Base>]
+      # @param type_alias_decls [Hash{String => RBS::AST::Declarations::TypeAlias}]
+      # @param expanding_aliases [Array<String>]
       # @return [ComplexType::UniqueType]
-      def build_type(type_name, type_args = [])
+      def build_type type_name, type_args = [], type_alias_decls = {}, expanding_aliases = []
         base = RBS_TO_YARD_TYPE[type_name.relative!.to_s] || type_name.relative!.to_s
-        params = type_args.map { |a| type_to_tag(a) }.map do |t|
+        params = type_args.map { |a| type_to_tag(a, type_alias_decls, expanding_aliases) }.map do |t|
           ComplexType.try_parse(t)
         end
         if base == 'Hash' && params.length == 2

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -38,7 +38,7 @@ module Solargraph
       Solargraph::Pin::Parameter.new(decl: decl, name: name, closure: closure, return_type: return_type, source: :rbs, type_location: to_sg_location(param_type.location) || closure.type_location)
     end
 
-    # @param method_type [RBS::MethodType]
+    # @param method_type [RBS::MethodType, RBS::Types::Block]
     # @param closure [Pin::Closure]
     # @param parameter_names [Array<String>]
     # @param type_alias_decls [Hash{String => RBS::AST::Declarations::TypeAlias}]
@@ -103,7 +103,8 @@ module Solargraph
       # @sg-ignore Wrong argument type for to_complex_type: type expected RBS::Types::Bases::Base, received union of concrete subtypes
       return_type = to_complex_type(method_type.type.return_type, type_alias_decls: type_alias_decls)
       block = if method_type.block
-                # @sg-ignore Wrong argument type for to_parameter_pins: method_type expected RBS::MethodType, received RBS::MethodType, RBS::Types::Block
+                # @sg-ignore The `if method_type.block` guard above doesn't narrow nil out of this
+                #   second `method_type.block` call: https://github.com/castwide/solargraph/issues/1249
                 block_parameters = to_parameter_pins(method_type.block, closure, type_alias_decls: type_alias_decls)
                 block_return_type = to_complex_type(method_type.block.type.return_type, type_alias_decls: type_alias_decls)
                 Pin::Signature.new(generics: generics, parameters: block_parameters, return_type: block_return_type, source: :rbs, type_location: closure.location, closure: closure)

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -110,22 +110,6 @@ module Solargraph
       Pin::Signature.new(generics: generics, parameters: parameters, return_type: return_type, block: block, source: :rbs, type_location: closure.location, closure: closure)
     end
 
-    # @param type_name [RBS::TypeName]
-    # @param type_args [Enumerable<RBS::Types::Bases::Base>]
-    # @param type_alias_decls [Hash{String => RBS::AST::Declarations::TypeAlias}]
-    # @return [ComplexType::UniqueType]
-    def self.build_unique_type type_name, type_args = [], type_alias_decls: {}
-      base = RBS_TO_YARD_TYPE[type_name.relative!.to_s] || type_name.relative!.to_s
-      params = type_args.map do |a|
-        RbsTranslator.to_complex_type(a, type_alias_decls: type_alias_decls)
-      end
-      if base == 'Hash' && params.length == 2
-        ComplexType::UniqueType.new(base, [params.first], [params.last], rooted: true, parameters_type: :hash)
-      else
-        ComplexType::UniqueType.new(base, [], params.reject(&:undefined?), rooted: true, parameters_type: :list)
-      end
-    end
-
     # @param location [RBS::Location, nil]
     # @return [Solargraph::Location, nil]
     def self.to_sg_location location

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -101,8 +101,7 @@ module Solargraph
       parameters = to_parameter_pins(method_type, closure, parameter_names, type_alias_decls: type_alias_decls)
       return_type = to_complex_type(method_type.type.return_type, type_alias_decls: type_alias_decls)
       block = if method_type.block
-                # @sg-ignore The `if method_type.block` guard above doesn't narrow nil out of this
-                #   second `method_type.block` call: https://github.com/castwide/solargraph/issues/1249
+                # @sg-ignore https://github.com/castwide/solargraph/issues/1249
                 block_parameters = to_parameter_pins(method_type.block, closure, type_alias_decls: type_alias_decls)
                 block_return_type = to_complex_type(method_type.block.type.return_type, type_alias_decls: type_alias_decls)
                 Pin::Signature.new(generics: generics, parameters: block_parameters, return_type: block_return_type, source: :rbs, type_location: closure.location, closure: closure)
@@ -166,15 +165,9 @@ module Solargraph
         when RBS::Types::Proc
           'Proc'
         when RBS::Types::Alias
-          # A top-level type alias use, e.g., 'bool' in "type bool = true | false".
-          #
-          # Expand to the alias's underlying type so structural
-          # conformance checks (e.g., typechecking) can compare against
-          # its actual members rather than its nominal name. Fall back to
-          # the nominal tag if the alias definition isn't known, if it's
-          # recursive, or if it's generic (e.g. "type box[T] = Array[T] |
-          # nil") — expanding those would leak an unbound `generic<T>`
-          # tag, since args aren't substituted into the expansion.
+          # Expand so conformance checks see the members, not the name. A
+          # generic alias falls back: args are not substituted, so expanding
+          # would leak an unbound generic<T>.
           # @sg-ignore flow sensitive typing should support case/when
           alias_name = type.name.to_s
           alias_decl = type_alias_decls[alias_name]

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -136,6 +136,27 @@ describe Solargraph::RbsMap::Conversions do
       end
     end
 
+    # https://github.com/castwide/solargraph/pull/1281#issuecomment-5270350329
+    context 'with a type alias that references a name declared only in RBS core' do
+      subject(:parameter) { method_pin.signatures.first.parameters.first }
+
+      let(:method_pin) { api_map.get_method_stack('Foo', 'bar', scope: :instance).first }
+
+      let(:rbs) do
+        <<~RBS
+          type wrapped_path = ::path
+
+          class Foo
+            def bar: (wrapped_path src) -> void
+          end
+        RBS
+      end
+
+      it 'expands the alias instead of falling back to a self-referential nominal tag' do
+        expect(parameter.return_type.rooted_tags).to eq('::String, ::_ToStr, ::_ToPath')
+      end
+    end
+
     # https://github.com/castwide/solargraph/issues/1255
     context 'with a recursive type alias' do
       subject(:parameter) { method_pin.signatures.first.parameters.first }

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -202,6 +202,28 @@ describe Solargraph::RbsMap::Conversions do
         expect(parameter.return_type.rooted_tags).not_to include('generic<')
       end
     end
+
+    context 'with a prepended module' do
+      subject(:prepend_pin) do
+        conversions.pins.find { |pin| pin.is_a?(Solargraph::Pin::Reference::Prepend) && pin.namespace == 'Foo' }
+      end
+
+      let(:rbs) do
+        <<~RBS
+          module Bar
+            def baz: () -> String
+          end
+
+          class Foo
+            prepend Bar
+          end
+        RBS
+      end
+
+      it 'generates a prepend reference naming the module' do
+        expect(prepend_pin.name).to eq('Bar')
+      end
+    end
   end
 
   context 'with standard loads for solargraph project' do

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -93,6 +93,94 @@ describe Solargraph::RbsMap::Conversions do
         expect(method_pin.return_type.tag).to eq('undefined')
       end
     end
+
+    # https://github.com/castwide/solargraph/issues/1255
+    context 'with a type alias used as a parameter type' do
+      subject(:parameter) { method_pin.signatures.first.parameters.first }
+
+      let(:method_pin) { api_map.get_method_stack('Foo', 'bar', scope: :instance).first }
+
+      let(:rbs) do
+        <<~RBS
+          type path = String | Integer
+
+          class Foo
+            def bar: (path src) -> void
+          end
+        RBS
+      end
+
+      it 'expands the alias to its underlying union instead of a nominal tag' do
+        expect(parameter.return_type.rooted_tags).to eq('::String, ::Integer')
+      end
+    end
+
+    # https://github.com/castwide/solargraph/issues/1255
+    context 'with a type alias declared after the class that references it' do
+      subject(:parameter) { method_pin.signatures.first.parameters.first }
+
+      let(:method_pin) { api_map.get_method_stack('Foo', 'bar', scope: :instance).first }
+
+      let(:rbs) do
+        <<~RBS
+          class Foo
+            def bar: (path src) -> void
+          end
+
+          type path = String | Integer
+        RBS
+      end
+
+      it 'still expands the alias to its underlying union' do
+        expect(parameter.return_type.rooted_tags).to eq('::String, ::Integer')
+      end
+    end
+
+    # https://github.com/castwide/solargraph/issues/1255
+    context 'with a recursive type alias' do
+      subject(:parameter) { method_pin.signatures.first.parameters.first }
+
+      let(:method_pin) { api_map.get_method_stack('Foo', 'bar', scope: :instance).first }
+
+      let(:rbs) do
+        <<~RBS
+          type json = String | Array[json]
+
+          class Foo
+            def bar: (json src) -> void
+          end
+        RBS
+      end
+
+      it 'does not crash expanding it' do
+        expect { conversions.pins }.not_to raise_error
+      end
+
+      it 'falls back to the nominal alias tag once a cycle is detected' do
+        expect(parameter.return_type.rooted_tags).to eq('::String, ::Array<json>')
+      end
+    end
+
+    # https://github.com/castwide/solargraph/issues/1255
+    context 'with a generic type alias' do
+      subject(:parameter) { method_pin.signatures.first.parameters.first }
+
+      let(:method_pin) { api_map.get_method_stack('Foo', 'bar', scope: :instance).first }
+
+      let(:rbs) do
+        <<~RBS
+          type box[T] = Array[T] | nil
+
+          class Foo
+            def bar: (box[String] src) -> void
+          end
+        RBS
+      end
+
+      it 'falls back to the nominal alias tag instead of leaking an unbound generic' do
+        expect(parameter.return_type.rooted_tags).not_to include('generic<')
+      end
+    end
   end
 
   context 'with standard loads for solargraph project' do


### PR DESCRIPTION
**Problem:** `solargraph typecheck --level strong` rejects valid arguments when a parameter is typed by an RBS `type` alias.

```rbs
# core/builtin.rbs
type path = string | _ToPath

# stdlib/fileutils/0/fileutils.rbs
type pathlist = ::path | Array[::path]
def self?.ln_sf: (pathlist src, ::path dest, ?noop: boolish, ?verbose: boolish) -> void
```

```ruby
require 'fileutils'

class Repro
  # @param source [String]
  # @param dest [String]
  # @return [void]
  def link(source, dest)
    # Wrong argument type for FileUtils.ln_sf: src expected
    #   FileUtils::path, Array<FileUtils::path>, received String
    FileUtils.ln_sf(source, dest)
  end
end
```

`String` satisfies `string`, so `pathlist` accepts it; every stdlib and gem method with an alias-typed parameter is affected.

**Solution:** `type_to_tag` expands an `RBS::Types::Alias` to its underlying type, falling back to the nominal tag for recursive aliases and for generic ones like `type box[T] = Array[T] | nil`, whose args are not substituted into the expansion.

Alias names resolve against a core-aware copy of the environment, because `RbsMap` loads each library with `core_root: nil` and `resolve_type_names` rebinds a reference it cannot find rather than raising. That copy reparses RBS core, so it is built only for a library whose aliases show the rebinding: one of 41 here.

**Test plan:** `FileUtils.ln_sf('a', 'b')` reports `0 problems found` against real stdlib RBS; the spec suite's self-contained RBS does not cover that path.

Cost: on a cold cache build of this bundle, not distinguishable from master — 113.3s against 113.7s over four interleaved runs on Ruby 3.2.6 / rbs 4.1.2.

Fixes #1255.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
