### PR TITLE
Fix duck_types_match? to check the inferred type's own duck interface

### DIFF
--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -227,7 +227,7 @@ module Solargraph
       expected = expected.downcast_to_literal_if_possible
       inferred = downcast_to_literal_if_possible
 
-      return duck_types_match?(api_map, expected, inferred) if expected.duck_type?
+      return duck_types_match?(api_map, expected, inferred, rules) if expected.duck_type?
 
       if rules.include? :allow_any_match
         inferred.any? do |inf|
@@ -245,17 +245,30 @@ module Solargraph
     # @param api_map [ApiMap]
     # @param expected [ComplexType, UniqueType]
     # @param inferred [ComplexType, UniqueType]
+    # @param rules [Array<Symbol>]
     # @return [Boolean]
-    def duck_types_match? api_map, expected, inferred
+    def duck_types_match? api_map, expected, inferred, rules = []
       raise ArgumentError, 'Expected type must be duck type' unless expected.duck_type?
+      allow_any_match = rules.include?(:allow_any_match)
       expected.each do |exp|
         next unless exp.duck_type?
-        quack = exp.to_s[1..]
-        # @sg-ignore Need to add nil check here
-        return false if api_map.get_method_stack(inferred.namespace, quack, scope: inferred.scope).empty?
+        quack = exp.to_s[1..] || ''
+        matched = allow_any_match ? inferred.any? { |inf| duck_type_provides?(api_map, inf, quack) } : inferred.all? { |inf| duck_type_provides?(api_map, inf, quack) }
+        return false unless matched
       end
       true
     end
+
+    # @param api_map [ApiMap]
+    # @param inf [UniqueType]
+    # @param quack [String]
+    # @return [Boolean]
+    def duck_type_provides? api_map, inf, quack
+      return true if inf.duck_type? && inf.to_s[1..] == quack
+
+      !api_map.get_method_stack(inf.namespace, quack, scope: inf.scope).empty?
+    end
+    private :duck_type_provides?
 
     # @return [String]
     def rooted_tags

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -743,5 +743,26 @@ describe 'YARD type specifier list parsing' do
       atype = Solargraph::ComplexType.parse(':foo')
       expect(atype.conforms_to?(api_map, ptype, :method_call)).to be(true)
     end
+
+    it 'recognizes a duck type conforms with an identical duck type' do
+      api_map = Solargraph::ApiMap.new
+      ptype = Solargraph::ComplexType.parse('#foo')
+      atype = Solargraph::ComplexType.parse('#foo')
+      expect(atype.conforms_to?(api_map, ptype, :method_call)).to be(true)
+    end
+
+    it 'recognizes a duck type does not conform with a different duck type' do
+      api_map = Solargraph::ApiMap.new
+      ptype = Solargraph::ComplexType.parse('#bar')
+      atype = Solargraph::ComplexType.parse('#foo')
+      expect(atype.conforms_to?(api_map, ptype, :method_call)).to be(false)
+    end
+
+    it 'recognizes a duck type conforms to a duck type method it inherits from Object' do
+      api_map = Solargraph::ApiMap.new
+      ptype = Solargraph::ComplexType.parse('#to_s')
+      atype = Solargraph::ComplexType.parse('#foo')
+      expect(atype.conforms_to?(api_map, ptype, :method_call)).to be(true)
+    end
   end
 end


### PR DESCRIPTION
## Summary

`ComplexType#duck_types_match?` checked `api_map.get_method_stack(inferred.namespace, quack, ...)`. `inferred.namespace` always returns `Object` for a duck type, so a duck-typed argument (e.g. `#foo`) could never satisfy a duck-typed parameter declaring the same interface — it was structurally impossible to pass.

Now `duck_type_provides?` first checks the inferred type's own declared duck interface, falling back to `Object`'s method table (the prior behavior) when the quacked method names don't match — so `#foo` satisfying `#foo`, and `#foo` still satisfying built-ins like `#to_s`, both work.

Also honors `:allow_any_match` (any? vs all?) when `inferred` is a union of types, consistent with the non-duck-type branch of `conforms_to?`.

Fixes #1294

## Test plan

- [x] `bundle exec rspec spec/complex_type_spec.rb spec/type_checker_spec.rb` — added specs for duck-to-duck match, mismatch, and duck-to-Object-method match
- [x] `bundle exec rspec` (full suite) — 1627 examples, 0 failures
- [x] `bundle exec rubocop lib/solargraph/complex_type.rb spec/complex_type_spec.rb` — no new offenses
- [x] `bundle exec solargraph typecheck --level strong lib/solargraph/complex_type.rb` — no new problems
- [x] Manually reproduced the issue's minimal repro before/after the fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01SyEXE8b5fersjWh41DKZZK