### PR TITLE
Resolve generic type variables against union @param types

### DIFF
--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -50,9 +50,10 @@ module Solargraph
     def resolve_generics_from_context generics_to_resolve, context_type, resolved_generic_values: {}
       return self unless generic?
 
-      ComplexType.new(@items.map do |i|
-        i.resolve_generics_from_context(generics_to_resolve, generic_item_context_type(i, context_type),
-                                        resolved_generic_values: resolved_generic_values)
+      ComplexType.new(@items.map do |unique_type|
+        unique_type.resolve_generics_from_context(generics_to_resolve,
+                                                  destructure_context_type(unique_type, context_type),
+                                                  resolved_generic_values: resolved_generic_values)
       end)
     end
 
@@ -556,11 +557,11 @@ module Solargraph
     # `generic<A>, nil` would bind to the entire `String, nil` context
     # instead of just `String`.
     #
-    # @param item [UniqueType] A member of @items
+    # @param unique_type [UniqueType] A member of @items
     # @param context_type [ComplexType, UniqueType, nil]
     # @return [ComplexType, UniqueType, nil]
-    def generic_item_context_type item, context_type
-      return context_type unless item.generic? && context_type.is_a?(ComplexType) && @items.length > 1
+    def destructure_context_type unique_type, context_type
+      return context_type unless unique_type.generic? && context_type.is_a?(ComplexType) && @items.length > 1
 
       concrete_items = @items.reject(&:generic?)
       return context_type if concrete_items.empty?

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -562,13 +562,9 @@ module Solargraph
 
     private
 
-    # When this type is itself a union (e.g. `generic<A>, nil`) being
-    # matched against a union context type (e.g. `String, nil`), a
-    # generic member should only be bound against the parts of the
-    # context union not already accounted for by this type's other,
-    # concrete (non-generic) members. Otherwise `generic<A>` in
-    # `generic<A>, nil` would bind to the entire `String, nil` context
-    # instead of just `String`.
+    # Narrows what a generic member binds against: context members this
+    # type already matches concretely are dropped, so the generic takes
+    # only what is left over rather than the whole union.
     #
     # @param unique_type [UniqueType] A member of @items
     # @param context_type [ComplexType, UniqueType, nil]

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -51,7 +51,7 @@ module Solargraph
       return self unless generic?
 
       ComplexType.new(@items.map do |i|
-        i.resolve_generics_from_context(generics_to_resolve, context_type,
+        i.resolve_generics_from_context(generics_to_resolve, generic_item_context_type(i, context_type),
                                         resolved_generic_values: resolved_generic_values)
       end)
     end
@@ -547,6 +547,29 @@ module Solargraph
     BOT = ComplexType.parse('bot')
 
     private
+
+    # When this type is itself a union (e.g. `generic<A>, nil`) being
+    # matched against a union context type (e.g. `String, nil`), a
+    # generic member should only be bound against the parts of the
+    # context union not already accounted for by this type's other,
+    # concrete (non-generic) members. Otherwise `generic<A>` in
+    # `generic<A>, nil` would bind to the entire `String, nil` context
+    # instead of just `String`.
+    #
+    # @param item [UniqueType] A member of @items
+    # @param context_type [ComplexType, UniqueType, nil]
+    # @return [ComplexType, UniqueType, nil]
+    def generic_item_context_type item, context_type
+      return context_type unless item.generic? && context_type.is_a?(ComplexType) && @items.length > 1
+
+      concrete_items = @items.reject(&:generic?)
+      return context_type if concrete_items.empty?
+
+      remaining_items = context_type.items.reject { |ct| concrete_items.any? { |ci| ci.name == ct.name } }
+      return context_type if remaining_items.empty?
+
+      ComplexType.new(remaining_items)
+    end
 
     # @todo This is a quick and dirty hack that forces `self` keywords
     #   to reference an instance of their class and never the class itself.

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -562,9 +562,9 @@ module Solargraph
 
     private
 
-    # Narrows what a generic member binds against: context members this
-    # type already matches concretely are dropped, so the generic takes
-    # only what is left over rather than the whole union.
+    # Narrows what a generic member binds against: context members this type
+    # already matches concretely are dropped. Nothing left over means no value
+    # can reach the generic, which is bot.
     #
     # @param unique_type [UniqueType] A member of @items
     # @param context_type [ComplexType, UniqueType, nil]
@@ -576,7 +576,7 @@ module Solargraph
       return context_type if concrete_items.empty?
 
       remaining_items = context_type.items.reject { |ct| concrete_items.any? { |ci| ci.name == ct.name } }
-      return context_type if remaining_items.empty?
+      return BOT if remaining_items.empty?
 
       ComplexType.new(remaining_items)
     end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -552,13 +552,12 @@ describe 'YARD type specifier list parsing' do
                                                  { 'K' => 'String', 'V' => 'Integer' }],
         non_discriminating_preserves_already_resolved_generic: ['generic<A>, nil', 'String, nil', { 'A' => 'Integer' },
                                                                 %w[A], 'Integer, nil', { 'A' => 'Integer' }],
-        # Known limitation: no concrete member to discriminate by, so both generics bind to the whole context.
-        no_discriminating_context_member: ['generic<A>, generic<B>', 'String, Integer', {}, %w[A B], 'String, Integer',
-                                           { 'A' => 'String, Integer', 'B' => 'String, Integer' }],
         discriminating_reordered_context_members: ['generic<A>, nil', 'nil, String', {}, %w[A], 'String, nil',
-                                                   { 'A' => 'String' }],
-        # Known limitation: duplicate concrete context members cancel out, leaving nothing to subtract.
-        duplicate_concrete_context_members: ['generic<A>, nil', 'nil, nil', {}, %w[A], 'nil', { 'A' => 'nil' }]
+                                                   { 'A' => 'String' }]
+        # Left out: nothing concrete to subtract, and union members are unordered, so
+        # what these should resolve to is undecided.
+        # no_discriminating_context_member: ['generic<A>, generic<B>', 'String, Integer', {}, %w[A B], ...],
+        # duplicate_concrete_context_members: ['generic<A>, nil', 'nil, nil', {}, %w[A], ...]
       }.freeze
 
       UNION_COMPLEX_TYPE_GENERIC_TESTS.each do |name, (tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_to_s, expected_output_map)|

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -533,6 +533,59 @@ describe 'YARD type specifier list parsing' do
           end
         end
       end
+
+      # Exercises ComplexType#resolve_generics_from_context directly
+      # (as opposed to UniqueType#resolve_generics_from_context above)
+      # against union types with more than one member, per
+      # https://github.com/castwide/solargraph/issues/1298
+      #
+      # Note: the resolved_generic_values assertion below must compare
+      # with #to_s, not #tag - ComplexType#tag delegates to the first
+      # union member only (via method_missing), so a binding that's
+      # incorrectly the *entire* multi-member context union - the
+      # #1298 bug - can still report the right #tag while silently
+      # carrying the rest of the union along. #to_s renders every
+      # member and catches that.
+      UNION_COMPLEX_TYPE_GENERIC_TESTS = [
+        # tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_to_s, expected_output_map
+        # Discriminating: fails pre-fix with A bound to 'String, nil' (the whole context) instead of 'String'.
+        ['generic<A>, nil', 'String, nil', {}, %w[A], 'String, nil', { 'A' => 'String' }],
+        # Discriminating: fails pre-fix with A bound to 'String, nil, Symbol' instead of 'String'.
+        ['generic<A>, nil, Symbol', 'String, nil, Symbol', {}, %w[A], 'String, nil, Symbol', { 'A' => 'String' }],
+        # Non-discriminating (passes either way): context has only one member, so there's
+        # nothing to subtract - included as a no-regression check for the single-member-context shape.
+        ['generic<A>, nil', 'String', {}, %w[A], 'String, nil', { 'A' => 'String' }],
+        # Non-discriminating: the nested generic<A> is resolved against context.subtypes, and
+        # ComplexType#method_missing's delegation to the first union member already narrows this
+        # correctly with or without the fix. Included to confirm the fix doesn't disturb it.
+        ['Array<generic<A>>, nil', 'Array<String>, nil', {}, %w[A], 'Array<String>, nil', { 'A' => 'String' }],
+        # Non-discriminating, same reason as the Array case above, but for Hash key/value generics.
+        ['Hash{generic<K> => generic<V>}, nil', 'Hash{String => Integer}, nil', {}, %w[K V],
+         'Hash{String => Integer}, nil', { 'K' => 'String', 'V' => 'Integer' }],
+        # Non-discriminating: an already-resolved value is never overwritten by context,
+        # with or without the fix. Included as a no-regression check.
+        ['generic<A>, nil', 'String, nil', { 'A' => 'Integer' }, %w[A], 'Integer, nil', { 'A' => 'Integer' }],
+        # Known limitation, unchanged by this fix: with no concrete union member to
+        # subtract, there's no positional information to tell which generic should
+        # bind to which context member, so both end up bound to the entire context union.
+        ['generic<A>, generic<B>', 'String, Integer', {}, %w[A B], 'String, Integer',
+         { 'A' => 'String, Integer', 'B' => 'String, Integer' }]
+      ].freeze
+
+      UNION_COMPLEX_TYPE_GENERIC_TESTS.each do |tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_to_s, expected_output_map|
+        context "when resolving union #{tag} with context #{context_type_tag} and existing resolved generics #{unfrozen_input_map}" do
+          let(:complex_type) { Solargraph::ComplexType.parse(tag) }
+          let(:context_type) { Solargraph::ComplexType.parse(context_type_tag) }
+
+          it "resolves to #{expected_to_s} with updated map #{expected_output_map}" do
+            resolved_generic_values = unfrozen_input_map.transform_values { |tag| Solargraph::ComplexType.parse(tag) }
+            resolved_type = complex_type.resolve_generics_from_context(generics_to_resolve, context_type,
+                                                                       resolved_generic_values: resolved_generic_values)
+            expect(resolved_type.to_s).to eq(expected_to_s)
+            expect(resolved_generic_values.transform_values(&:to_s)).to eq(expected_output_map)
+          end
+        end
+      end
     end
   end
 

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -569,7 +569,17 @@ describe 'YARD type specifier list parsing' do
         # subtract, there's no positional information to tell which generic should
         # bind to which context member, so both end up bound to the entire context union.
         ['generic<A>, generic<B>', 'String, Integer', {}, %w[A B], 'String, Integer',
-         { 'A' => 'String, Integer', 'B' => 'String, Integer' }]
+         { 'A' => 'String, Integer', 'B' => 'String, Integer' }],
+        # Discriminating: the concrete union member (nil) is matched against context
+        # by name, not position, so the fix works even when the context lists its
+        # members in a different order than self does.
+        ['generic<A>, nil', 'nil, String', {}, %w[A], 'String, nil', { 'A' => 'String' }],
+        # Known limitation: a duplicated concrete member in the context (nil, nil)
+        # matches and removes both context members, leaving nothing to subtract, so
+        # this falls back to the full (deduplicated) context union rather than a
+        # meaningful remainder. Included as a no-regression check for this shape,
+        # not as evidence the shape is handled well.
+        ['generic<A>, nil', 'nil, nil', {}, %w[A], 'nil', { 'A' => 'nil' }]
       ].freeze
 
       UNION_COMPLEX_TYPE_GENERIC_TESTS.each do |tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_to_s, expected_output_map|

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -554,10 +554,11 @@ describe 'YARD type specifier list parsing' do
                                                                 %w[A], 'Integer, nil', { 'A' => 'Integer' }],
         discriminating_reordered_context_members: ['generic<A>, nil', 'nil, String', {}, %w[A], 'String, nil',
                                                    { 'A' => 'String' }]
-        # Left out: nothing concrete to subtract, and union members are unordered, so
-        # what these should resolve to is undecided.
+        # Left out as open questions. The first has no concrete member to subtract,
+        # and telling A from B would need union member order, which carries no
+        # meaning. The second leaves nothing over, so A binds to the whole context.
         # no_discriminating_context_member: ['generic<A>, generic<B>', 'String, Integer', {}, %w[A B], ...],
-        # duplicate_concrete_context_members: ['generic<A>, nil', 'nil, nil', {}, %w[A], ...]
+        # context_fully_covered_by_concrete_member: ['generic<A>, nil', 'nil', {}, %w[A], ...]
       }.freeze
 
       UNION_COMPLEX_TYPE_GENERIC_TESTS.each do |name, (tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_to_s, expected_output_map)|

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -534,56 +534,35 @@ describe 'YARD type specifier list parsing' do
         end
       end
 
-      # Exercises ComplexType#resolve_generics_from_context directly
-      # (as opposed to UniqueType#resolve_generics_from_context above)
-      # against union types with more than one member, per
+      # Exercises ComplexType#resolve_generics_from_context against union
+      # types with more than one member. Compares #to_s, not #tag, since
+      # #tag delegates to only the first union member (method_missing).
       # https://github.com/castwide/solargraph/issues/1298
-      #
-      # Note: the resolved_generic_values assertion below must compare
-      # with #to_s, not #tag - ComplexType#tag delegates to the first
-      # union member only (via method_missing), so a binding that's
-      # incorrectly the *entire* multi-member context union - the
-      # #1298 bug - can still report the right #tag while silently
-      # carrying the rest of the union along. #to_s renders every
-      # member and catches that.
-      UNION_COMPLEX_TYPE_GENERIC_TESTS = [
+      UNION_COMPLEX_TYPE_GENERIC_TESTS = {
         # tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_to_s, expected_output_map
-        # Discriminating: fails pre-fix with A bound to 'String, nil' (the whole context) instead of 'String'.
-        ['generic<A>, nil', 'String, nil', {}, %w[A], 'String, nil', { 'A' => 'String' }],
-        # Discriminating: fails pre-fix with A bound to 'String, nil, Symbol' instead of 'String'.
-        ['generic<A>, nil, Symbol', 'String, nil, Symbol', {}, %w[A], 'String, nil, Symbol', { 'A' => 'String' }],
-        # Non-discriminating (passes either way): context has only one member, so there's
-        # nothing to subtract - included as a no-regression check for the single-member-context shape.
-        ['generic<A>, nil', 'String', {}, %w[A], 'String, nil', { 'A' => 'String' }],
-        # Non-discriminating: the nested generic<A> is resolved against context.subtypes, and
-        # ComplexType#method_missing's delegation to the first union member already narrows this
-        # correctly with or without the fix. Included to confirm the fix doesn't disturb it.
-        ['Array<generic<A>>, nil', 'Array<String>, nil', {}, %w[A], 'Array<String>, nil', { 'A' => 'String' }],
-        # Non-discriminating, same reason as the Array case above, but for Hash key/value generics.
-        ['Hash{generic<K> => generic<V>}, nil', 'Hash{String => Integer}, nil', {}, %w[K V],
-         'Hash{String => Integer}, nil', { 'K' => 'String', 'V' => 'Integer' }],
-        # Non-discriminating: an already-resolved value is never overwritten by context,
-        # with or without the fix. Included as a no-regression check.
-        ['generic<A>, nil', 'String, nil', { 'A' => 'Integer' }, %w[A], 'Integer, nil', { 'A' => 'Integer' }],
-        # Known limitation, unchanged by this fix: with no concrete union member to
-        # subtract, there's no positional information to tell which generic should
-        # bind to which context member, so both end up bound to the entire context union.
-        ['generic<A>, generic<B>', 'String, Integer', {}, %w[A B], 'String, Integer',
-         { 'A' => 'String, Integer', 'B' => 'String, Integer' }],
-        # Discriminating: the concrete union member (nil) is matched against context
-        # by name, not position, so the fix works even when the context lists its
-        # members in a different order than self does.
-        ['generic<A>, nil', 'nil, String', {}, %w[A], 'String, nil', { 'A' => 'String' }],
-        # Known limitation: a duplicated concrete member in the context (nil, nil)
-        # matches and removes both context members, leaving nothing to subtract, so
-        # this falls back to the full (deduplicated) context union rather than a
-        # meaningful remainder. Included as a no-regression check for this shape,
-        # not as evidence the shape is handled well.
-        ['generic<A>, nil', 'nil, nil', {}, %w[A], 'nil', { 'A' => 'nil' }]
-      ].freeze
+        discriminating_two_member_union: ['generic<A>, nil', 'String, nil', {}, %w[A], 'String, nil', { 'A' => 'String' }],
+        discriminating_three_member_union: ['generic<A>, nil, Symbol', 'String, nil, Symbol', {}, %w[A],
+                                            'String, nil, Symbol', { 'A' => 'String' }],
+        non_discriminating_single_member_context: ['generic<A>, nil', 'String', {}, %w[A], 'String, nil',
+                                                   { 'A' => 'String' }],
+        non_discriminating_nested_array_generic: ['Array<generic<A>>, nil', 'Array<String>, nil', {}, %w[A],
+                                                  'Array<String>, nil', { 'A' => 'String' }],
+        non_discriminating_nested_hash_generic: ['Hash{generic<K> => generic<V>}, nil', 'Hash{String => Integer}, nil',
+                                                 {}, %w[K V], 'Hash{String => Integer}, nil',
+                                                 { 'K' => 'String', 'V' => 'Integer' }],
+        non_discriminating_preserves_already_resolved_generic: ['generic<A>, nil', 'String, nil', { 'A' => 'Integer' },
+                                                                %w[A], 'Integer, nil', { 'A' => 'Integer' }],
+        # Known limitation: no concrete member to discriminate by, so both generics bind to the whole context.
+        no_discriminating_context_member: ['generic<A>, generic<B>', 'String, Integer', {}, %w[A B], 'String, Integer',
+                                           { 'A' => 'String, Integer', 'B' => 'String, Integer' }],
+        discriminating_reordered_context_members: ['generic<A>, nil', 'nil, String', {}, %w[A], 'String, nil',
+                                                   { 'A' => 'String' }],
+        # Known limitation: duplicate concrete context members cancel out, leaving nothing to subtract.
+        duplicate_concrete_context_members: ['generic<A>, nil', 'nil, nil', {}, %w[A], 'nil', { 'A' => 'nil' }]
+      }.freeze
 
-      UNION_COMPLEX_TYPE_GENERIC_TESTS.each do |tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_to_s, expected_output_map|
-        context "when resolving union #{tag} with context #{context_type_tag} and existing resolved generics #{unfrozen_input_map}" do
+      UNION_COMPLEX_TYPE_GENERIC_TESTS.each do |name, (tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_to_s, expected_output_map)|
+        context "when resolving #{name}: union #{tag} with context #{context_type_tag} and existing resolved generics #{unfrozen_input_map}" do
           let(:complex_type) { Solargraph::ComplexType.parse(tag) }
           let(:context_type) { Solargraph::ComplexType.parse(context_type_tag) }
 

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -534,12 +534,9 @@ describe 'YARD type specifier list parsing' do
         end
       end
 
-      # Exercises ComplexType#resolve_generics_from_context against union
-      # types with more than one member. Compares #to_s, not #tag, since
-      # #tag delegates to only the first union member (method_missing).
-      # https://github.com/castwide/solargraph/issues/1298
+      # Exercises resolve_generics_from_context against unions of more than one member.
       UNION_COMPLEX_TYPE_GENERIC_TESTS = {
-        # tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_to_s, expected_output_map
+        # tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_rooted_tags, expected_output_map
         discriminating_two_member_union: ['generic<A>, nil', 'String, nil', {}, %w[A], 'String, nil', { 'A' => 'String' }],
         discriminating_three_member_union: ['generic<A>, nil, Symbol', 'String, nil, Symbol', {}, %w[A],
                                             'String, nil, Symbol', { 'A' => 'String' }],
@@ -554,24 +551,19 @@ describe 'YARD type specifier list parsing' do
                                                                 %w[A], 'Integer, nil', { 'A' => 'Integer' }],
         discriminating_reordered_context_members: ['generic<A>, nil', 'nil, String', {}, %w[A], 'String, nil',
                                                    { 'A' => 'String' }]
-        # Left out as open questions. The first has no concrete member to subtract,
-        # and telling A from B would need union member order, which carries no
-        # meaning. The second leaves nothing over, so A binds to the whole context.
-        # no_discriminating_context_member: ['generic<A>, generic<B>', 'String, Integer', {}, %w[A B], ...],
-        # context_fully_covered_by_concrete_member: ['generic<A>, nil', 'nil', {}, %w[A], ...]
       }.freeze
 
-      UNION_COMPLEX_TYPE_GENERIC_TESTS.each do |name, (tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_to_s, expected_output_map)|
+      UNION_COMPLEX_TYPE_GENERIC_TESTS.each do |name, (tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_rooted_tags, expected_output_map)|
         context "when resolving #{name}: union #{tag} with context #{context_type_tag} and existing resolved generics #{unfrozen_input_map}" do
           let(:complex_type) { Solargraph::ComplexType.parse(tag) }
           let(:context_type) { Solargraph::ComplexType.parse(context_type_tag) }
 
-          it "resolves to #{expected_to_s} with updated map #{expected_output_map}" do
+          it "resolves to #{expected_rooted_tags} with updated map #{expected_output_map}" do
             resolved_generic_values = unfrozen_input_map.transform_values { |tag| Solargraph::ComplexType.parse(tag) }
             resolved_type = complex_type.resolve_generics_from_context(generics_to_resolve, context_type,
                                                                        resolved_generic_values: resolved_generic_values)
-            expect(resolved_type.to_s).to eq(expected_to_s)
-            expect(resolved_generic_values.transform_values(&:to_s)).to eq(expected_output_map)
+            expect(resolved_type.rooted_tags).to eq(expected_rooted_tags)
+            expect(resolved_generic_values.transform_values(&:rooted_tags)).to eq(expected_output_map)
           end
         end
       end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -553,12 +553,26 @@ describe 'YARD type specifier list parsing' do
                                                    { 'A' => 'String' }]
       }.freeze
 
-      UNION_COMPLEX_TYPE_GENERIC_TESTS.each do |name, (tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_rooted_tags, expected_output_map)|
+      # The concrete members cover the whole context, so no value can reach the
+      # generic: it binds to bot, which the union then absorbs.
+      UNION_COMPLEX_TYPE_GENERIC_BOT_TESTS = {
+        context_covered_by_one_member: ['generic<A>, nil', 'nil', {}, %w[A], 'nil', { 'A' => 'bot' }],
+        context_covered_by_two_members: ['generic<A>, String, nil', 'String, nil', {}, %w[A], 'String, nil',
+                                         { 'A' => 'bot' }]
+      }.freeze
+
+      BOT_TYPE_PR = 'https://github.com/castwide/solargraph/pull/1277'
+
+      union_generic_cases = UNION_COMPLEX_TYPE_GENERIC_TESTS.map { |name, row| [name, row, nil] } +
+                            UNION_COMPLEX_TYPE_GENERIC_BOT_TESTS.map { |name, row| [name, row, BOT_TYPE_PR] }
+
+      union_generic_cases.each do |name, (tag, context_type_tag, unfrozen_input_map, generics_to_resolve, expected_rooted_tags, expected_output_map), pending_url|
         context "when resolving #{name}: union #{tag} with context #{context_type_tag} and existing resolved generics #{unfrozen_input_map}" do
           let(:complex_type) { Solargraph::ComplexType.parse(tag) }
           let(:context_type) { Solargraph::ComplexType.parse(context_type_tag) }
 
           it "resolves to #{expected_rooted_tags} with updated map #{expected_output_map}" do
+            pending pending_url if pending_url
             resolved_generic_values = unfrozen_input_map.transform_values { |tag| Solargraph::ComplexType.parse(tag) }
             resolved_type = complex_type.resolve_generics_from_context(generics_to_resolve, context_type,
                                                                        resolved_generic_values: resolved_generic_values)

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -731,6 +731,80 @@ describe Solargraph::TypeChecker do
       expect(messages).not_to include('Unresolved call to length on String, nil')
     end
 
+    # NOTE: this scenario doesn't distinguish fixed from unfixed
+    # behavior - a union return type of the exact same shape as the
+    # union @param type flattens/dedupes an incorrectly-too-wide
+    # binding back down to the right answer by coincidence (the union
+    # already contains 'nil' as a sibling member either way). It's
+    # included as a no-regression check for union return types, not as
+    # a regression test for #1298 itself.
+    it 'resolves a generic type variable when both the @param and @return types are the same union' do
+      checker = type_checker(%(
+        # @generic A
+        # @param arg [generic<A>, nil]
+        # @return [generic<A>, nil]
+        def maybe(arg)
+          arg
+        end
+
+        # @param arg [String, nil]
+        # @return [String, nil]
+        def via(arg) = maybe(arg)
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
+    it 'resolves a generic type variable against a union @param type with more than two members' do
+      checker = type_checker(%(
+        # @generic A
+        # @param arg [generic<A>, nil, Symbol]
+        # @return [generic<A>]
+        def must_not_nil_or_symbol(arg)
+          raise if arg.nil? || arg.is_a?(Symbol)
+
+          arg
+        end
+
+        # @param arg [String, nil, Symbol]
+        # @return [Integer]
+        def via_triple(arg) = must_not_nil_or_symbol(arg).length
+      ))
+      # As with the two-member case above, the remaining "Declared
+      # return type...does not match inferred type" problem is #1276
+      # (`raise` does not narrow the type), independent of this test.
+      messages = checker.problems.map(&:message)
+      expect(messages).not_to include('#via_triple return type could not be inferred')
+      expect(messages).not_to include('Unresolved call to length on String, nil, Symbol')
+    end
+
+    it 'resolves a generic type variable against a union @param type through two layers of generic methods' do
+      checker = type_checker(%(
+        # @generic A
+        # @param arg [generic<A>, nil]
+        # @return [generic<A>]
+        def layer1(arg)
+          raise if arg.nil?
+
+          arg
+        end
+
+        # @generic A
+        # @param arg [generic<A>, nil]
+        # @return [generic<A>]
+        def layer2(arg) = layer1(arg)
+
+        # @param arg [String, nil]
+        # @return [Integer]
+        def via_layers(arg) = layer2(arg).length
+      ))
+      # As above, any "Declared return type...does not match inferred
+      # type" problems here are #1276 (`raise` does not narrow the
+      # type), independent of this test.
+      messages = checker.problems.map(&:message)
+      expect(messages).not_to include('#via_layers return type could not be inferred')
+      expect(messages).not_to include('Unresolved call to length on String, nil')
+    end
+
     it 'resolves constants inside modules inside classes' do
       checker = type_checker(%(
         class Bar

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -707,6 +707,30 @@ describe Solargraph::TypeChecker do
       end
     end
 
+    it 'resolves a generic type variable against a union @param type' do
+      checker = type_checker(%(
+        # @generic A
+        # @param arg [generic<A>, nil]
+        # @return [generic<A>]
+        def must_nilable(arg)
+          raise if arg.nil?
+
+          arg
+        end
+
+        # @param arg [String, nil]
+        # @return [Integer]
+        def via_nilable(arg) = must_nilable(arg).length
+      ))
+      # The remaining "Declared return type generic<A> does not match
+      # inferred type generic<A>, nil for #must_nilable" problem is
+      # caused by #1276 (`raise` does not narrow the type), which is
+      # independent of the generic resolution behavior under test here.
+      messages = checker.problems.map(&:message)
+      expect(messages).not_to include('#via_nilable return type could not be inferred')
+      expect(messages).not_to include('Unresolved call to length on String, nil')
+    end
+
     it 'resolves constants inside modules inside classes' do
       checker = type_checker(%(
         class Bar

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -801,8 +801,6 @@ describe Solargraph::TypeChecker do
       expect(messages).not_to include('Unresolved call to length on String, nil')
     end
 
-    # Non-discriminating: an identically-shaped union return type flattens/dedupes
-    # a too-wide binding back to the right answer by coincidence, not by the fix.
     it 'resolves a generic type variable when both the @param and @return types are the same union' do
       checker = type_checker(%(
         # @generic A
@@ -834,9 +832,8 @@ describe Solargraph::TypeChecker do
         # @return [Integer]
         def via_triple(arg) = must_not_nil_or_symbol(arg).length
       ))
-      # As with the two-member case above, the remaining "Declared
-      # return type...does not match inferred type" problem is #1276
-      # (`raise` does not narrow the type), independent of this test.
+      # The remaining problem is unrelated to this test:
+      # https://github.com/castwide/solargraph/issues/1276
       messages = checker.problems.map(&:message)
       expect(messages).not_to include('#via_triple return type could not be inferred')
       expect(messages).not_to include('Unresolved call to length on String, nil, Symbol')
@@ -862,9 +859,8 @@ describe Solargraph::TypeChecker do
         # @return [Integer]
         def via_layers(arg) = layer2(arg).length
       ))
-      # As above, any "Declared return type...does not match inferred
-      # type" problems here are #1276 (`raise` does not narrow the
-      # type), independent of this test.
+      # The remaining problem is unrelated to this test:
+      # https://github.com/castwide/solargraph/issues/1276
       messages = checker.problems.map(&:message)
       expect(messages).not_to include('#via_layers return type could not be inferred')
       expect(messages).not_to include('Unresolved call to length on String, nil')

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -780,12 +780,13 @@ describe Solargraph::TypeChecker do
     end
 
     it 'resolves a generic type variable against a union @param type' do
+      pending 'https://github.com/castwide/solargraph/issues/1276'
       checker = type_checker(%(
         # @generic A
         # @param arg [generic<A>, nil]
         # @return [generic<A>]
         def must_nilable(arg)
-          raise if arg.nil?
+          raise ArgumentError, 'arg must not be nil' if arg.nil?
 
           arg
         end
@@ -794,11 +795,7 @@ describe Solargraph::TypeChecker do
         # @return [Integer]
         def via_nilable(arg) = must_nilable(arg).length
       ))
-      # The remaining problem is unrelated to this test:
-      # https://github.com/castwide/solargraph/issues/1276
-      messages = checker.problems.map(&:message)
-      expect(messages).not_to include('#via_nilable return type could not be inferred')
-      expect(messages).not_to include('Unresolved call to length on String, nil')
+      expect(checker.problems.map(&:message)).to be_empty
     end
 
     it 'resolves a generic type variable when both the @param and @return types are the same union' do
@@ -818,12 +815,13 @@ describe Solargraph::TypeChecker do
     end
 
     it 'resolves a generic type variable against a union @param type with more than two members' do
+      pending 'https://github.com/castwide/solargraph/issues/1276'
       checker = type_checker(%(
         # @generic A
         # @param arg [generic<A>, nil, Symbol]
         # @return [generic<A>]
         def must_not_nil_or_symbol(arg)
-          raise if arg.nil? || arg.is_a?(Symbol)
+          raise ArgumentError, 'arg must not be nil or a Symbol' if arg.nil? || arg.is_a?(Symbol)
 
           arg
         end
@@ -832,20 +830,17 @@ describe Solargraph::TypeChecker do
         # @return [Integer]
         def via_triple(arg) = must_not_nil_or_symbol(arg).length
       ))
-      # The remaining problem is unrelated to this test:
-      # https://github.com/castwide/solargraph/issues/1276
-      messages = checker.problems.map(&:message)
-      expect(messages).not_to include('#via_triple return type could not be inferred')
-      expect(messages).not_to include('Unresolved call to length on String, nil, Symbol')
+      expect(checker.problems.map(&:message)).to be_empty
     end
 
     it 'resolves a generic type variable against a union @param type through two layers of generic methods' do
+      pending 'https://github.com/castwide/solargraph/issues/1276'
       checker = type_checker(%(
         # @generic A
         # @param arg [generic<A>, nil]
         # @return [generic<A>]
         def layer1(arg)
-          raise if arg.nil?
+          raise ArgumentError, 'arg must not be nil' if arg.nil?
 
           arg
         end
@@ -859,11 +854,7 @@ describe Solargraph::TypeChecker do
         # @return [Integer]
         def via_layers(arg) = layer2(arg).length
       ))
-      # The remaining problem is unrelated to this test:
-      # https://github.com/castwide/solargraph/issues/1276
-      messages = checker.problems.map(&:message)
-      expect(messages).not_to include('#via_layers return type could not be inferred')
-      expect(messages).not_to include('Unresolved call to length on String, nil')
+      expect(checker.problems.map(&:message)).to be_empty
     end
 
     it 'resolves constants inside modules inside classes' do

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -794,22 +794,15 @@ describe Solargraph::TypeChecker do
         # @return [Integer]
         def via_nilable(arg) = must_nilable(arg).length
       ))
-      # The remaining "Declared return type generic<A> does not match
-      # inferred type generic<A>, nil for #must_nilable" problem is
-      # caused by #1276 (`raise` does not narrow the type), which is
-      # independent of the generic resolution behavior under test here.
+      # The remaining problem is unrelated to this test:
+      # https://github.com/castwide/solargraph/issues/1276
       messages = checker.problems.map(&:message)
       expect(messages).not_to include('#via_nilable return type could not be inferred')
       expect(messages).not_to include('Unresolved call to length on String, nil')
     end
 
-    # NOTE: this scenario doesn't distinguish fixed from unfixed
-    # behavior - a union return type of the exact same shape as the
-    # union @param type flattens/dedupes an incorrectly-too-wide
-    # binding back down to the right answer by coincidence (the union
-    # already contains 'nil' as a sibling member either way). It's
-    # included as a no-regression check for union return types, not as
-    # a regression test for #1298 itself.
+    # Non-discriminating: an identically-shaped union return type flattens/dedupes
+    # a too-wide binding back to the right answer by coincidence, not by the fix.
     it 'resolves a generic type variable when both the @param and @return types are the same union' do
       checker = type_checker(%(
         # @generic A


### PR DESCRIPTION
**Problem:** A generic declared inside a union `@param` makes the call site report an error that isn't real.

```ruby
# @generic A
# @param arg [generic<A>, nil]
# @return [generic<A>]
def must_nilable(arg)
  raise ArgumentError, 'arg must not be nil' if arg.nil?

  arg
end

# @param arg [String, nil]
# @return [Integer]
def via_nilable(arg) = must_nilable(arg).length
#                                       ^ Unresolved call to length on String, nil
```

Any generic method with a nilable parameter hits this, since `generic<A>, nil` is the ordinary way to declare one. Fixes #1298.

**Solution:** `ComplexType#resolve_generics_from_context` subtracts the type's own concrete union members from the context before a generic member binds, leaving the generic only what is not already accounted for.

The three type-checker examples are `pending` on #1276, since `raise` does not narrow a type yet. The `ComplexType` table specs carry the regression guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
