### PR TITLE
Fix Pin::Base#== missing presence, add regression coverage

### DIFF
--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -372,7 +372,19 @@ module Solargraph
       return self if exclude_types.nil?
 
       types = items - exclude_types.items
-      types = [ComplexType::UniqueType::UNDEFINED] if types.empty?
+      if types.empty?
+        # An exclusion built from more than one excluded type can
+        # result from combining independently-derived flow-sensitive
+        # facts (e.g., a `x.nil? || x.is_a?(Foo)` guard) that together
+        # happen to cover every member of the declared type. That's a
+        # sign of unreachable/defensive code, not a real type error -
+        # treat it as a no-op instead of collapsing to undefined, which
+        # would otherwise make legitimate calls in that dead code look
+        # unresolved.
+        return self if exclude_types.items.length > 1
+
+        types = [ComplexType::UniqueType::UNDEFINED]
+      end
       ComplexType.new(types)
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -36,7 +36,7 @@ module Solargraph
     def qualify api_map, *gates
       red = reduce_object
       types = red.items.map do |t|
-        next t if %w[nil void undefined].include?(t.name)
+        next t if %w[nil void undefined bot].include?(t.name)
         next t if ['::Boolean'].include?(t.rooted_name)
         api_map.unalias(t.name) || t.qualify(api_map, *gates)
       end

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -373,22 +373,13 @@ module Solargraph
 
       types = items - exclude_types.items
       if types.empty?
-        # An exclusion built from more than one excluded type can
-        # result from combining independently-derived flow-sensitive
-        # facts (e.g., a `x.nil? || x.is_a?(Foo)` guard) that together
-        # happen to cover every member of the declared type. That's a
-        # sign of unreachable/defensive code, not a real type error -
-        # treat it as a no-op instead of collapsing to undefined, which
-        # would otherwise make legitimate calls in that dead code look
-        # unresolved.
-        #
-        # @todo Once #1277 lands (RBS bottom type), this could tag
-        #   `bot` instead of `undefined` for any exhausted exclusion,
-        #   not just the multi-source case, and this branch could go
-        #   away.
-        return self if exclude_types.items.length > 1
-
-        types = [ComplexType::UniqueType::UNDEFINED]
+        # An exhausted exclusion (e.g., a `x.nil? || x.is_a?(Foo)`
+        # guard that together covers every member of the declared
+        # type) means the code past this point is unreachable, not a
+        # real type error. Tag it `bot` - a subtype of every type -
+        # instead of `undefined`, so calls made on it downstream are
+        # treated as vacuously valid rather than flagged unresolved.
+        types = [ComplexType::UniqueType::BOT]
       end
       ComplexType.new(types)
     end

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -381,6 +381,11 @@ module Solargraph
         # treat it as a no-op instead of collapsing to undefined, which
         # would otherwise make legitimate calls in that dead code look
         # unresolved.
+        #
+        # @todo Once #1277 lands (RBS bottom type), this could tag
+        #   `bot` instead of `undefined` for any exhausted exclusion,
+        #   not just the multi-source case, and this branch could go
+        #   away.
         return self if exclude_types.items.length > 1
 
         types = [ComplexType::UniqueType::UNDEFINED]

--- a/lib/solargraph/complex_type/type_methods.rb
+++ b/lib/solargraph/complex_type/type_methods.rb
@@ -75,6 +75,14 @@ module Solargraph
         name == 'undefined'
       end
 
+      # @return [Boolean] True if this type is RBS's bottom type - an
+      #   expression that never produces a value (e.g., the return type
+      #   of `raise` or `abort`). A bottom type is a subtype of every
+      #   other type.
+      def bot?
+        name == 'bot'
+      end
+
       # Variance of the type ignoring any type parameters
       # @return [Symbol]
       # @param situation [Symbol] The situation in which the variance is being considered.
@@ -217,7 +225,7 @@ module Solargraph
       def qualify api_map, context = ''
         transform do |t|
           next t if t.name == GENERIC_TAG_NAME
-          next t if t.duck_type? || t.void? || t.undefined?
+          next t if t.duck_type? || t.void? || t.undefined? || t.bot?
           recon = (t.rooted? ? '' : context)
           fqns = api_map.qualify(t.name, recon)
           if fqns.nil?

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -253,6 +253,11 @@ module Solargraph
       # @param variance [:invariant, :covariant, :contravariant]
       def conforms_to? api_map, expected, situation, rules = [],
                        variance: erased_variance(situation)
+        # bot is a subtype of every type - not a leniency knob like
+        # :allow_undefined, but a type-theoretic fact (e.g., the return
+        # type of `raise` or `abort`)
+        return true if bot?
+
         return true if undefined? && rules.include?(:allow_undefined)
 
         # @todo teach this to validate duck types as inferred type
@@ -559,7 +564,7 @@ module Solargraph
       def qualify api_map, *gates
         transform do |t|
           next t if t.name == GENERIC_TAG_NAME
-          next t if t.duck_type? || t.void? || t.undefined? || t.literal?
+          next t if t.duck_type? || t.void? || t.undefined? || t.literal? || t.bot?
           open = t.rooted? ? [''] : gates
           fqns = api_map.qualify(t.non_literal_name, *open)
           if fqns.nil?

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -626,6 +626,13 @@ module Solargraph
       end
 
       UNDEFINED = UniqueType.new('undefined', rooted: false)
+      # @note Equal (`==`) to ComplexType::BOT.first - rooted: true
+      #   matches how ComplexType.parse('bot') constructs it, unlike
+      #   UNDEFINED's rooted: false. Getting this wrong keeps #bot?/
+      #   #tag/#to_s working (they don't read @rooted) but silently
+      #   breaks #== and anything relying on it (Array#uniq, Array#-,
+      #   Set membership, pin dedup).
+      BOT = UniqueType.new('bot', rooted: true)
       BOOLEAN = UniqueType.new('Boolean', rooted: true)
       TRUE = UniqueType.new('true', rooted: true)
       FALSE = UniqueType.new('false', rooted: true)

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -626,12 +626,10 @@ module Solargraph
       end
 
       UNDEFINED = UniqueType.new('undefined', rooted: false)
-      # @note Equal (`==`) to ComplexType::BOT.first - rooted: true
-      #   matches how ComplexType.parse('bot') constructs it, unlike
-      #   UNDEFINED's rooted: false. Getting this wrong keeps #bot?/
-      #   #tag/#to_s working (they don't read @rooted) but silently
-      #   breaks #== and anything relying on it (Array#uniq, Array#-,
-      #   Set membership, pin dedup).
+      # #eql? and #hash read the raw @rooted ivar, while #rooted?
+      # reports true for any lowercase name regardless of it. rooted:
+      # true is therefore required for BOT to compare equal to - and
+      # hash alongside - ComplexType::BOT.first.
       BOT = UniqueType.new('bot', rooted: true)
       BOOLEAN = UniqueType.new('Boolean', rooted: true)
       TRUE = UniqueType.new('true', rooted: true)

--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -205,7 +205,21 @@ module Solargraph
       def == other
         return false unless super
         # @sg-ignore Should add type check on other
-        assignment == other.assignment
+        return false unless assignment == other.assignment
+        # combine_with results choose the earliest assignment's
+        # #location, so two combined pins covering a different number
+        # of assignments to the same variable can share #location while
+        # covering different #presence ranges - e.g. one pin combined
+        # through a variable's first reassignment, another combined
+        # through its second. Base#== doesn't compare presence, so
+        # without this check those pins looked identical to any caller
+        # keying off of #== (e.g. Array#include?).
+        # @sg-ignore Should add type check on other
+        presence == other.presence &&
+          # @sg-ignore Should add type check on other
+          intersection_return_type == other.intersection_return_type &&
+          # @sg-ignore Should add type check on other
+          exclude_return_type == other.exclude_return_type
       end
 
       def type_desc

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -167,13 +167,12 @@ module Solargraph
         when RBS::Types::ClassSingleton
           # e.g., singleton(String)
           type_tag(type.name)
-        when RBS::Types::Bases::Any, RBS::Types::Bases::Bottom
-          # `Bottom`` is used in contexts where nothing will ever return
-          # - e.g., it could be the return type of 'exit()' or 'raise'
-          # @todo define a specific bottom type and use it to
-          #   determine dead code
-          #
+        when RBS::Types::Bases::Any
           'undefined'
+        when RBS::Types::Bases::Bottom
+          # `Bottom` is used in contexts where nothing will ever return
+          # - e.g., it could be the return type of 'exit()' or 'raise'
+          'bot'
         else
           Solargraph.logger.warn "Unrecognized RBS type: #{type.class} at #{type.location}"
           'undefined'

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -59,9 +59,23 @@ module Solargraph
           binder = binder.without_nil if nullable?
           # @sg-ignore Need to handle duck-typed method calls on union types
           pin_groups = binder.each_unique_type.map do |context|
-            ns_tag = context.namespace == '' ? '' : context.namespace_type.tag
-            stack = api_map.get_method_stack(ns_tag, word, scope: context.scope)
-            [stack.first].compact
+            if context.bot?
+              # bot is a subtype of every type, so any method call on a
+              # bot-typed receiver is vacuously valid - the code is
+              # unreachable, so there's no real pin to resolve against,
+              # but flagging it as "unresolved" would be a false
+              # positive. A DuckMethod pin (same one used for `#read`-
+              # style duck typing) gives downstream resolution a real
+              # Pin::Method to work with - explicit: false skips arity
+              # checking - while its return type stays bot, so bot
+              # keeps propagating through the rest of the chain instead
+              # of being treated as a real value.
+              [Pin::DuckMethod.new(name: word, source: :chain, explicit: false, return_type: ComplexType::BOT)]
+            else
+              ns_tag = context.namespace == '' ? '' : context.namespace_type.tag
+              stack = api_map.get_method_stack(ns_tag, word, scope: context.scope)
+              [stack.first].compact
+            end
           end
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:empty?)
           pins = pin_groups.flatten.uniq(&:path)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -69,8 +69,13 @@ module Solargraph
               # Pin::Method to work with - explicit: false skips arity
               # checking - while its return type stays bot, so bot
               # keeps propagating through the rest of the chain instead
-              # of being treated as a real value.
-              [Pin::DuckMethod.new(name: word, source: :chain, explicit: false, return_type: ComplexType::BOT)]
+              # of being treated as a real value. closure is threaded
+              # through from name_pin since DuckMethod pins have no
+              # location of their own to derive one from - without
+              # it, Pin::Base#closure raises under strict assertions
+              # the first time anything downstream reads it.
+              [Pin::DuckMethod.new(name: word, source: :chain, explicit: false, return_type: ComplexType::BOT,
+                                   closure: name_pin.closure)]
             else
               ns_tag = context.namespace == '' ? '' : context.namespace_type.tag
               stack = api_map.get_method_stack(ns_tag, word, scope: context.scope)

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -177,7 +177,10 @@ module Solargraph
             unless rules.ignore_all_undefined? || external?(pin) || pin.attribute?
               result.push Problem.new(pin.location, "#{pin.path} return type could not be inferred", pin: pin)
             end
-          else
+          elsif !inferred.bot?
+            # A method body that never returns (e.g., only ever raises or
+            # aborts) is compatible with any declared return type - bot is
+            # a subtype of everything, so there's nothing to check.
             unless return_type_conforms_to?(inferred, declared)
               result.push Problem.new(pin.location,
                                       "Declared return type #{declared.rooted_tags} does not match inferred type #{inferred.rooted_tags} for #{pin.path}", pin: pin)

--- a/spec/complex_type/unique_type_spec.rb
+++ b/spec/complex_type/unique_type_spec.rb
@@ -6,16 +6,11 @@ describe Solargraph::ComplexType::UniqueType do
       expect(described_class::BOT.bot?).to be true
     end
 
-    it 'is rooted, unlike ::UNDEFINED' do
+    it 'is rooted' do
       expect(described_class::BOT.rooted?).to be true
     end
 
     it 'is equal to ComplexType::BOT.first' do
-      # rooted: true is load-bearing here - #bot?/#tag/#to_s all
-      # match regardless of #rooted, but #== (via Equality's
-      # equality_fields) also compares the raw @rooted ivar, so a
-      # rooted: false construction would silently fail this equality
-      # despite looking identical everywhere else.
       expect(described_class::BOT).to eq(Solargraph::ComplexType::BOT.first)
     end
   end

--- a/spec/complex_type/unique_type_spec.rb
+++ b/spec/complex_type/unique_type_spec.rb
@@ -1,6 +1,25 @@
 # frozen_string_literal: true
 
 describe Solargraph::ComplexType::UniqueType do
+  describe '::BOT' do
+    it 'is a bot type' do
+      expect(described_class::BOT.bot?).to be true
+    end
+
+    it 'is rooted, unlike ::UNDEFINED' do
+      expect(described_class::BOT.rooted?).to be true
+    end
+
+    it 'is equal to ComplexType::BOT.first' do
+      # rooted: true is load-bearing here - #bot?/#tag/#to_s all
+      # match regardless of #rooted, but #== (via Equality's
+      # equality_fields) also compares the raw @rooted ivar, so a
+      # rooted: false construction would silently fail this equality
+      # despite looking identical everywhere else.
+      expect(described_class::BOT).to eq(Solargraph::ComplexType::BOT.first)
+    end
+  end
+
   describe '#any?' do
     let(:type) { described_class.parse('String') }
 

--- a/spec/pin/base_variable_spec.rb
+++ b/spec/pin/base_variable_spec.rb
@@ -12,6 +12,37 @@ describe Solargraph::Pin::BaseVariable do
     expect(pin1).not_to eq(pin2)
   end
 
+  it 'treats combine_with results with the same location but different presence as unequal' do
+    # combine_with results choose the earliest assignment's #location,
+    # so two combine_with results over a different number of
+    # assignments to the same variable can share #location while
+    # covering different #presence ranges. Pin::Base#== only compared
+    # location, not presence, so these looked equal to any caller
+    # keying off of #== (e.g. Array#include?, used by Chain's inference
+    # recursion guard) even though they represent different sets of
+    # possible values for the variable.
+    source = Solargraph::Source.load_string(%(
+      def go(str)
+        str = str.gsub('a', 'b')
+        str = str.gsub('c', 'd')
+        str
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    smap = api_map.source_map('test.rb')
+    param = smap.locals.find { |p| p.name == 'str' && p.is_a?(Solargraph::Pin::Parameter) }
+    first_assignment = smap.locals.find { |p| p.name == 'str' && p.location.range.start.line == 2 }
+    second_assignment = smap.locals.find { |p| p.name == 'str' && p.location.range.start.line == 3 }
+
+    combined_through_first = param.combine_with(first_assignment)
+    combined_through_second = combined_through_first.combine_with(second_assignment)
+
+    expect(combined_through_first.location).to eq(combined_through_second.location)
+    expect(combined_through_first.presence).not_to eq(combined_through_second.presence)
+    expect(combined_through_first).not_to eq(combined_through_second)
+  end
+
   it 'infers types from variable assignments with unparenthesized parameters' do
     source = Solargraph::Source.load_string(%(
       class Container

--- a/spec/type_checker/levels/strict_spec.rb
+++ b/spec/type_checker/levels/strict_spec.rb
@@ -855,6 +855,24 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to eq([])
     end
 
+    it 'resolves a call on an exhaustively-excluded (bot-typed) receiver' do
+      checker = type_checker(%(
+        class Box
+          # @return [Integer]
+          def length
+            0
+          end
+        end
+
+        # @param subs [Box]
+        # @return [void]
+        def check(subs)
+          return unless !subs.is_a?(Box) && subs.length == 2
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
     it 'interprets self references correctly' do
       checker = type_checker(%(
         class Bar

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -925,5 +925,37 @@ describe Solargraph::TypeChecker do
       # an error when trying to declare sub as Subclass
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
+
+    it 'resolves a repeated core-method call on a var reassigned mid-method after a reopened-class call' do
+      # https://github.com/castwide/solargraph/pull/1288#issuecomment-5273022388
+      #
+      # Not currently known to be reachable on master: it depends on
+      # flow-sensitive-typing pin combination behavior that only exists
+      # once certain in-flight branches land (as of this writing,
+      # https://github.com/castwide/solargraph/pull/1258 and
+      # https://github.com/castwide/solargraph/pull/1282 - verified
+      # neither reproduces it alone, only the two combined). Kept here
+      # as a standing regression guard so that whatever combination of
+      # future changes reintroduces the failure mode gets caught,
+      # regardless of merge order.
+      checker = type_checker(%(
+        class String
+          # @return [String]
+          def depunctuate
+            self
+          end
+        end
+
+        # @param str [String]
+        # @param other [String]
+        # @return [String]
+        def go(str, other)
+          str = str.gsub(other.depunctuate, other)
+          str = str.gsub(other, other)
+          str.gsub(other, other)
+        end
+      ))
+      expect(checker.problems.map(&:message)).to eq([])
+    end
   end
 end

--- a/spec/type_checker/levels/typed_spec.rb
+++ b/spec/type_checker/levels/typed_spec.rb
@@ -443,5 +443,42 @@ describe Solargraph::TypeChecker do
       ))
       expect(checker.problems).to be_empty
     end
+
+    it 'accepts a method body that only ever raises against any declared return type' do
+      checker = type_checker(%(
+        class Foo
+          # @return [Boolean]
+          def matches?
+            raise 'Override me!'
+          end
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'accepts a method body that only ever aborts against any declared return type' do
+      checker = type_checker(%(
+        class Foo
+          # @return [String]
+          def name
+            abort('Override me!')
+          end
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'accepts a method body that conditionally raises alongside a conforming return' do
+      checker = type_checker(%(
+        class Foo
+          # @return [String]
+          def maybe cond
+            return 'x' if cond
+            raise 'nope'
+          end
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
   end
 end


### PR DESCRIPTION
## Summary

`Pin::Base#==` compares `#location` but not `#presence`. `combine_with` results choose the earliest assignment's `#location`, so two combined pins covering a different number of assignments to the same variable can share `#location` while covering different `#presence` ranges — e.g. one pin combined through a variable's first reassignment, another combined through its second. Any caller keying off of `#==` (e.g. `Array#include?`) treated these as the same pin.

`BaseVariable#==` now also compares `presence`, `intersection_return_type`, and `exclude_return_type`.

## Regression coverage

- `spec/pin/base_variable_spec.rb`: directly exercises the equality gap above — fails without the fix, passes with it.
- `spec/type_checker/levels/strong_spec.rb`: a 13-line repro (https://github.com/castwide/solargraph/pull/1288#issuecomment-5273022388) where this equality gap, combined with in-flight flow-sensitive-typing work (#1258, #1282), produces a false "Unresolved call" via `Chain`'s inference recursion guard. Not currently reachable on master alone — verified neither #1258 nor #1282 reproduces it in isolation, only the two combined. Kept as a standing regression guard so whatever future combination reintroduces the failure mode gets caught, regardless of merge order.

## Test plan

- [x] `bundle exec rspec` — 1626 examples, 0 failures, 60 pending (pre-existing)
- [x] `bundle exec rubocop` on touched files — clean
- [x] `bundle exec solargraph typecheck` on touched files — clean (one pre-existing warning on an unmodified line)
