### PR TITLE
Fix @yieldparam type lost on multi-overload block-form methods

### DIFF
--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -148,12 +148,13 @@ module Solargraph
 
       # @param parameters [::Array<Parameter>]
       # @param return_type [ComplexType, nil]
+      # @param tag_docstring [YARD::Docstring] source of @yieldparam/@yieldreturn tags; pass an @overload tag's own docstring here
       # @return [Signature]
-      def generate_signature parameters, return_type
+      def generate_signature parameters, return_type, tag_docstring = docstring
         # @type [Pin::Signature, nil]
         block = nil
-        yieldparam_tags = docstring.tags(:yieldparam)
-        yieldreturn_tags = docstring.tags(:yieldreturn)
+        yieldparam_tags = tag_docstring.tags(:yieldparam)
+        yieldreturn_tags = tag_docstring.tags(:yieldreturn)
         generics = docstring.tags(:generic).map(&:name)
         needs_block_param_signature =
           parameters.last&.block? || !yieldreturn_tags.empty? || !yieldparam_tags.empty?
@@ -747,7 +748,9 @@ module Solargraph
         top_type = generate_complex_type
         result = []
         result.push generate_signature(parameters, top_type) if top_type.defined?
-        result.concat(overloads.map { |meth| generate_signature(meth.parameters, meth.return_type) }) unless overloads.empty?
+        # @param meth [Pin::Signature]
+        # @param tag [YARD::Tags::OverloadTag]
+        result.concat(overloads.zip(docstring.tags(:overload).select(&:parameters)).map { |meth, tag| generate_signature(meth.parameters, meth.return_type, tag.docstring) }) unless overloads.empty?
         result.push generate_signature(parameters, @return_type || ComplexType::UNDEFINED) if result.empty?
         result
       end

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -315,6 +315,32 @@ describe Solargraph::Pin::Method do
     expect(kwrestarg_overload.parameters.first.decl).to eq(:kwrestarg)
   end
 
+  it 'applies yieldparam tags from the matching overload only' do
+    pin = described_class.new(name: 'build', comments: %(
+@overload build
+  @return [String]
+@overload build
+  @yieldparam widget [String]
+  @return [void]
+    ))
+    expect(pin.signatures.length).to eq(2)
+    plain, block_form = pin.signatures
+    expect(plain.block).to be_nil
+    expect(block_form.block).not_to be_nil
+    expect(block_form.block.parameters.first.return_type.tag).to eq('String')
+  end
+
+  it 'does not leak a method-level yieldparam into an overload that declares no block' do
+    pin = described_class.new(name: 'foo', comments: %(
+@yieldparam bing [Integer]
+@overload foo(bar)
+  @param bar [Integer]
+  @return [String]
+    ))
+    expect(pin.signatures.length).to eq(1)
+    expect(pin.signatures.first.block).to be_nil
+  end
+
   it 'infers from nil return nodes' do
     source = Solargraph::Source.load_string(%(
       class Foo

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -219,6 +219,26 @@ describe Solargraph::TypeChecker do
                                                      'Unresolved call to upcase on String, nil'])
     end
 
+    it 'applies a yieldparam type declared on a block-form @overload' do
+      checker = type_checker(%(
+        # @overload build
+        #   @return [String]
+        # @overload build
+        #   @yieldparam widget [String]
+        #   @return [void]
+        def build
+          return 'hi' unless block_given?
+
+          yield 'hi'
+        end
+
+        build do |w|
+          w.upcase
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     it 'does not complain on array dereference' do
       checker = type_checker(%(
         # @param idx [Integer] an index


### PR DESCRIPTION
## Summary

Fixes https://github.com/castwide/solargraph/issues/1289.

`Pin::Method#generate_signature` always read `@yieldparam`/`@yieldreturn` tags from the method's own docstring, even when it was building the `Signature` for an `@overload` tag. Per YARD, `@overload` docstrings are self-contained, so when a method declared a block-form `@overload` alongside a second, plain `@overload`, the block-form overload's `@yieldparam` was silently dropped — the block-local variable resolved as untyped at the call site.

`generate_signature` now takes the docstring to read those tags from, and `#signatures` passes each overload tag's own docstring instead of the method's.

```ruby
# @overload build
#   @return [String]
# @overload build
#   @yieldparam widget [String]
#   @return [void]
def build
  return 'hi' unless block_given?
  yield 'hi'
end

build do |w|
  w.upcase # was: Unresolved call to upcase
end
```

## Test plan

- [x] `bundle exec rspec` (1443 examples, 0 failures)
- [x] `bundle exec rubocop` on changed files (clean)
- [x] Manually confirmed `solargraph typecheck --level strong` on the issue's repro now reports 0 problems
