### PR TITLE
Index `X = Class.new(Super)` constant assignments as classes

### DIFF
--- a/lib/solargraph/convention.rb
+++ b/lib/solargraph/convention.rb
@@ -11,6 +11,7 @@ module Solargraph
     autoload :Rakefile, 'solargraph/convention/rakefile'
     autoload :StructDefinition, 'solargraph/convention/struct_definition'
     autoload :DataDefinition,   'solargraph/convention/data_definition'
+    autoload :ClassDefinition,  'solargraph/convention/class_definition'
     autoload :ActiveSupportConcern, 'solargraph/convention/active_support_concern'
 
     # @type [Set<Convention::Base>]

--- a/lib/solargraph/convention/class_definition.rb
+++ b/lib/solargraph/convention/class_definition.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Solargraph
+  module Convention
+    # Handles anonymous class definitions assigned to a constant, e.g.
+    #
+    #   Specific = Class.new(StandardError) do
+    #     def retry_after; 5; end
+    #   end
+    #
+    # Without this, the constant is indexed as an untyped Pin::Constant and the
+    # methods in the block are attached to the enclosing namespace.
+    module ClassDefinition
+      autoload :ClassAssignmentNode, 'solargraph/convention/class_definition/class_assignment_node'
+
+      module NodeProcessors
+        class ClassNode < Parser::NodeProcessor::Base
+          # @return [Boolean] continue processing the next processor of the same node.
+          def process
+            definition_node = class_definition_node
+            return true if definition_node.nil?
+
+            loc = get_node_location(node)
+            nspin = Solargraph::Pin::Namespace.new(
+              type: :class,
+              location: loc,
+              closure: region.closure,
+              name: definition_node.class_name,
+              comments: comments_for(node),
+              visibility: :public,
+              gates: region.closure.gates.freeze,
+              source: :class_definition
+            )
+            pins.push nspin
+
+            superclass_name = definition_node.superclass_name
+            if superclass_name
+              pins.push Pin::Reference::Superclass.new(
+                location: loc,
+                closure: nspin,
+                name: superclass_name,
+                source: :class_definition
+              )
+            end
+
+            process_children region.update(closure: nspin, visibility: :public)
+            false
+          end
+
+          private
+
+          # @return [ClassDefinition::ClassAssignmentNode, nil]
+          def class_definition_node
+            @class_definition_node ||= ClassAssignmentNode.new(node) if ClassAssignmentNode.match?(node)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/convention/class_definition/class_assignment_node.rb
+++ b/lib/solargraph/convention/class_definition/class_assignment_node.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Solargraph
+  module Convention
+    module ClassDefinition
+      # A node wrapper for a class definition via const assignment.
+      # @example
+      #   MyError = Class.new(StandardError) do
+      #     def retry_after; 5; end
+      #   end
+      class ClassAssignmentNode
+        class << self
+          # @example
+          #   s(:casgn, nil, :Foo,
+          #     s(:block,
+          #       s(:send,
+          #         s(:const, nil, :Class), :new,
+          #         s(:const, nil, :StandardError)),
+          #       s(:args),
+          #       s(:def, :retry_after, s(:args), s(:int, 5))))
+          #
+          # @param node [Parser::AST::Node]
+          # @return [Boolean]
+          def match? node
+            return false unless node&.type == :casgn
+
+            class_new_node?(new_node(node))
+          end
+
+          # The `Class.new(...)` send node, whether or not a block is attached.
+          #
+          # @param node [Parser::AST::Node]
+          # @return [Parser::AST::Node, nil]
+          def new_node node
+            value = node.children[2]
+            return nil if value.nil?
+            return value unless value.type == :block
+
+            value.children[0]
+          end
+
+          private
+
+          # @param send_node [Parser::AST::Node, nil]
+          # @return [Boolean]
+          def class_new_node? send_node
+            return false if send_node.nil?
+            return false unless send_node.type == :send
+            return false unless send_node.children[1] == :new
+
+            receiver = send_node.children[0]
+            return false if receiver.nil?
+            return false unless receiver.type == :const
+
+            receiver.children[1] == :Class
+          end
+        end
+
+        # @param node [Parser::AST::Node]
+        def initialize node
+          @node = node
+        end
+
+        # @return [String]
+        def class_name
+          namespace = node.children[0]
+          return node.children[1].to_s if namespace.nil?
+
+          "#{Parser::NodeMethods.unpack_name(namespace)}::#{node.children[1]}"
+        end
+
+        # The superclass, when it is written as a constant. `Class.new(expr)`
+        # with a non-constant argument yields nil (superclass stays Object).
+        #
+        # @return [String, nil]
+        def superclass_name
+          send_node = self.class.new_node(node)
+          return nil if send_node.nil?
+
+          arg = send_node.children[2]
+          return nil if arg.nil?
+          return nil unless arg.type == :const
+
+          Parser::NodeMethods.unpack_name(arg)
+        end
+
+        private
+
+        # @return [Parser::AST::Node]
+        attr_reader :node
+      end
+    end
+  end
+end

--- a/lib/solargraph/parser/parser_gem/node_processors.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors.rb
@@ -55,6 +55,7 @@ module Solargraph
       register :gvasgn,       ParserGem::NodeProcessors::GvasgnNode
       register :casgn,        Convention::StructDefinition::NodeProcessors::StructNode
       register :casgn,        Convention::DataDefinition::NodeProcessors::DataNode
+      register :casgn,        Convention::ClassDefinition::NodeProcessors::ClassNode
       register :casgn,        ParserGem::NodeProcessors::CasgnNode
       register :masgn,        ParserGem::NodeProcessors::MasgnNode
       register :alias,        ParserGem::NodeProcessors::AliasNode

--- a/spec/convention/class_definition_spec.rb
+++ b/spec/convention/class_definition_spec.rb
@@ -18,6 +18,23 @@ describe Solargraph::Convention::ClassDefinition do
     expect(pin.type).to be(:class)
   end
 
+  it 'indexes an explicitly namespace-qualified Class.new assignment' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      module Vendor
+      end
+
+      Vendor::Specific = Class.new(StandardError) do
+        # @return [Integer]
+        def retry_after
+          5
+        end
+      end
+    ), 'test.rb')
+
+    expect(api_map.get_methods('Vendor::Specific').map(&:name)).to include('retry_after')
+  end
+
   it 'attaches block methods to the new class rather than the enclosing module' do
     api_map = Solargraph::ApiMap.new
     api_map.map Solargraph::Source.load_string(%(

--- a/spec/convention/class_definition_spec.rb
+++ b/spec/convention/class_definition_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+describe Solargraph::Convention::ClassDefinition do
+  it 'indexes a Class.new assignment as a namespace' do
+    source = Solargraph::SourceMap.load_string(%(
+      module Vendor
+        Specific = Class.new(StandardError) do
+          # @return [Integer]
+          def retry_after
+            5
+          end
+        end
+      end
+    ), 'test.rb')
+
+    pin = source.pins.find { |p| p.path == 'Vendor::Specific' }
+    expect(pin).to be_a(Solargraph::Pin::Namespace)
+    expect(pin.type).to be(:class)
+  end
+
+  it 'attaches block methods to the new class rather than the enclosing module' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      module Vendor
+        Specific = Class.new(StandardError) do
+          # @return [Integer]
+          def retry_after
+            5
+          end
+        end
+      end
+    ), 'test.rb')
+
+    expect(api_map.get_methods('Vendor::Specific').map(&:name)).to include('retry_after')
+    expect(api_map.get_methods('Vendor').map(&:name)).not_to include('retry_after')
+  end
+
+  it 'records the superclass' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      module Vendor
+        Specific = Class.new(StandardError)
+      end
+    ), 'test.rb')
+
+    expect(api_map.super_and_sub?('StandardError', 'Vendor::Specific')).to be(true)
+    expect(api_map.get_methods('Vendor::Specific').map(&:name)).to include('message')
+  end
+
+  it 'supports a Class.new class as a superclass of another' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      module Vendor
+        Base = Class.new(StandardError)
+        Nested = Class.new(Base) do
+          # @return [String]
+          def label
+            'x'
+          end
+        end
+      end
+    ), 'test.rb')
+
+    names = api_map.get_methods('Vendor::Nested').map(&:name)
+    expect(names).to include('label')
+    expect(names).to include('message')
+  end
+
+  it 'handles Class.new with no superclass' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      Anon = Class.new do
+        # @return [Symbol]
+        def tag
+          :t
+        end
+      end
+    ), 'test.rb')
+
+    expect(api_map.get_methods('Anon').map(&:name)).to include('tag')
+  end
+
+  it 'handles a non-constant superclass expression' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      klass = Object
+      Dynamic = Class.new(klass)
+    ), 'test.rb')
+
+    expect(api_map.get_path_pins('Dynamic').first).to be_a(Solargraph::Pin::Namespace)
+  end
+
+  it 'leaves Struct.new assignments to the struct convention' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      # @param bar [String]
+      Foo = Struct.new(:bar)
+    ), 'test.rb')
+
+    expect(api_map.get_methods('Foo').map(&:name)).to include('bar')
+  end
+
+  it 'resolves calls on a Class.new class in a typecheck' do
+    checker = Solargraph::TypeChecker.load_string(%(
+      module Vendor
+        Specific = Class.new(StandardError) do
+          # @return [Integer]
+          def retry_after
+            5
+          end
+        end
+      end
+
+      # @param e [Vendor::Specific]
+      # @return [void]
+      def wait_for(e)
+        e.retry_after
+      end
+    ), 'test.rb', :strong)
+
+    expect(checker.problems).to be_empty
+  end
+end


### PR DESCRIPTION
Fixes #1303.

Gems commonly build classes as `X = Class.new(Parent) do ... end` — Asana's entire error hierarchy is one example. Solargraph indexed the result as an untyped constant, so no method on such a class resolved, and the methods in the block were attached to the enclosing namespace instead of the new class. There was no annotation that worked around it: a `@!parse` stub declaring the same name contributed nothing, and `@!override` on the constant crashed the typechecker (#1302).

```ruby
module Vendor
  Specific = Class.new(StandardError) do
    # @return [Integer]
    def retry_after
      5
    end
  end
end

# @param e [Vendor::Specific]
# @return [void]
def wait_for(e)
  e.retry_after   # Unresolved call to retry_after on Vendor::Specific
end
```

This adds a `Convention::ClassDefinition` following the existing `StructDefinition` / `DataDefinition` pattern: a `:casgn` node processor that pushes a `Pin::Namespace` for the assigned constant plus a `Pin::Reference::Superclass`, so block methods attach to the new class and the superclass is recorded. It registers after the Struct/Data processors and before `ParserGem::NodeProcessors::CasgnNode`, since registration order is precedence and Struct/Data must keep winning.

Negative controls verified in one file covering all four forms: `S = Struct.new(:bar)` and `D = Data.define(:baz)` still resolve through their own conventions, a plain `Alias = Other` is still an ordinary `Pin::Constant`, and `C = Class.new(StandardError) do … end` now resolves its block methods. Full suite green locally: 1632 examples, 0 failures, 60 pending. RuboCop clean; strong typecheck on both new lib files reports 0 problems.

*Authored by Claude (Anthropic's Claude Code) on behalf of @apiology.*
