### PR TITLE
Fix generic binding and block signature merging through a @!parse stub

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -814,7 +814,7 @@ module Solargraph
 
     # The namespace pin for fqns that actually declares its generics,
     # picked from any duplicate pins for the same namespace.
-    #
+    # @todo Consider trade-offs of merging namespace pins instead of trying to choose the best one for this use
     # @param fqns [String]
     # @return [Pin::Namespace, nil]
     def namespace_pin_for_generics fqns

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -818,8 +818,8 @@ module Solargraph
     # @param fqns [String]
     # @return [Pin::Namespace, nil]
     def namespace_pin_for_generics fqns
-      # @type [Array<Pin::Namespace>]
       candidates = store.get_path_pins(fqns).select { |p| p.is_a?(Pin::Namespace) }
+      # @sg-ignore select with an is_a? block does not narrow the element type
       candidates.find { |p| !p.generics.empty? } || candidates.first
     end
 

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -812,12 +812,8 @@ module Solargraph
       @store ||= Store.new
     end
 
-    # Get the namespace pin that should be used to resolve generic type
-    # parameters for a fully qualified namespace. Multiple pins can
-    # exist for the same namespace (e.g., a gem's own class definition
-    # plus a `@!parse` stub in a different file that adds `@generic`
-    # tags); the one that actually declares the generics must be used,
-    # regardless of load order.
+    # The namespace pin for fqns that actually declares its generics,
+    # picked from any duplicate pins for the same namespace.
     #
     # @param fqns [String]
     # @return [Pin::Namespace, nil]

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -452,7 +452,7 @@ module Solargraph
     def get_methods rooted_tag, scope: :instance, visibility: [:public], deep: true
       rooted_type = ComplexType.try_parse(rooted_tag)
       fqns = rooted_type.namespace
-      namespace_pin = store.get_path_pins(fqns).select { |p| p.is_a?(Pin::Namespace) }.first
+      namespace_pin = namespace_pin_for_generics(fqns)
       cached = cache.get_methods(rooted_tag, scope, visibility, deep)
       return cached.clone unless cached.nil?
       # @type [Array<Solargraph::Pin::Method>]
@@ -783,9 +783,10 @@ module Solargraph
       # @todo Can inner_get_methods be cached?  Lots of lookups of base types going on.
       methods = inner_get_methods(resolved_reference_type.tag, scope, visibility, deep, skip, no_core)
       if namespace_pin && !resolved_reference_type.all_params.empty?
-        reference_pin = store.get_path_pins(resolved_reference_type.name).select { |p| p.is_a?(Pin::Namespace) }.first
+        reference_pin = namespace_pin_for_generics(resolved_reference_type.name)
         # logger.debug { "ApiMap#add_methods_from_reference(type=#{type}) - resolving generics with #{reference_pin.generics}, #{resolved_reference_type.rooted_tags}" }
         methods = methods.map do |method_pin|
+          # @sg-ignore Need to add nil check here
           method_pin.resolve_generics(reference_pin, resolved_reference_type)
         end
       end
@@ -811,6 +812,21 @@ module Solargraph
       @store ||= Store.new
     end
 
+    # Get the namespace pin that should be used to resolve generic type
+    # parameters for a fully qualified namespace. Multiple pins can
+    # exist for the same namespace (e.g., a gem's own class definition
+    # plus a `@!parse` stub in a different file that adds `@generic`
+    # tags); the one that actually declares the generics must be used,
+    # regardless of load order.
+    #
+    # @param fqns [String]
+    # @return [Pin::Namespace, nil]
+    def namespace_pin_for_generics fqns
+      # @type [Array<Pin::Namespace>]
+      candidates = store.get_path_pins(fqns).select { |p| p.is_a?(Pin::Namespace) }
+      candidates.find { |p| !p.generics.empty? } || candidates.first
+    end
+
     # @return [Solargraph::ApiMap::Cache]
     attr_reader :cache
 
@@ -826,7 +842,7 @@ module Solargraph
       rooted_type = ComplexType.parse(rooted_tag).force_rooted
       fqns = rooted_type.namespace
       rooted_type.all_params
-      namespace_pin = store.get_path_pins(fqns).select { |p| p.is_a?(Pin::Namespace) }.first
+      namespace_pin = namespace_pin_for_generics(fqns)
       return [] if no_core && fqns =~ /^(Object|BasicObject|Class|Module)$/
       reqstr = "#{fqns}|#{scope}|#{visibility.sort}|#{deep}"
       return [] if skip.include?(reqstr)
@@ -867,6 +883,7 @@ module Solargraph
           end
           rooted_sc_tag = qualify_superclass(rooted_tag)
           unless rooted_sc_tag.nil?
+            # @sg-ignore Need to add nil check here
             result.concat inner_get_methods_from_reference(rooted_sc_tag, namespace_pin, rooted_type, scope,
                                                            visibility, true, skip, no_core)
           end
@@ -880,6 +897,7 @@ module Solargraph
           end
           rooted_sc_tag = qualify_superclass(rooted_tag)
           unless rooted_sc_tag.nil?
+            # @sg-ignore Need to add nil check here
             result.concat inner_get_methods_from_reference(rooted_sc_tag, namespace_pin, rooted_type, scope,
                                                            visibility, true, skip, true)
           end

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -297,16 +297,12 @@ module Solargraph
         @index ||= Index.new
       end
 
-      # A method can be defined by more than one pin with the same
-      # path - e.g., a gem's own implementation plus a `@!parse` stub
-      # in a separate file that overrides its documentation. Combine
-      # them into a single pin so callers see one consistent signature
-      # instead of an arbitrary pick among duplicates.
-      #
-      # Aliases are skipped: combining a MethodAlias pin with a
-      # non-alias pin at the same path produces a `:combined` pin that
-      # #resolve_method_alias can't trace back to its original target,
-      # which raises under SOLARGRAPH_ASSERTS=on.
+      # Combines pins that share a method path (e.g. a gem's own
+      # implementation plus a `@!parse` stub overriding its docs)
+      # into one pin, so callers see a single consistent signature.
+      # Aliases are skipped: combining a MethodAlias with a
+      # non-alias pin breaks #resolve_method_alias under
+      # SOLARGRAPH_ASSERTS=on.
       #
       # @param pins [Array<Pin::Method>]
       # @return [Array<Pin::Method>]

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -297,10 +297,9 @@ module Solargraph
         @index ||= Index.new
       end
 
-      # Combines same-path pins into one. Skips aliases (breaks
-      # #resolve_method_alias under SOLARGRAPH_ASSERTS=on) and
-      # DelegatedMethod (initialize needs exactly one of
-      # :method/:receiver; a merged pin can't hold both).
+      # Combines same-path pins into one. Skips aliases (a merged pin
+      # breaks #resolve_method_alias under SOLARGRAPH_ASSERTS=on) and
+      # DelegatedMethod (initialize needs exactly one of :method/:receiver).
       #
       # @param pins [Array<Pin::Method>]
       # @return [Array<Pin::Method>]

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -304,12 +304,20 @@ module Solargraph
       # non-alias pin breaks #resolve_method_alias under
       # SOLARGRAPH_ASSERTS=on.
       #
+      # DelegatedMethod pins are skipped for the same reason, but they
+      # raise outright rather than degrade: Pin::Base#combine_with rebuilds
+      # the merged pin with self.class.new(**new_attrs) carrying only
+      # generic pin attributes, and DelegatedMethod#initialize requires
+      # exactly one of :method / :receiver. Each pin's delegation target is
+      # per-pin state that a merged pin has no way to represent, so both
+      # are kept.
+      #
       # @param pins [Array<Pin::Method>]
       # @return [Array<Pin::Method>]
       def combine_duplicate_method_pins pins
         result = []
         pins.group_by(&:path).each_value do |group|
-          if group.length == 1 || group.any? { |pin| pin.is_a?(Pin::MethodAlias) }
+          if group.length == 1 || group.any? { |pin| pin.is_a?(Pin::MethodAlias) || pin.is_a?(Pin::DelegatedMethod) }
             result.concat(group)
           else
             # @sg-ignore group is never empty here (group_by never yields an empty group)

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -297,11 +297,8 @@ module Solargraph
         @index ||= Index.new
       end
 
-      # Combines pins that share a method path (e.g. a gem's own
-      # implementation plus a `@!parse` stub overriding its docs)
-      # into one pin, so callers see a single consistent signature.
-      # Aliases are skipped: combining a MethodAlias with a
-      # non-alias pin breaks #resolve_method_alias under
+      # Combines same-path pins into one pin. Skips aliases - merging
+      # a MethodAlias breaks #resolve_method_alias under
       # SOLARGRAPH_ASSERTS=on.
       #
       # @param pins [Array<Pin::Method>]

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -72,11 +72,12 @@ module Solargraph
       # @param fqns [String]
       # @param scope [Symbol]
       # @param visibility [Array<Symbol>]
-      # @return [Enumerable<Solargraph::Pin::Method>]
+      # @return [Array<Solargraph::Pin::Method>]
       def get_methods fqns, scope: :instance, visibility: [:public]
-        namespace_children(fqns).select do |pin|
+        pins = namespace_children(fqns).select do |pin|
           pin.is_a?(Pin::Method) && pin.scope == scope && visibility.include?(pin.visibility)
         end
+        combine_duplicate_method_pins(pins)
       end
 
       BOOLEAN_SUPERCLASS_PIN = Pin::Reference::Superclass.new(name: 'Boolean', closure: Pin::ROOT_PIN,
@@ -294,6 +295,33 @@ module Solargraph
       # @return [Index]
       def index
         @index ||= Index.new
+      end
+
+      # A method can be defined by more than one pin with the same
+      # path - e.g., a gem's own implementation plus a `@!parse` stub
+      # in a separate file that overrides its documentation. Combine
+      # them into a single pin so callers see one consistent signature
+      # instead of an arbitrary pick among duplicates.
+      #
+      # Aliases are skipped: combining a MethodAlias pin with a
+      # non-alias pin at the same path produces a `:combined` pin that
+      # #resolve_method_alias can't trace back to its original target,
+      # which raises under SOLARGRAPH_ASSERTS=on.
+      #
+      # @param pins [Array<Pin::Method>]
+      # @return [Array<Pin::Method>]
+      def combine_duplicate_method_pins pins
+        result = []
+        pins.group_by(&:path).each_value do |group|
+          if group.length == 1 || group.any? { |pin| pin.is_a?(Pin::MethodAlias) }
+            result.concat(group)
+          else
+            # @sg-ignore group is never empty here (group_by never yields an empty group)
+            combined = group[1..].reduce(group.first) { |memo, pin| memo.combine_with(pin) }
+            result.push(combined)
+          end
+        end
+        result
       end
 
       # @param pinsets [Array<Array<Pin::Base>>]

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -297,9 +297,10 @@ module Solargraph
         @index ||= Index.new
       end
 
-      # Combines same-path pins into one. Skips aliases (a merged pin
-      # breaks #resolve_method_alias under SOLARGRAPH_ASSERTS=on) and
-      # DelegatedMethod (initialize needs exactly one of :method/:receiver).
+      # Combines same-path pins into one. They arise when a method is
+      # documented in more than one file - a `@!parse` stub re-documenting
+      # a method the gem already defines, or a reopened class. Aliases and
+      # DelegatedMethod are skipped; neither survives a merge.
       #
       # @param pins [Array<Pin::Method>]
       # @return [Array<Pin::Method>]

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -297,17 +297,10 @@ module Solargraph
         @index ||= Index.new
       end
 
-      # Combines same-path pins into one pin. Skips aliases - merging
-      # a MethodAlias breaks #resolve_method_alias under
-      # SOLARGRAPH_ASSERTS=on.
-      #
-      # DelegatedMethod pins are skipped for the same reason, but they
-      # raise outright rather than degrade: Pin::Base#combine_with rebuilds
-      # the merged pin with self.class.new(**new_attrs) carrying only
-      # generic pin attributes, and DelegatedMethod#initialize requires
-      # exactly one of :method / :receiver. Each pin's delegation target is
-      # per-pin state that a merged pin has no way to represent, so both
-      # are kept.
+      # Combines same-path pins into one. Skips aliases (breaks
+      # #resolve_method_alias under SOLARGRAPH_ASSERTS=on) and
+      # DelegatedMethod (initialize needs exactly one of
+      # :method/:receiver; a merged pin can't hold both).
       #
       # @param pins [Array<Pin::Method>]
       # @return [Array<Pin::Method>]

--- a/lib/solargraph/pin/callable.rb
+++ b/lib/solargraph/pin/callable.rb
@@ -34,17 +34,17 @@ module Solargraph
         closure.namespace
       end
 
-      # A block declaring no yielded parameters says nothing about
-      # what it yields, so it loses to a sibling that documents
-      # them, rather than being picked between arbitrarily.
+      # A block documented with fewer yielded parameters says less
+      # about what it yields than a sibling with more, so it loses to
+      # that sibling rather than being picked between arbitrarily.
       #
       # @param other [self]
       #
       # @return [Pin::Signature, nil]
       def combine_blocks other
         return other.block if block.nil? ||
-                              (block.parameters.empty? && !other.block.nil? && !other.block.parameters.empty?)
-        return block if other.block.nil? || (other.block.parameters.empty? && !block.parameters.empty?)
+                              (!other.block.nil? && block.parameters.length < other.block.parameters.length)
+        return block if other.block.nil? || (block.parameters.length > other.block.parameters.length)
         return block.combine_with(other.block) if block.arity == other.block.arity
 
         # @type [Pin::Signature, nil]

--- a/lib/solargraph/pin/callable.rb
+++ b/lib/solargraph/pin/callable.rb
@@ -34,18 +34,21 @@ module Solargraph
         closure.namespace
       end
 
+      # A block declaring no yielded parameters says nothing about
+      # what it yields, so it loses to a sibling that documents
+      # them, rather than being picked between arbitrarily.
+      #
       # @param other [self]
       #
       # @return [Pin::Signature, nil]
       def combine_blocks other
-        if block.nil?
-          other.block
-        elsif other.block.nil?
-          block
-        else
-          # @type [Pin::Signature, nil]
-          choose_pin_attr(other, :block)
-        end
+        return other.block if block.nil? ||
+                              (block.parameters.empty? && !other.block.nil? && !other.block.parameters.empty?)
+        return block if other.block.nil? || (other.block.parameters.empty? && !block.parameters.empty?)
+        return block.combine_with(other.block) if block.arity == other.block.arity
+
+        # @type [Pin::Signature, nil]
+        choose_pin_attr(other, :block)
       end
 
       # @param other [self]

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -294,8 +294,7 @@ module Solargraph
         type = see_reference(api_map) || typify_from_super(api_map)
         logger.debug { "Method#typify(self=#{self}) - type=#{type&.rooted_tags.inspect}" }
         unless type.nil?
-          # @sg-ignore Need to add nil check here
-          qualified = type.qualify(api_map, *closure.gates)
+          qualified = type.qualify(api_map, *(closure&.gates || ['']))
           logger.debug { "Method#typify(self=#{self}) => #{qualified.rooted_tags.inspect}" }
           return qualified
         end

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -507,13 +507,14 @@ module Solargraph
         by_type_arity.values.flatten
       end
 
-      # A block that declares no yielded parameters (e.g. `&block`
-      # with no @yieldparam) differs in type_arity from one that
-      # does, so combine_signatures_by_type_arity's bucketing would
-      # otherwise keep them as separate overloads. They're the same
-      # overload, just documented with different completeness -
-      # merge them here, before that bucketing, so the merged
-      # signature carries the informative block onward.
+      # A block documented with fewer yielded parameters than a
+      # sibling signature's block (including zero, e.g. `&block` with
+      # no @yieldparam at all) differs in type_arity from it, so
+      # combine_signatures_by_type_arity's bucketing would otherwise
+      # keep them as separate overloads. They're the same overload,
+      # just documented with different completeness - merge them
+      # here, before that bucketing, so the merged signature carries
+      # the more complete block onward.
       #
       # @param signature_pins [Array<Pin::Signature>]
       # @return [Array<Pin::Signature>]
@@ -542,7 +543,7 @@ module Solargraph
       # @return [Boolean]
       def combinable_by_block_informativeness? sig1, sig2
         return false if sig1.block.nil? || sig2.block.nil?
-        return false if sig1.block.parameters.empty? == sig2.block.parameters.empty?
+        return false if sig1.block.parameters.length == sig2.block.parameters.length
         sig1.type_arity[0..-2] == sig2.type_arity[0..-2]
       end
 

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -492,9 +492,11 @@ module Solargraph
       #
       # @return [Array<Pin::Signature>]
       def combine_signatures_by_type_arity(*signature_pins)
+        merged_pins = merge_signatures_differing_only_by_block_informativeness(signature_pins)
+
         # @type [Hash{Array => Array<Pin::Signature>}]
         by_type_arity = {}
-        signature_pins.each do |signature_pin|
+        merged_pins.each do |signature_pin|
           by_type_arity[signature_pin.type_arity] ||= []
           by_type_arity[signature_pin.type_arity] << signature_pin
         end
@@ -503,6 +505,45 @@ module Solargraph
           combine_same_type_arity_signatures same_type_arity_signatures
         end
         by_type_arity.values.flatten
+      end
+
+      # A block that declares no yielded parameters (e.g. `&block`
+      # with no @yieldparam) differs in type_arity from one that
+      # does, so combine_signatures_by_type_arity's bucketing would
+      # otherwise keep them as separate overloads. They're the same
+      # overload, just documented with different completeness -
+      # merge them here, before that bucketing, so the merged
+      # signature carries the informative block onward.
+      #
+      # @param signature_pins [Array<Pin::Signature>]
+      # @return [Array<Pin::Signature>]
+      def merge_signatures_differing_only_by_block_informativeness signature_pins
+        # @param sig [Pin::Signature]
+        # @param result [Array<Pin::Signature>]
+        signature_pins.each_with_object([]) do |sig, result|
+          # @type [Integer, nil]
+          match_index = result.find_index { |existing| combinable_by_block_informativeness?(existing, sig) }
+          if match_index.nil?
+            result << sig
+          else
+            existing = result.fetch(match_index)
+            # Bypass Callable#combine_with's default parameter zip: it
+            # compares the signatures' full arity, which folds in the
+            # block's own arity and would raise here even though the
+            # blockless parameters already match (that's what
+            # combinable_by_block_informativeness? just verified).
+            result[match_index] = existing.combine_with(sig, parameters: existing.parameters)
+          end
+        end
+      end
+
+      # @param sig1 [Pin::Signature]
+      # @param sig2 [Pin::Signature]
+      # @return [Boolean]
+      def combinable_by_block_informativeness? sig1, sig2
+        return false if sig1.block.nil? || sig2.block.nil?
+        return false if sig1.block.parameters.empty? == sig2.block.parameters.empty?
+        sig1.type_arity[0..-2] == sig2.type_arity[0..-2]
       end
 
       # @param same_type_arity_signatures [Array<Pin::Signature>]

--- a/spec/api_map/store_spec.rb
+++ b/spec/api_map/store_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'timeout'
+
 describe Solargraph::ApiMap::Store do
   it 'indexes multiple pinsets' do
     foo_pin = Solargraph::Pin::Namespace.new(name: 'Foo')
@@ -90,6 +92,52 @@ describe Solargraph::ApiMap::Store do
       bar_pins = pins.select { |p| p.name == 'bar' }
       expect(bar_pins.length).to eq(2)
       expect(bar_pins).to include(an_instance_of(Solargraph::Pin::MethodAlias))
+    end
+
+    it 'combines many same-path pins without timing out' do
+      # Smoke test for the concern that originally motivated
+      # castwide/solargraph#1186 ("Stub combine_same_type_arity_signatures",
+      # merged as a stopgap for "an infinite loop bug in Ruby 3.x") and
+      # castwide/solargraph#1195 ("Limit pin combination to doc maps",
+      # which removed this combining logic from Store#get_methods
+      # entirely). The "infinite loop" was later diagnosed as an
+      # exponential blowup in Pin::Method#combine_same_type_arity_signatures
+      # and fixed in castwide/solargraph#1238.
+      #
+      # This does NOT reproduce that specific bug: these hand-written
+      # single-type parameters all collapse to the same
+      # Pin::Parameter#type_arity_decl bucket (a separate, still-open
+      # gap - it groups by union member *count*, not the actual
+      # types), so they hit the ">10" bail-out before ever reaching
+      # the code path #1238 fixed. #1238's own regression spec
+      # (spec/pin/method_spec.rb "combines many non-mergeable
+      # same-type-arity signatures without exponential blowup") is
+      # the precise guard for that bug, exercising
+      # combine_same_type_arity_signatures directly with signatures
+      # engineered to never merge. This spec instead just confirms
+      # Store#get_methods' combination of many real same-path pins,
+      # as this PR adds, completes quickly rather than hanging.
+      maps = (1..30).map do |i|
+        Solargraph::SourceMap.load_string(%(
+          class Foo
+            # @param other [Type#{i}]
+            # @return [Type#{i}]
+            def bar(other); end
+          end
+        ), "source#{i}.rb")
+      end
+      store = nil
+      Timeout.timeout(5) { store = described_class.new(maps.flat_map(&:pins)) }
+
+      result = nil
+      Timeout.timeout(5) { result = store.get_methods('Foo', scope: :instance) }
+
+      bar_pins = result.select { |p| p.name == 'bar' }
+      expect(bar_pins.length).to eq(1)
+      # The real regression is combinatorial blowup, not the exact
+      # merge outcome - bound the result size rather than pin down
+      # merge semantics unrelated to this concern.
+      expect(bar_pins.first.signatures.length).to be <= maps.length
     end
   end
 

--- a/spec/api_map/store_spec.rb
+++ b/spec/api_map/store_spec.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require 'timeout'
-
 describe Solargraph::ApiMap::Store do
   it 'indexes multiple pinsets' do
     foo_pin = Solargraph::Pin::Namespace.new(name: 'Foo')
@@ -108,7 +106,7 @@ describe Solargraph::ApiMap::Store do
       expect(bar_pins).to all(be_an_instance_of(Solargraph::Pin::DelegatedMethod))
     end
 
-    it 'combines many same-path pins without timing out' do
+    it 'combines many same-path pins into a single pin' do
       maps = (1..30).map do |i|
         Solargraph::SourceMap.load_string(%(
           class Foo
@@ -118,13 +116,9 @@ describe Solargraph::ApiMap::Store do
           end
         ), "source#{i}.rb")
       end
-      store = nil
-      Timeout.timeout(5) { store = described_class.new(maps.flat_map(&:pins)) }
+      store = described_class.new(maps.flat_map(&:pins))
 
-      result = nil
-      Timeout.timeout(5) { result = store.get_methods('Foo', scope: :instance) }
-
-      bar_pins = result.select { |p| p.name == 'bar' }
+      bar_pins = store.get_methods('Foo', scope: :instance).select { |p| p.name == 'bar' }
       expect(bar_pins.length).to eq(1)
       # The regression is combinatorial blowup, not a specific merge
       # outcome, so bound the size rather than assert exact merges.

--- a/spec/api_map/store_spec.rb
+++ b/spec/api_map/store_spec.rb
@@ -49,6 +49,50 @@ describe Solargraph::ApiMap::Store do
     expect(store.get_path_pins('Bar')).to eq([bar_pin])
   end
 
+  describe '#get_methods' do
+    it 'combines pins for the same method path from different sources' do
+      plain_impl = Solargraph::SourceMap.load_string(%(
+        class Foo
+          def bar; end
+        end
+      ), 'plain.rb')
+      override = Solargraph::SourceMap.load_string(%(
+        class Foo
+          # @return [String]
+          def bar; end
+        end
+      ), 'override.rb')
+      store = described_class.new(plain_impl.pins + override.pins)
+      pins = store.get_methods('Foo', scope: :instance).select { |p| p.name == 'bar' }
+      expect(pins.length).to eq(1)
+      expect(pins.first.return_type.tag).to eq('String')
+    end
+
+    it 'does not combine a method alias with a regular method sharing its path' do
+      # Combining an alias pin with a non-alias pin at the same path
+      # previously produced a `:combined` pin that couldn't be
+      # resolved back to its original target, raising under
+      # SOLARGRAPH_ASSERTS=on.
+      regular = Solargraph::SourceMap.load_string(%(
+        class Foo
+          def bar; end
+        end
+      ), 'regular.rb')
+      aliased = Solargraph::SourceMap.load_string(%(
+        class Foo
+          def baz; end
+          alias bar baz
+        end
+      ), 'aliased.rb')
+      store = described_class.new(regular.pins + aliased.pins)
+      pins = []
+      expect { pins = store.get_methods('Foo', scope: :instance) }.not_to raise_error
+      bar_pins = pins.select { |p| p.name == 'bar' }
+      expect(bar_pins.length).to eq(2)
+      expect(bar_pins).to include(an_instance_of(Solargraph::Pin::MethodAlias))
+    end
+  end
+
   # @todo This will become #get_superclass
   describe '#get_superclass' do
     it 'returns simple superclasses' do

--- a/spec/api_map/store_spec.rb
+++ b/spec/api_map/store_spec.rb
@@ -93,13 +93,8 @@ describe Solargraph::ApiMap::Store do
     end
 
     it 'does not combine two delegated methods sharing a path' do
-      # Pin::Base#combine_with rebuilds the merged pin with
-      # self.class.new(**new_attrs), and new_attrs carries only generic pin
-      # attributes. Pin::DelegatedMethod#initialize requires exactly one of
-      # :method / :receiver, so combining two of them raises
-      # `either :method or :receiver is required (ArgumentError)`.
-      # castwide/solargraph#1311 mints these pins for def_delegators, which
-      # makes duplicate-path groups routine.
+      # DelegatedMethod#initialize requires exactly one of :method /
+      # :receiver, so a merged pin can't hold both delegation targets.
       closure = Solargraph::Pin::Namespace.new(name: 'Foo', closure: Solargraph::Pin::ROOT_PIN, type: :class)
       delegated = lambda do |receiver_name|
         chain = Solargraph::Source::Chain.new([Solargraph::Source::Chain::Call.new(receiver_name, nil)])

--- a/spec/api_map/store_spec.rb
+++ b/spec/api_map/store_spec.rb
@@ -92,6 +92,27 @@ describe Solargraph::ApiMap::Store do
       expect(bar_pins).to include(an_instance_of(Solargraph::Pin::MethodAlias))
     end
 
+    it 'does not combine two delegated methods sharing a path' do
+      # Pin::Base#combine_with rebuilds the merged pin with
+      # self.class.new(**new_attrs), and new_attrs carries only generic pin
+      # attributes. Pin::DelegatedMethod#initialize requires exactly one of
+      # :method / :receiver, so combining two of them raises
+      # `either :method or :receiver is required (ArgumentError)`.
+      # castwide/solargraph#1311 mints these pins for def_delegators, which
+      # makes duplicate-path groups routine.
+      closure = Solargraph::Pin::Namespace.new(name: 'Foo', closure: Solargraph::Pin::ROOT_PIN, type: :class)
+      delegated = lambda do |receiver_name|
+        chain = Solargraph::Source::Chain.new([Solargraph::Source::Chain::Call.new(receiver_name, nil)])
+        Solargraph::Pin::DelegatedMethod.new(closure: closure, scope: :instance, name: 'bar', receiver: chain)
+      end
+      store = described_class.new([closure, delegated.call('one'), delegated.call('two')])
+      pins = []
+      expect { pins = store.get_methods('Foo', scope: :instance) }.not_to raise_error
+      bar_pins = pins.select { |p| p.name == 'bar' }
+      expect(bar_pins.length).to eq(2)
+      expect(bar_pins).to all(be_an_instance_of(Solargraph::Pin::DelegatedMethod))
+    end
+
     it 'combines many same-path pins without timing out' do
       # Store#get_methods must combine many real same-path pins
       # quickly, not hang or blow up combinatorially.

--- a/spec/api_map/store_spec.rb
+++ b/spec/api_map/store_spec.rb
@@ -126,8 +126,8 @@ describe Solargraph::ApiMap::Store do
 
       bar_pins = result.select { |p| p.name == 'bar' }
       expect(bar_pins.length).to eq(1)
-      # Regression is combinatorial blowup, not exact merge outcome -
-      # bound the result size rather than pin exact merge semantics.
+      # The regression is combinatorial blowup, not a specific merge
+      # outcome, so bound the size rather than assert exact merges.
       expect(bar_pins.first.signatures.length).to be <= maps.length
     end
   end

--- a/spec/api_map/store_spec.rb
+++ b/spec/api_map/store_spec.rb
@@ -93,8 +93,6 @@ describe Solargraph::ApiMap::Store do
     end
 
     it 'combines many same-path pins without timing out' do
-      # Store#get_methods must combine many real same-path pins
-      # quickly, not hang or blow up combinatorially.
       maps = (1..30).map do |i|
         Solargraph::SourceMap.load_string(%(
           class Foo
@@ -112,9 +110,8 @@ describe Solargraph::ApiMap::Store do
 
       bar_pins = result.select { |p| p.name == 'bar' }
       expect(bar_pins.length).to eq(1)
-      # The real regression is combinatorial blowup, not the exact
-      # merge outcome - bound the result size rather than pin down
-      # merge semantics unrelated to this concern.
+      # Regression is combinatorial blowup, not exact merge outcome -
+      # bound the result size rather than pin exact merge semantics.
       expect(bar_pins.first.signatures.length).to be <= maps.length
     end
   end

--- a/spec/api_map/store_spec.rb
+++ b/spec/api_map/store_spec.rb
@@ -71,10 +71,8 @@ describe Solargraph::ApiMap::Store do
     end
 
     it 'does not combine a method alias with a regular method sharing its path' do
-      # Combining an alias pin with a non-alias pin at the same path
-      # previously produced a `:combined` pin that couldn't be
-      # resolved back to its original target, raising under
-      # SOLARGRAPH_ASSERTS=on.
+      # A combined alias pin can't be traced back to its original
+      # target, which #resolve_method_alias needs to work.
       regular = Solargraph::SourceMap.load_string(%(
         class Foo
           def bar; end
@@ -95,28 +93,8 @@ describe Solargraph::ApiMap::Store do
     end
 
     it 'combines many same-path pins without timing out' do
-      # Smoke test for the concern that originally motivated
-      # castwide/solargraph#1186 ("Stub combine_same_type_arity_signatures",
-      # merged as a stopgap for "an infinite loop bug in Ruby 3.x") and
-      # castwide/solargraph#1195 ("Limit pin combination to doc maps",
-      # which removed this combining logic from Store#get_methods
-      # entirely). The "infinite loop" was later diagnosed as an
-      # exponential blowup in Pin::Method#combine_same_type_arity_signatures
-      # and fixed in castwide/solargraph#1238.
-      #
-      # This does NOT reproduce that specific bug: these hand-written
-      # single-type parameters all collapse to the same
-      # Pin::Parameter#type_arity_decl bucket (a separate, still-open
-      # gap - it groups by union member *count*, not the actual
-      # types), so they hit the ">10" bail-out before ever reaching
-      # the code path #1238 fixed. #1238's own regression spec
-      # (spec/pin/method_spec.rb "combines many non-mergeable
-      # same-type-arity signatures without exponential blowup") is
-      # the precise guard for that bug, exercising
-      # combine_same_type_arity_signatures directly with signatures
-      # engineered to never merge. This spec instead just confirms
-      # Store#get_methods' combination of many real same-path pins,
-      # as this PR adds, completes quickly rather than hanging.
+      # Store#get_methods must combine many real same-path pins
+      # quickly, not hang or blow up combinatorially.
       maps = (1..30).map do |i|
         Solargraph::SourceMap.load_string(%(
           class Foo

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -760,4 +760,10 @@ describe Solargraph::Pin::Method do
       expect { pin.signatures }.not_to raise_error
     end
   end
+
+  it 'typifies a DuckMethod pin with no closure without raising' do
+    api_map = Solargraph::ApiMap.new
+    pin = Solargraph::Pin::DuckMethod.new(name: 'to_s', source: :api_map)
+    expect { pin.typify(api_map) }.not_to raise_error
+  end
 end

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -787,7 +787,7 @@ describe Solargraph::Pin::Method do
     end
   end
 
-  it 'resolves a closureless DuckMethod pin to the core method return type' do
+  it 'typifies a closureless DuckMethod pin as String via Object#to_s' do
     api_map = Solargraph::ApiMap.new
     pin = Solargraph::Pin::DuckMethod.new(name: 'to_s', source: :api_map)
     expect(pin.closure).to be_nil

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -787,9 +787,11 @@ describe Solargraph::Pin::Method do
     end
   end
 
-  it 'typifies a DuckMethod pin with no closure without raising' do
+  it 'resolves a closureless DuckMethod pin to the core method return type' do
     api_map = Solargraph::ApiMap.new
     pin = Solargraph::Pin::DuckMethod.new(name: 'to_s', source: :api_map)
-    expect { pin.typify(api_map) }.not_to raise_error
+    expect(pin.closure).to be_nil
+    expect(pin.return_type).to be_undefined
+    expect(pin.typify(api_map).rooted_tags).to eq('::String')
   end
 end

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -128,6 +128,32 @@ describe Solargraph::Pin::Method do
     expect(result.length).to eq(signatures.length)
   end
 
+  it 'merges a block signature that declares parameters with one that does not' do
+    plain_impl = Solargraph::SourceMap.load_string(%(
+      module Widgetbox
+        class << self
+          # @return [String]
+          def build(&block) = 'x'
+        end
+      end
+    ), 'widgetbox.rb')
+    parse_stub = Solargraph::SourceMap.load_string(%(
+      # @!parse
+      #   module Widgetbox
+      #     class << self
+      #       # @yieldparam config [String]
+      #       # @return [String]
+      #       def build(&block); end
+      #     end
+      #   end
+    ), 'annotations.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.catalog Solargraph::Bench.new(source_maps: [plain_impl, parse_stub])
+    method = api_map.get_method_stack('Widgetbox', 'build', scope: :class).first
+    expect(method.signatures.length).to eq(1)
+    expect(method.signatures.first.block.parameters.map(&:name)).to eq(['config'])
+  end
+
   it 'does not merge with changes in parameters' do
     # @todo Method pin parameters are pins now
     pin1 = described_class.new(name: 'bar', parameters: %w[one two])

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -154,6 +154,34 @@ describe Solargraph::Pin::Method do
     expect(method.signatures.first.block.parameters.map(&:name)).to eq(['config'])
   end
 
+  it 'merges a block signature with more declared parameters than one with fewer' do
+    fewer_params = Solargraph::SourceMap.load_string(%(
+      module Widgetbox
+        class << self
+          # @yieldparam a [String]
+          # @return [String]
+          def build(&block) = 'x'
+        end
+      end
+    ), 'widgetbox.rb')
+    more_params = Solargraph::SourceMap.load_string(%(
+      # @!parse
+      #   module Widgetbox
+      #     class << self
+      #       # @yieldparam a [String]
+      #       # @yieldparam b [Integer]
+      #       # @return [String]
+      #       def build(&block); end
+      #     end
+      #   end
+    ), 'annotations.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.catalog Solargraph::Bench.new(source_maps: [fewer_params, more_params])
+    method = api_map.get_method_stack('Widgetbox', 'build', scope: :class).first
+    expect(method.signatures.length).to eq(1)
+    expect(method.signatures.first.block.parameters.map(&:name)).to eq(%w[a b])
+  end
+
   it 'does not merge with changes in parameters' do
     # @todo Method pin parameters are pins now
     pin1 = described_class.new(name: 'bar', parameters: %w[one two])

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1918,9 +1918,8 @@ describe Solargraph::SourceMap::Clip do
   end
 
   it 'binds generics through a cross-file @!parse stub that adds @generic to an existing class' do
-    # The plain implementation (e.g., as it would be defined in a gem) is
-    # unaware of any generics. It's mapped first, simulating a gem's pins
-    # being loaded before the workspace's.
+    # plain_impl has no `@generic` tag or `@!parse` stub - as a gem's
+    # own source looks - and is mapped before the workspace's stub.
     plain_impl = Solargraph::SourceMap.load_string(%(
       module Widgetbox
         class Collection

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1918,9 +1918,9 @@ describe Solargraph::SourceMap::Clip do
   end
 
   it 'binds generics through a cross-file @!parse stub that adds @generic to an existing class' do
-    # plain_impl has no `@generic` tag or `@!parse` stub - as a gem's
-    # own source looks - and is mapped before the workspace's stub.
-    plain_impl = Solargraph::SourceMap.load_string(%(
+    # gem_source has no `@generic` tag or `@!parse` stub, and is mapped
+    # before the workspace's stub.
+    gem_source = Solargraph::SourceMap.load_string(%(
       module Widgetbox
         class Collection
           def self.make
@@ -1958,7 +1958,7 @@ describe Solargraph::SourceMap::Clip do
       Widgetbox::Collection.make.last.resource_subtype
     ), 'test.rb')
     api_map = Solargraph::ApiMap.new
-    api_map.catalog Solargraph::Bench.new(source_maps: [plain_impl, parse_stub, Solargraph::SourceMap.map(caller_source)])
+    api_map.catalog Solargraph::Bench.new(source_maps: [gem_source, parse_stub, Solargraph::SourceMap.map(caller_source)])
     clip = api_map.clip_at('test.rb', [1, 40])
     type = clip.infer
     expect(type.tag).to eq('String')

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1917,6 +1917,54 @@ describe Solargraph::SourceMap::Clip do
     expect(type.to_s).to eq('undefined')
   end
 
+  it 'binds generics through a cross-file @!parse stub that adds @generic to an existing class' do
+    # The plain implementation (e.g., as it would be defined in a gem) is
+    # unaware of any generics. It's mapped first, simulating a gem's pins
+    # being loaded before the workspace's.
+    plain_impl = Solargraph::SourceMap.load_string(%(
+      module Widgetbox
+        class Collection
+          def self.make
+            new
+          end
+
+          def last
+            nil
+          end
+        end
+
+        class Widget
+          # @return [String, nil]
+          def resource_subtype; end
+        end
+      end
+    ), 'widgetbox.rb')
+    # A `@!parse` stub in a separate file adds `@generic T` to the existing
+    # class and overrides the return types of its methods.
+    parse_stub = Solargraph::SourceMap.load_string(%(
+      # @!parse
+      #   module Widgetbox
+      #     # @generic T
+      #     class Collection
+      #       class << self
+      #         # @return [Widgetbox::Collection<Widgetbox::Widget>]
+      #         def make; end
+      #       end
+      #       # @return [generic<T>]
+      #       def last; end
+      #     end
+      #   end
+    ), 'annotations.rb')
+    caller_source = Solargraph::Source.load_string(%(
+      Widgetbox::Collection.make.last.resource_subtype
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.catalog Solargraph::Bench.new(source_maps: [plain_impl, parse_stub, Solargraph::SourceMap.map(caller_source)])
+    clip = api_map.clip_at('test.rb', [1, 40])
+    type = clip.infer
+    expect(type.tag).to eq('String')
+  end
+
   it 'uses simple return value of block to infer return value of Enumerable#map' do
     source = Solargraph::Source.load_string(%(
       a = ['a'].map { 123 }

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1964,6 +1964,48 @@ describe Solargraph::SourceMap::Clip do
     expect(type.tag).to eq('String')
   end
 
+  it 'yields the block parameter type declared by a cross-file @!parse stub' do
+    # The plain implementation only documents that it takes a block (no
+    # @yieldparam), simulating a gem's pins loading before a workspace
+    # @!parse stub that adds the block's parameter type.
+    plain_impl = Solargraph::SourceMap.load_string(%(
+      module Widgetbox
+        class Collection
+          # @return [String]
+          def name
+            'collection'
+          end
+        end
+
+        class << self
+          # @return [Widgetbox::Collection]
+          def build(&block)
+            Collection.new
+          end
+        end
+      end
+    ), 'widgetbox.rb')
+    parse_stub = Solargraph::SourceMap.load_string(%(
+      # @!parse
+      #   module Widgetbox
+      #     class << self
+      #       # @yieldparam config [Widgetbox::Collection]
+      #       # @return [Widgetbox::Collection]
+      #       def build(&block); end
+      #     end
+      #   end
+    ), 'annotations.rb')
+    caller_source = Solargraph::Source.load_string(%(
+      Widgetbox.build do |config|
+        config
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.catalog Solargraph::Bench.new(source_maps: [plain_impl, parse_stub, Solargraph::SourceMap.map(caller_source)])
+    clip = api_map.clip_at('test.rb', [2, 14])
+    expect(clip.infer.tag).to eq('Widgetbox::Collection')
+  end
+
   it 'uses simple return value of block to infer return value of Enumerable#map' do
     source = Solargraph::Source.load_string(%(
       a = ['a'].map { 123 }


### PR DESCRIPTION
Fixes https://github.com/castwide/solargraph/issues/1286

**Problem:**

A `@generic` tag that a `@!parse` stub adds to a class already defined elsewhere doesn't apply, so the type variable never binds and every call downstream of it stops resolving.

```ruby
# widgetbox.rb - the gem's own class, no generics
module Widgetbox
  class Collection
    def self.make; new; end
    def last; nil; end
  end

  class Widget
    # @return [String, nil]
    def resource_subtype; end
  end
end

# annotations.rb - a @!parse stub adds @generic T and the return types
# @!parse
#   module Widgetbox
#     # @generic T
#     class Collection
#       class << self
#         # @return [Widgetbox::Collection<Widgetbox::Widget>]
#         def make; end
#       end
#       # @return [generic<T>]
#       def last; end
#     end
#   end

# app.rb
# @return [String, nil]
def check
  Widgetbox::Collection.make.last.resource_subtype
end
```

```
$ solargraph typecheck --level strong app.rb
app.rb:2: #check return type could not be inferred
```

It happens whenever the plain definition is mapped first — a gem loading ahead of the workspace, or simply appearing earlier in the same file — so an annotation written this way is inert with nothing reported to say so.

**Solution:**

Choose the namespace pin that actually declares generics rather than whichever loaded first, and combine same-path method pins so a stub's `@return` tags survive alongside the gem's own definition.

---

**Problem:**

A workspace `@!parse` stub's block parameter type has no effect when the gem's own doc already declares a return type:

```ruby
module Widgetbox
  class << self
    # @return [String]
    def build(&block) = 'x'
  end
end

# @!parse
#   module Widgetbox
#     class << self
#       # @yieldparam config [String]
#       # @return [String]
#       def build(&block); end
#     end
#   end

Widgetbox.build { |config| config.upcase } # Unresolved call to upcase
```

The method pin itself carries only one of the two signatures, so hover and completion lose the same information inference does.

**Solution:**

`combine_signatures_by_type_arity` buckets signatures by `type_arity` before merging, and a block's declared-parameter count changes that bucket, so this adds a pass that merges block-informativeness-only differences first and makes `Callable#combine_blocks` prefer the more informative block instead of choosing arbitrarily; two related gaps stay open (a stub missing `@return` is discarded wholesale by `combine_signatures`, and `def self.build` paired with `class << self` never combines pins at all).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
