### PR TITLE
Match trailing keyword arguments to keyword/kwrest parameters, not by position

### DIFF
--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -97,25 +97,12 @@ module Solargraph
             # @param ol [Pin::Signature]
             sorted_overloads.each do |ol|
               next unless ol.arity_matches?(arguments, with_block?)
-              match = true
 
+              positional_arguments, keyword_argument = split_keyword_argument(arguments, ol)
               atypes = []
-              arguments.each_with_index do |arg, idx|
-                param = ol.parameters[idx]
-                if param.nil?
-                  match = ol.parameters.any?(&:restarg?)
-                  break
-                end
-                arg_name_pin = Pin::ProxyType.anonymous(name_pin.context,
-                                                        closure: name_pin.closure,
-                                                        gates: name_pin.gates,
-                                                        source: :chain)
-                atype = atypes[idx] ||= arg.infer(api_map, arg_name_pin, locals)
-                unless param.compatible_arg?(atype, api_map) || param.restarg?
-                  match = false
-                  break
-                end
-              end
+              match = positional_arguments_match?(positional_arguments, ol, api_map, name_pin, locals, atypes)
+              match &&= keyword_argument_matches?(keyword_argument, ol, api_map, name_pin, locals) if match
+
               if match
                 if ol.block && with_block?
                   block_atypes = ol.block.parameters.map(&:return_type)
@@ -184,6 +171,65 @@ module Solargraph
               selfy == pin.return_type ? pin : pin.proxy(selfy)
             end
           end
+        end
+
+        # A trailing keyword-arguments hash doesn't line up positionally
+        # with the method's declared parameters, so it's split off to be
+        # matched separately against the keyword/kwrest parameters
+        # instead of the positional ones.
+        #
+        # @param arguments [::Array<Chain>]
+        # @param overload [Pin::Signature]
+        # @return [::Array(::Array<Chain>, Chain, nil)]
+        def split_keyword_argument arguments, overload
+          keyword_params = overload.parameters.select { |param| param.keyword? || param.kwrestarg? }
+          last_argument = arguments.last
+          if !keyword_params.empty? && last_argument.is_a?(Chain) && last_argument.links.last.is_a?(Chain::Hash)
+            [arguments[0..-2], last_argument]
+          else
+            [arguments, nil]
+          end
+        end
+
+        # @param positional_arguments [::Array<Chain>]
+        # @param overload [Pin::Signature]
+        # @param api_map [ApiMap]
+        # @param name_pin [Pin::Base]
+        # @param locals [::Array<Pin::LocalVariable>]
+        # @param atypes [::Array<ComplexType>] populated with the inferred type of each positional argument
+        # @return [Boolean]
+        def positional_arguments_match? positional_arguments, overload, api_map, name_pin, locals, atypes
+          positional_params = overload.parameters.reject { |param| param.keyword? || param.kwrestarg? }
+          positional_arguments.each_with_index do |arg, idx|
+            param = positional_params[idx]
+            return positional_params.any?(&:restarg?) if param.nil?
+
+            arg_name_pin = Pin::ProxyType.anonymous(name_pin.context,
+                                                    closure: name_pin.closure,
+                                                    gates: name_pin.gates,
+                                                    source: :chain)
+            atype = atypes[idx] ||= arg.infer(api_map, arg_name_pin, locals)
+            return false unless param.compatible_arg?(atype, api_map) || param.restarg?
+          end
+          true
+        end
+
+        # @param keyword_argument [Chain, nil]
+        # @param overload [Pin::Signature]
+        # @param api_map [ApiMap]
+        # @param name_pin [Pin::Base]
+        # @param locals [::Array<Pin::LocalVariable>]
+        # @return [Boolean]
+        def keyword_argument_matches? keyword_argument, overload, api_map, name_pin, locals
+          return true if keyword_argument.nil?
+
+          kw_arg_name_pin = Pin::ProxyType.anonymous(name_pin.context,
+                                                     closure: name_pin.closure,
+                                                     gates: name_pin.gates,
+                                                     source: :chain)
+          kw_atype = keyword_argument.infer(api_map, kw_arg_name_pin, locals)
+          keyword_params = overload.parameters.select { |param| param.keyword? || param.kwrestarg? }
+          keyword_params.any? { |param| param.compatible_arg?(kw_atype, api_map) }
         end
 
         # @param docstring [YARD::Docstring]

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -223,13 +223,28 @@ module Solargraph
         def keyword_argument_matches? keyword_argument, overload, api_map, name_pin, locals
           return true if keyword_argument.nil?
 
+          # @type [::Hash{::Symbol => Chain}]
+          kwargs = convert_hash(keyword_argument.node)
+          keyword_params = overload.parameters.select { |param| param.keyword? || param.kwrestarg? }
+          named_params = keyword_params.reject(&:kwrestarg?)
+          kwrestarg = keyword_params.find(&:kwrestarg?)
+
           kw_arg_name_pin = Pin::ProxyType.anonymous(name_pin.context,
                                                      closure: name_pin.closure,
                                                      gates: name_pin.gates,
                                                      source: :chain)
-          kw_atype = keyword_argument.infer(api_map, kw_arg_name_pin, locals)
-          keyword_params = overload.parameters.select { |param| param.keyword? || param.kwrestarg? }
-          keyword_params.any? { |param| param.compatible_arg?(kw_atype, api_map) }
+          kwargs.each_pair do |key, value_chain|
+            param = named_params.find { |p| p.name.to_sym == key }
+            if param.nil?
+              return false if kwrestarg.nil?
+              next
+            end
+            # @sg-ignore flow sensitive typing needs to infer Hash#each_pair block param types from a local @type tag
+            atype = value_chain.infer(api_map, kw_arg_name_pin, locals)
+            # @sg-ignore flow sensitive typing needs to infer Hash#each_pair block param types from a local @type tag
+            return false unless param.compatible_arg?(atype, api_map)
+          end
+          named_params.none? { |param| param.decl == :kwarg && !kwargs.key?(param.name.to_sym) }
         end
 
         # @param docstring [YARD::Docstring]

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -497,4 +497,71 @@ describe Solargraph::Source::Chain::Call do
     clip = api_map.clip_at('test.rb', [14, 14])
     expect(clip.infer.rooted_tags).to eq('::Set<::Foo::Bar::Symbol>')
   end
+
+  context 'with an RBS-declared generic block-form overload accepting a kwrest parameter' do
+    # create a temporary directory with the scope of the spec
+    around do |example|
+      require 'tmpdir'
+      Dir.mktmpdir('rspec-solargraph-') do |dir|
+        @temp_dir = dir
+        example.run
+      end
+    end
+
+    attr_reader :temp_dir
+
+    let(:rbs) do
+      <<~RBS
+        class Box
+          def self.start: (Integer val, ?String opt1, ?String opt2) -> Box
+                         | [T] (Integer val, ?String opt1, ?String opt2, **untyped opts) { (Integer v) -> T } -> T
+        end
+      RBS
+    end
+
+    let(:conversions) do
+      loader = RBS::EnvironmentLoader.new(core_root: nil, repository: RBS::Repository.new(no_stdlib: false))
+      loader.add(path: Pathname(temp_dir))
+      Solargraph::RbsMap::Conversions.new(loader: loader)
+    end
+
+    before do
+      File.write(File.join(temp_dir, 'box.rbs'), rbs)
+    end
+
+    # Simulates a gem/stdlib method (loaded via `convention_pins`, the
+    # same mechanism DocMap uses for a resolved `require`) being called
+    # with a keyword argument that should bind to the overload's kwrest
+    # parameter, not the next positional parameter.
+    #
+    # @param code [String]
+    # @return [Solargraph::ComplexType]
+    # @param [Object] position
+    def infer_at code, position
+      api_map = Solargraph::ApiMap.new
+      source = Solargraph::Source.load_string(code, 'test.rb')
+      source_map = Solargraph::SourceMap.map(source)
+      source_map.send(:convention_pins=, conversions.pins)
+      api_map.catalog(Solargraph::Bench.new(source_maps: [source_map], live_map: source_map))
+      api_map.clip_at('test.rb', position).infer
+    end
+
+    it 'matches a trailing keyword argument to a kwrest parameter instead of the next positional parameter' do
+      type = infer_at(%(
+        Box.start(1, "x", foo: true) do |v|
+          v
+        end
+      ), [2, 10])
+      expect(type.rooted_tags).to eq('::Integer')
+    end
+
+    it 'still resolves the block-form overload when no keyword argument is passed' do
+      type = infer_at(%(
+        Box.start(1, "x") do |v|
+          v
+        end
+      ), [2, 10])
+      expect(type.rooted_tags).to eq('::Integer')
+    end
+  end
 end

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -564,4 +564,55 @@ describe Solargraph::Source::Chain::Call do
       expect(type.rooted_tags).to eq('::Integer')
     end
   end
+
+  context 'with overloads that differ only in which keyword(s) they accept' do
+    around do |example|
+      require 'tmpdir'
+      Dir.mktmpdir('rspec-solargraph-') do |dir|
+        @temp_dir = dir
+        example.run
+      end
+    end
+
+    attr_reader :temp_dir
+
+    let(:rbs) do
+      <<~RBS
+        class Box
+          def self.add: (path: String) -> Integer
+                       | (library: String, ?resolve_dependencies: untyped) -> String
+        end
+      RBS
+    end
+
+    let(:conversions) do
+      loader = RBS::EnvironmentLoader.new(core_root: nil, repository: RBS::Repository.new(no_stdlib: false))
+      loader.add(path: Pathname(temp_dir))
+      Solargraph::RbsMap::Conversions.new(loader: loader)
+    end
+
+    before do
+      File.write(File.join(temp_dir, 'box.rbs'), rbs)
+    end
+
+    # @param code [String]
+    # @param position [Array(Integer, Integer)]
+    # @return [Solargraph::ComplexType]
+    def infer_at code, position
+      api_map = Solargraph::ApiMap.new
+      source = Solargraph::Source.load_string(code, 'test.rb')
+      source_map = Solargraph::SourceMap.map(source)
+      source_map.send(:convention_pins=, conversions.pins)
+      api_map.catalog(Solargraph::Bench.new(source_maps: [source_map], live_map: source_map))
+      api_map.clip_at('test.rb', position).infer
+    end
+
+    it 'matches a call by the keyword it actually passes, not an earlier overload with an untyped keyword param' do
+      code = %(
+        Box.add(path: "x")
+      )
+      type = infer_at(code, [1, code.lines[1].chomp.length])
+      expect(type.rooted_tags).to eq('::Integer')
+    end
+  end
 end

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -1,5 +1,23 @@
 # frozen_string_literal: true
 
+# Contributes a fixed set of pins to every source map, standing in for
+# the pins a resolved `require` brings in from a gem or the stdlib.
+# Specs assign #pins, register it, and unregister it again afterwards.
+class RbsPinConvention < Solargraph::Convention::Base
+  class << self
+    # @return [Array<Solargraph::Pin::Base>]
+    attr_accessor :pins
+  end
+
+  self.pins = []
+
+  # @param _source_map [Solargraph::SourceMap]
+  # @return [Solargraph::Environ]
+  def local _source_map
+    Solargraph::Environ.new(pins: self.class.pins)
+  end
+end
+
 describe Solargraph::Source::Chain::Call do
   it 'recognizes core methods that return subtypes' do
     api_map = Solargraph::ApiMap.new
@@ -498,7 +516,10 @@ describe Solargraph::Source::Chain::Call do
     expect(clip.infer.rooted_tags).to eq('::Set<::Foo::Bar::Symbol>')
   end
 
-  context 'with an RBS-declared generic block-form overload accepting a kwrest parameter' do
+  # Serves an RBS file's pins through the public Convention extension
+  # point, standing in for the pins a resolved `require` contributes via
+  # DocMap, so these specs exercise calls into a gem/stdlib method.
+  shared_context 'with a Box declared in RBS' do
     # create a temporary directory with the scope of the spec
     around do |example|
       require 'tmpdir'
@@ -510,15 +531,6 @@ describe Solargraph::Source::Chain::Call do
 
     attr_reader :temp_dir
 
-    let(:rbs) do
-      <<~RBS
-        class Box
-          def self.start: (Integer val, ?String opt1, ?String opt2) -> Box
-                         | [T] (Integer val, ?String opt1, ?String opt2, **untyped opts) { (Integer v) -> T } -> T
-        end
-      RBS
-    end
-
     let(:conversions) do
       loader = RBS::EnvironmentLoader.new(core_root: nil, repository: RBS::Repository.new(no_stdlib: false))
       loader.add(path: Pathname(temp_dir))
@@ -527,23 +539,37 @@ describe Solargraph::Source::Chain::Call do
 
     before do
       File.write(File.join(temp_dir, 'box.rbs'), rbs)
+      RbsPinConvention.pins = conversions.pins
+      Solargraph::Convention.register RbsPinConvention
     end
 
-    # Simulates a gem/stdlib method (loaded via `convention_pins`, the
-    # same mechanism DocMap uses for a resolved `require`) being called
-    # with a keyword argument that should bind to the overload's kwrest
-    # parameter, not the next positional parameter.
-    #
+    after do
+      Solargraph::Convention.unregister RbsPinConvention
+      RbsPinConvention.pins = []
+    end
+
     # @param code [String]
+    # @param position [Array(Integer, Integer)]
     # @return [Solargraph::ComplexType]
-    # @param [Object] position
     def infer_at code, position
       api_map = Solargraph::ApiMap.new
       source = Solargraph::Source.load_string(code, 'test.rb')
       source_map = Solargraph::SourceMap.map(source)
-      source_map.send(:convention_pins=, conversions.pins)
       api_map.catalog(Solargraph::Bench.new(source_maps: [source_map], live_map: source_map))
       api_map.clip_at('test.rb', position).infer
+    end
+  end
+
+  context 'with an RBS-declared generic block-form overload accepting a kwrest parameter' do
+    include_context 'with a Box declared in RBS'
+
+    let(:rbs) do
+      <<~RBS
+        class Box
+          def self.start: (Integer val, ?String opt1, ?String opt2) -> Box
+                         | [T] (Integer val, ?String opt1, ?String opt2, **untyped opts) { (Integer v) -> T } -> T
+        end
+      RBS
     end
 
     it 'matches a trailing keyword argument to a kwrest parameter instead of the next positional parameter' do
@@ -566,15 +592,7 @@ describe Solargraph::Source::Chain::Call do
   end
 
   context 'with overloads that differ only in which keyword(s) they accept' do
-    around do |example|
-      require 'tmpdir'
-      Dir.mktmpdir('rspec-solargraph-') do |dir|
-        @temp_dir = dir
-        example.run
-      end
-    end
-
-    attr_reader :temp_dir
+    include_context 'with a Box declared in RBS'
 
     let(:rbs) do
       <<~RBS
@@ -583,28 +601,6 @@ describe Solargraph::Source::Chain::Call do
                        | (library: String, ?resolve_dependencies: untyped) -> String
         end
       RBS
-    end
-
-    let(:conversions) do
-      loader = RBS::EnvironmentLoader.new(core_root: nil, repository: RBS::Repository.new(no_stdlib: false))
-      loader.add(path: Pathname(temp_dir))
-      Solargraph::RbsMap::Conversions.new(loader: loader)
-    end
-
-    before do
-      File.write(File.join(temp_dir, 'box.rbs'), rbs)
-    end
-
-    # @param code [String]
-    # @param position [Array(Integer, Integer)]
-    # @return [Solargraph::ComplexType]
-    def infer_at code, position
-      api_map = Solargraph::ApiMap.new
-      source = Solargraph::Source.load_string(code, 'test.rb')
-      source_map = Solargraph::SourceMap.map(source)
-      source_map.send(:convention_pins=, conversions.pins)
-      api_map.catalog(Solargraph::Bench.new(source_maps: [source_map], live_map: source_map))
-      api_map.clip_at('test.rb', position).infer
     end
 
     it 'matches a call by the keyword it actually passes, not an earlier overload with an untyped keyword param' do


### PR DESCRIPTION
## Summary

`Call#inferred_pins` matched call-site arguments to a signature's parameters purely by array index. A trailing keyword-arguments hash (e.g. `use_ssl: true`) is just another element in that array, so it was checked against whatever positional parameter happened to sit at that index instead of the method's keyword or kwrest parameter. The type mismatch rejected the whole overload, so a generic block-form overload lost its block-param typing whenever the call also passed a keyword argument.

Found while following up on [#1290](https://github.com/castwide/solargraph/pull/1290#issuecomment-5272957964), which reported this against `Net::HTTP.start`, an RBS-declared generic block-form overload:

```ruby
require 'net/http'

Net::HTTP.start('example.com', use_ssl: true) do |http|
  http.request(Net::HTTP::Get.new('/'))
end
```

```
$ bundle exec solargraph typecheck --level strong repro.rb
repro.rb:4: Unresolved call to request
```

Dropping `use_ssl: true` resolves `http` correctly, matching the original report.

Confirmed this is independent of #1290/#1289: it reproduces on `master` before that PR's commit, and with a plain YARD `**kwrest` method that has no RBS involvement at all — the gap is in call-site argument matching (`Call#inferred_pins`, `lib/solargraph/source/chain/call.rb`), not in RBS translation.

## Fix

Split the trailing keyword-arguments hash out of the positional argument list and match it against the signature's `keyword?`/`kwrestarg?` parameters instead of by position.

## Test plan

- [x] Added `spec/source/chain/call_spec.rb` cases using an inline RBS signature (`Box.start`) shaped like `Net::HTTP.start` (multiple optional positional params before a generic block-form overload with `**kwrest`), covering: kwarg matches the kwrest param, no-kwarg baseline still works.
- [x] `bundle exec rspec` — 1626 examples, 0 failures
- [x] `bundle exec rubocop` on changed files — no new offenses
- [x] `bundle exec solargraph typecheck --level strong` on changed files — 0 problems
