### PR TITLE
Apply @!override to constants instead of crashing the typechecker

### DIFF
--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -198,7 +198,7 @@ module Solargraph
         end
       end
 
-      # @param pin [Pin::Method]
+      # @param pin [Pin::Base]
       # @param tag [YARD::Tags::Tag]
       # @return [void]
       def redefine_return_type pin, tag
@@ -206,6 +206,9 @@ module Solargraph
         #   proxy() / proxy_with_signatures() instead?
         return unless pin && tag.tag_name == 'return'
         pin.instance_variable_set(:@return_type, ComplexType.try_parse(tag.type))
+        # Only methods carry signatures; constants and other pins have
+        # just the one return type set above.
+        return unless pin.is_a?(Pin::Method)
         pin.signatures.each do |sig|
           sig.instance_variable_set(:@return_type, ComplexType.try_parse(tag.type))
         end

--- a/spec/api_map/index_spec.rb
+++ b/spec/api_map/index_spec.rb
@@ -61,4 +61,27 @@ describe Solargraph::ApiMap::Index do
       expect(first_parameter.return_type.tag).to eq('String')
     end
   end
+
+  describe '#map_overrides on a constant' do
+    let(:baz_constant) do
+      Solargraph::Pin::Constant.new(name: 'BAZ',
+                                    closure: Solargraph::Pin::ROOT_PIN,
+                                    comments: '@return [String]')
+    end
+
+    let(:baz_override) do
+      Solargraph::Pin::Reference::Override.from_comment('BAZ', '@return [Integer]')
+    end
+
+    let(:input_pins) { [baz_constant, baz_override] }
+
+    it 'does not raise on a pin without signatures' do
+      expect { output_pins }.not_to raise_error
+    end
+
+    it 'redefines the return type of the constant' do
+      constant_pin = output_pins.find { |pin| pin.path == 'BAZ' }
+      expect(constant_pin.return_type.tag).to eq('Integer')
+    end
+  end
 end

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -1005,4 +1005,22 @@ describe Solargraph::ApiMap do
     # @todo Undefined because the return tag expands to `type: String`
     expect(pins.map(&:return_type).map(&:tag)).to eq(%w[undefined])
   end
+
+  # @!override on a constant used to abort cataloging with NoMethodError
+  # because Pin::Constant does not respond to #signatures.
+  # https://github.com/castwide/solargraph/issues/1302
+  it 'applies override directives to constants without aborting' do
+    source = Solargraph::Source.load_string(%(
+      # @!override Overridable::CONST
+      #   @return [Integer]
+
+      module Overridable
+        CONST = 'a string'
+      end
+    ), 'test.rb')
+    api_map = described_class.new
+    expect { api_map.map source }.not_to raise_error
+    pin = api_map.get_path_pins('Overridable::CONST').first
+    expect(pin.return_type.tag).to eq('Integer')
+  end
 end


### PR DESCRIPTION
Fixes #1302.

Correcting a constant whose resolved type is wrong is a reasonable thing to want, and `@!override` is the natural tool for it. Instead of being rejected or ignored, it aborted the whole typecheck with a traceback into Solargraph's internals, so nothing indicated that an annotation caused it:

```
api_map/index.rb:217:in 'redefine_return_type':
  undefined method 'signatures' for an instance of Solargraph::Pin::Constant (NoMethodError)
  from api_map/index.rb:196:in 'block (3 levels) in map_overrides'
```

`redefine_return_type` assumed every overridable pin responds to `#signatures`, which only `Pin::Method` defines. This keeps the `@return_type` assignment unconditional and guards just the signatures loop, so `@!override` now actually works on a constant rather than merely not crashing — `Pin::Constant#return_type` is `@return_type ||= generate_complex_type`, and neither `Pin::Base#reset_generated!` nor `Pin::BaseVariable#reset_generated!` clears it, so the assignment sticks. Putting the guard here rather than in `map_overrides` also means any other non-method pin degrades to return-type-only instead of aborting the run.

Verified against a local-constant repro (`FOO = 'bar'` with `# @!override FOO` / `@return [Integer]`), which hits the identical line with the identical error before the change and resolves to `Integer` after. Note I did not reproduce the literal `URI::DEFAULT_PARSER` form from the issue — that path returned zero pins locally, so `path_pin_hash[ovr.name]` was empty and it never reached the crash line; it needs stdlib RBS pins loaded.

Specs: two unit specs in `spec/api_map/index_spec.rb` (override on a `Pin::Constant` doesn't raise; return type becomes `Integer`) plus an end-to-end regression in `spec/api_map_spec.rb`. Full suite green locally: 1627 examples, 0 failures, 60 pending. RuboCop clean.

*Authored by Claude (Anthropic's Claude Code) on behalf of @apiology.*
