### PR TITLE
Don't let a bracketed comment in a class body drop its superclass

### DIFF
--- a/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
@@ -27,7 +27,6 @@ module Solargraph
               source: :parser
             )
             pins.push nspin
-            Solargraph.logger.warn "Superclass: #{superclass_name}" if superclass_name&.start_with?('Array')
             if superclass_name
               pins.push Pin::Reference::Superclass.new(
                 location: loc,
@@ -41,12 +40,22 @@ module Solargraph
 
           private
 
-          # @param comments [String]
+          # Type arguments for a generic superclass in inline RBS syntax, e.g.,
+          # `class Foo < Array #[String]`. Only recognized where RBS defines
+          # it: directly after the superclass, on the same line, with no space
+          # between `#` and `[`. Anything else is an ordinary comment.
+          #
           # @return [String, nil]
           def parameters_from_inline_rbs
-            source = region.source.code_for(node)
-            match = source.match(/[^\n]*?#\s?+\[([^\]]*)/)
-            return unless match && match[1]
+            superclass = node.children[1]
+            return unless superclass
+
+            source = region.source.code
+            pos = get_node_end_position(superclass)
+            offset = Position.line_char_to_offset(source, pos.line, pos.character)
+            eol = source.index("\n", offset) || source.length
+            match = source[offset...eol].to_s.match(/\A\s*#\[([^\]]*)\]/)
+            return unless match
 
             code = match[1].strip
             return if code.empty?

--- a/spec/parser/node_processor_spec.rb
+++ b/spec/parser/node_processor_spec.rb
@@ -79,4 +79,23 @@ describe Solargraph::Parser::NodeProcessor do
 
     expect(map.pins.last.type.to_s).to eq('Array<String>')
   end
+
+  it 'ignores bracketed comments in the class body' do
+    map = Solargraph::SourceMap.load_string(%(
+      class Foo < Array
+        # [:b, { c: :d }]
+      end
+    ), 'test.rb')
+
+    expect(map.pins.last.type.to_s).to eq('Array')
+  end
+
+  it 'ignores a bracketed comment separated from the hash' do
+    map = Solargraph::SourceMap.load_string(%(
+      class Foo < Array # [String]
+      end
+    ), 'test.rb')
+
+    expect(map.pins.last.type.to_s).to eq('Array')
+  end
 end


### PR DESCRIPTION
Fixes https://github.com/castwide/solargraph/issues/1300

An ordinary comment anywhere in a class body could silently remove that
class's superclass:

```ruby
class Sub < Base
  # [:b, { c: :d }]

  def call_it
    greet   # Unresolved call to greet
  end
end
```

Every inherited method then reports `Unresolved call`, including on lines
*above* the comment, so the reported locations point nowhere near the cause.

`parameters_from_inline_rbs` regex-scanned the whole class body for `#[...]`,
so any bracketed comment was read as the superclass's inline RBS type
arguments. `# [:b, { c: :d }]` yields the superclass name `Base<:b, { c: :d`,
which resolves to nothing.

The annotation is now only read where [ruby/rbs's inline
syntax](https://github.com/ruby/rbs/blob/master/docs/inline.md) defines it —
directly after the superclass, on the same line, `#[` with no space — and a
closing `]` is required.

Tightening worth noting: `class Foo < Array # [String]` (space after the `#`)
is now an ordinary comment rather than a type annotation.

Also removes a leftover debug `logger.warn` from
https://github.com/castwide/solargraph/pull/1173.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NtwP1oKRXfJAbPQrPHm5oU
