### PR TITLE
ensure clause breaks return type inference

### DIFF
--- a/lib/solargraph/parser/parser_gem/node_methods.rb
+++ b/lib/solargraph/parser/parser_gem/node_methods.rb
@@ -442,6 +442,11 @@ module Solargraph
             CONDITIONAL_ALL_BUT_FIRST = %i[if unless].freeze
             ONLY_ONE_CHILD = [:return].freeze
             FIRST_TWO_CHILDREN = [:rescue].freeze
+            # :ensure's value is always its body's value (first
+            # child); the ensure clause itself (second child) never
+            # contributes to the method's return value unless it
+            # explicitly returns.
+            ENSURE = [:ensure].freeze
             COMPOUND_STATEMENTS = %i[begin kwbegin].freeze
             SKIPPABLE = %i[def defs class sclass module].freeze
             FUNCTION_VALUE = [:block].freeze
@@ -488,6 +493,12 @@ module Solargraph
                 result.concat reduce_to_value_nodes([node.children[0]])
               elsif FIRST_TWO_CHILDREN.include?(node.type)
                 result.concat reduce_to_value_nodes([node.children[0], node.children[1]])
+              elsif ENSURE.include?(node.type)
+                result.concat reduce_to_value_nodes([node.children[0]])
+                if include_explicit_returns
+                  # @sg-ignore Need to add nil check here
+                  result.concat explicit_return_values_from_compound_statement(node.children[1])
+                end
               elsif FUNCTION_VALUE.include?(node.type)
                 # the block itself is a first class value that could be returned
                 result.push node
@@ -605,8 +616,7 @@ module Solargraph
                 elsif CONDITIONAL_ALL_BUT_FIRST.include?(node.type)
                   # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
                   result.concat reduce_to_value_nodes(node.children[1..])
-                # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
-                elsif node.type == :return
+                elsif ONLY_ONE_CHILD.include?(node.type) || ENSURE.include?(node.type)
                   # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
                   result.concat reduce_to_value_nodes([node.children[0]])
                 # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check

--- a/lib/solargraph/parser/parser_gem/node_methods.rb
+++ b/lib/solargraph/parser/parser_gem/node_methods.rb
@@ -619,6 +619,10 @@ module Solargraph
                 elsif ONLY_ONE_CHILD.include?(node.type) || ENSURE.include?(node.type)
                   # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
                   result.concat reduce_to_value_nodes([node.children[0]])
+                elsif FIRST_TWO_CHILDREN.include?(node.type)
+                  # a :rescue node's value is its body's value or the
+                  # value of whichever resbody handled the exception
+                  result.concat reduce_to_value_nodes([node.children[0], node.children[1]])
                 # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
                 elsif node.type == :or
                   # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check

--- a/lib/solargraph/parser/parser_gem/node_methods.rb
+++ b/lib/solargraph/parser/parser_gem/node_methods.rb
@@ -495,9 +495,10 @@ module Solargraph
                 result.concat reduce_to_value_nodes([node.children[0], node.children[1]])
               elsif ENSURE.include?(node.type)
                 result.concat reduce_to_value_nodes([node.children[0]])
-                if include_explicit_returns
-                  # @sg-ignore Need to add nil check here
-                  result.concat explicit_return_values_from_compound_statement(node.children[1])
+                ensure_body = node.children[1]
+                if include_explicit_returns && ensure_body.is_a?(::Parser::AST::Node)
+                  # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
+                  result.concat explicit_return_values_from_compound_statement(ensure_body)
                 end
               elsif FUNCTION_VALUE.include?(node.type)
                 # the block itself is a first class value that could be returned

--- a/spec/parser/node_methods_spec.rb
+++ b/spec/parser/node_methods_spec.rb
@@ -240,6 +240,34 @@ describe Solargraph::Parser::NodeMethods do
     expect(rets.map(&:type)).to eq(%i[str int])
   end
 
+  it 'uses the body and rescue values for a method with both a rescue and an ensure clause' do
+    def_node = parse(%(
+      def foo
+        'hello'
+      rescue StandardError
+        'goodbye'
+      ensure
+        nil
+      end
+    ))
+    rets = described_class.returns_from_method_body(def_node.children[2])
+    expect(rets.map(&:type)).to eq(%i[str str])
+  end
+
+  it 'includes explicit returns from an ensure clause alongside a rescue clause' do
+    def_node = parse(%(
+      def foo
+        'hello'
+      rescue StandardError
+        'goodbye'
+      ensure
+        return 1 if bar
+      end
+    ))
+    rets = described_class.returns_from_method_body(def_node.children[2])
+    expect(rets.map(&:type)).to eq(%i[str str int])
+  end
+
   it 'returns nested return blocks' do
     node = parse(%(
       if foo

--- a/spec/parser/node_methods_spec.rb
+++ b/spec/parser/node_methods_spec.rb
@@ -216,6 +216,17 @@ describe Solargraph::Parser::NodeMethods do
     expect(rets.map(&:type)).to eq(%i[str str])
   end
 
+  it 'handles an ensure clause with an empty body' do
+    node = parse(%(
+      begin
+        'hello'
+      ensure
+      end
+    ))
+    rets = described_class.returns_from_method_body(node)
+    expect(rets.map(&:type)).to eq([:str])
+  end
+
   it 'uses the body value for a method-level ensure clause with no begin/end' do
     def_node = parse(%(
       def foo

--- a/spec/parser/node_methods_spec.rb
+++ b/spec/parser/node_methods_spec.rb
@@ -192,6 +192,54 @@ describe Solargraph::Parser::NodeMethods do
     expect(rets.map(&:type)).to eq([:str])
   end
 
+  it 'uses the body value for a method with an ensure clause' do
+    node = parse(%(
+      begin
+        'hello'
+      ensure
+        nil
+      end
+    ))
+    rets = described_class.returns_from_method_body(node)
+    expect(rets.map(&:type)).to eq([:str])
+  end
+
+  it 'includes explicit returns from an ensure clause' do
+    node = parse(%(
+      begin
+        'hello'
+      ensure
+        return 'goodbye' if foo
+      end
+    ))
+    rets = described_class.returns_from_method_body(node)
+    expect(rets.map(&:type)).to eq(%i[str str])
+  end
+
+  it 'uses the body value for a method-level ensure clause with no begin/end' do
+    def_node = parse(%(
+      def foo
+        'hello'
+      ensure
+        nil
+      end
+    ))
+    rets = described_class.returns_from_method_body(def_node.children[2])
+    expect(rets.map(&:type)).to eq([:str])
+  end
+
+  it 'includes explicit returns from a method-level ensure clause with no begin/end' do
+    def_node = parse(%(
+      def foo
+        'hello'
+      ensure
+        return 1 if bar
+      end
+    ))
+    rets = described_class.returns_from_method_body(def_node.children[2])
+    expect(rets.map(&:type)).to eq(%i[str int])
+  end
+
   it 'returns nested return blocks' do
     node = parse(%(
       if foo


### PR DESCRIPTION
**Problem:** Any method with an `ensure` clause fails `solargraph typecheck --level strong` with `return type could not be inferred`, whatever the body returns and whatever `@return` declares.

```ruby
class Repro
  # @return [String]
  def call
    'hello'
  ensure
    nil
  end
end
```

```
$ solargraph typecheck --level strong repro.rb
repro.rb:3: Repro#call return type could not be inferred
```

An empty `ensure` is enough to trigger it, so every method using one for cleanup is unusable at `strict` or `strong`. Fixes #1284.

**Solution:** Unwrap an `:ensure` node to its body's value, scanning the ensure clause separately for explicit `return`s, since only those reach the caller.

`reduce_to_value_nodes` also gains the `:rescue` case it never had, which is what a rescue nested inside an ensure body needs in order to resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XGDWQqVqW2ZdP2rbfr5DDs
