### PR TITLE
Index gem constants defined with Class.new

### DIFF
--- a/lib/solargraph/convention.rb
+++ b/lib/solargraph/convention.rb
@@ -11,6 +11,7 @@ module Solargraph
     autoload :Rakefile, 'solargraph/convention/rakefile'
     autoload :StructDefinition, 'solargraph/convention/struct_definition'
     autoload :DataDefinition,   'solargraph/convention/data_definition'
+    autoload :ClassDefinition,  'solargraph/convention/class_definition'
     autoload :ActiveSupportConcern, 'solargraph/convention/active_support_concern'
 
     # @type [Set<Convention::Base>]

--- a/lib/solargraph/convention/class_definition.rb
+++ b/lib/solargraph/convention/class_definition.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+module Solargraph
+  module Convention
+    # Handles anonymous class definitions assigned to a constant, e.g.
+    #
+    #   Specific = Class.new(StandardError) do
+    #     def retry_after; 5; end
+    #   end
+    #
+    # Without this, the constant is indexed as an untyped Pin::Constant and the
+    # methods in the block are attached to the enclosing namespace.
+    module ClassDefinition
+      autoload :ClassAssignmentNode, 'solargraph/convention/class_definition/class_assignment_node'
+
+      module NodeProcessors
+        class ClassNode < Parser::NodeProcessor::Base
+          # @return [Boolean] continue processing the next processor of the same node.
+          def process
+            definition_node = class_definition_node
+            return true if definition_node.nil?
+
+            loc = get_node_location(node)
+            nspin = Solargraph::Pin::Namespace.new(
+              type: :class,
+              location: loc,
+              closure: region.closure,
+              name: definition_node.class_name,
+              comments: comments_for(node),
+              visibility: :public,
+              gates: region.closure.gates.freeze,
+              source: :class_definition
+            )
+            pins.push nspin
+
+            superclass_name = definition_node.superclass_name
+            if superclass_name
+              pins.push Pin::Reference::Superclass.new(
+                location: loc,
+                closure: nspin,
+                name: superclass_name,
+                source: :class_definition
+              )
+            end
+
+            process_children region.update(closure: nspin, visibility: :public)
+            false
+          end
+
+          private
+
+          # @return [ClassDefinition::ClassAssignmentNode, nil]
+          def class_definition_node
+            @class_definition_node ||= ClassAssignmentNode.new(node) if ClassAssignmentNode.match?(node)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/convention/class_definition/class_assignment_node.rb
+++ b/lib/solargraph/convention/class_definition/class_assignment_node.rb
@@ -1,0 +1,94 @@
+# frozen_string_literal: true
+
+module Solargraph
+  module Convention
+    module ClassDefinition
+      # A node wrapper for a class definition via const assignment.
+      # @example
+      #   MyError = Class.new(StandardError) do
+      #     def retry_after; 5; end
+      #   end
+      class ClassAssignmentNode
+        class << self
+          # @example
+          #   s(:casgn, nil, :Foo,
+          #     s(:block,
+          #       s(:send,
+          #         s(:const, nil, :Class), :new,
+          #         s(:const, nil, :StandardError)),
+          #       s(:args),
+          #       s(:def, :retry_after, s(:args), s(:int, 5))))
+          #
+          # @param node [Parser::AST::Node]
+          # @return [Boolean]
+          def match? node
+            return false unless node&.type == :casgn
+
+            class_new_node?(new_node(node))
+          end
+
+          # The `Class.new(...)` send node, whether or not a block is attached.
+          #
+          # @param node [Parser::AST::Node]
+          # @return [Parser::AST::Node, nil]
+          def new_node node
+            value = node.children[2]
+            return nil if value.nil?
+            return value unless value.type == :block
+
+            value.children[0]
+          end
+
+          private
+
+          # @param send_node [Parser::AST::Node, nil]
+          # @return [Boolean]
+          def class_new_node? send_node
+            return false if send_node.nil?
+            return false unless send_node.type == :send
+            return false unless send_node.children[1] == :new
+
+            receiver = send_node.children[0]
+            return false if receiver.nil?
+            return false unless receiver.type == :const
+
+            receiver.children[1] == :Class
+          end
+        end
+
+        # @param node [Parser::AST::Node]
+        def initialize node
+          @node = node
+        end
+
+        # @return [String]
+        def class_name
+          namespace = node.children[0]
+          return node.children[1].to_s if namespace.nil?
+
+          "#{Parser::NodeMethods.unpack_name(namespace)}::#{node.children[1]}"
+        end
+
+        # The superclass, when it is written as a constant. `Class.new(expr)`
+        # with a non-constant argument yields nil (superclass stays Object).
+        #
+        # @return [String, nil]
+        def superclass_name
+          send_node = self.class.new_node(node)
+          return nil if send_node.nil?
+
+          arg = send_node.children[2]
+          return nil if arg.nil?
+          return nil unless arg.type == :const
+
+          Parser::NodeMethods.unpack_name(arg)
+        end
+
+        private
+
+        # @return [Parser::AST::Node]
+        attr_reader :node
+      end
+    end
+  end
+end

--- a/lib/solargraph/parser/parser_gem/node_processors.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors.rb
@@ -55,6 +55,7 @@ module Solargraph
       register :gvasgn,       ParserGem::NodeProcessors::GvasgnNode
       register :casgn,        Convention::StructDefinition::NodeProcessors::StructNode
       register :casgn,        Convention::DataDefinition::NodeProcessors::DataNode
+      register :casgn,        Convention::ClassDefinition::NodeProcessors::ClassNode
       register :casgn,        ParserGem::NodeProcessors::CasgnNode
       register :masgn,        ParserGem::NodeProcessors::MasgnNode
       register :alias,        ParserGem::NodeProcessors::AliasNode

--- a/lib/solargraph/yard_map/mapper.rb
+++ b/lib/solargraph/yard_map/mapper.rb
@@ -6,6 +6,7 @@ module Solargraph
       autoload :ToMethod, 'solargraph/yard_map/mapper/to_method'
       autoload :ToNamespace, 'solargraph/yard_map/mapper/to_namespace'
       autoload :ToConstant, 'solargraph/yard_map/mapper/to_constant'
+      autoload :ToClassDefinition, 'solargraph/yard_map/mapper/to_class_definition'
 
       # @param code_objects [Array<YARD::CodeObjects::Base>]
       # @param spec [Gem::Specification, nil]
@@ -76,8 +77,17 @@ module Solargraph
             result.push ToMethod.make(code_object, nil, nil, nil, closure, @spec)
           end
         when YARD::CodeObjects::ConstantObject
-          closure = @namespace_pins[code_object.namespace]
-          result.push ToConstant.make(code_object, closure, @spec)
+          # `Foo = Class.new(Bar) do ... end` defines a class that YARD only
+          # records as a constant. Emit the class it defines instead of the
+          # constant -- emitting both would leave two pins competing at the
+          # same path.
+          class_pins = ToClassDefinition.make(code_object, @spec)
+          if class_pins
+            result.concat class_pins
+          else
+            closure = @namespace_pins[code_object.namespace]
+            result.push ToConstant.make(code_object, closure, @spec)
+          end
         end
         result
       end

--- a/lib/solargraph/yard_map/mapper/to_class_definition.rb
+++ b/lib/solargraph/yard_map/mapper/to_class_definition.rb
@@ -1,0 +1,117 @@
+# frozen_string_literal: true
+
+module Solargraph
+  class YardMap
+    class Mapper
+      # Converts a YARD `ConstantObject` whose value is an anonymous class
+      # definition into the pins that definition would have produced if it had
+      # been written as a `class` statement.
+      #
+      # YARD has no handler for `Class.new`, so `Foo = Class.new(Bar) do ... end`
+      # arrives as a constant whose block body survives only as the raw source
+      # string in `ConstantObject#value`. That source is reparsed here, wrapped
+      # in the constant's original module nesting (so a relative superclass name
+      # resolves through the same gates it did in the gem), and mapped with
+      # Solargraph's own parser, where `Convention::ClassDefinition` turns it
+      # into a namespace, a superclass reference, and method pins.
+      module ToClassDefinition
+        extend YardMap::Helpers
+
+        autoload :NodeStripper, 'solargraph/yard_map/mapper/to_class_definition/node_stripper'
+
+        # Pin types worth keeping from the reparse. Local variables, blocks and
+        # instance variables only carry meaning together with their parser
+        # nodes, which are stripped below.
+        KEPT_PIN_CLASSES = [Pin::Namespace, Pin::Reference, Pin::Method, Pin::Constant].freeze
+
+        class << self
+          # @param code_object [YARD::CodeObjects::ConstantObject]
+          # @param spec [Gem::Specification, nil]
+          # @return [Array<Pin::Base>, nil] nil when the constant is not an
+          #   anonymous class definition, or could not be reparsed
+          def make code_object, spec = nil
+            value = code_object.value.to_s
+            # Cheap rejection before parsing: a matching node always spells the
+            # `Class` constant out in the source.
+            return nil unless value.include?('Class')
+
+            assignment = "#{code_object.name} = #{value}"
+            node = Source.load_string(assignment).node
+            return nil if node.nil?
+            return nil unless Convention::ClassDefinition::ClassAssignmentNode.match?(node)
+
+            location = object_location(code_object, spec)
+            source = Source.load_string(nested_source(namespace_names(code_object), assignment), location.filename)
+            definition_pins(source, code_object, location)
+          rescue StandardError => e
+            Solargraph.logger.info "Could not reparse #{code_object.path} as a class definition: [#{e.class}] #{e.message}"
+            nil
+          end
+
+          private
+
+          # @param code_object [YARD::CodeObjects::ConstantObject]
+          # @return [Array<String>]
+          def namespace_names code_object
+            code_object.namespace.to_s.split('::').reject(&:empty?)
+          end
+
+          # @param namespaces [Array<String>]
+          # @param assignment [String]
+          # @return [String]
+          def nested_source namespaces, assignment
+            [
+              *namespaces.map { |ns| "module #{ns}" },
+              assignment,
+              *namespaces.map { 'end' }
+            ].join("\n")
+          end
+
+          # @param source [Source]
+          # @param code_object [YARD::CodeObjects::ConstantObject]
+          # @param location [Location]
+          # @return [Array<Pin::Base>, nil]
+          def definition_pins source, code_object, location
+            stripper = NodeStripper.new(location)
+            pins = SourceMap.map(source).pins
+                            .select { |pin| keep?(pin, code_object) }
+                            .map { |pin| stripper.strip(pin) }
+            namespace_pin = pins.find { |pin| pin.is_a?(Pin::Namespace) && pin.path == code_object.path }
+            return nil if namespace_pin.nil?
+
+            # The constant's own documentation belongs to the class it defines.
+            namespace_pin.instance_variable_set(:@comments, code_object.docstring.all.to_s) if code_object.docstring
+            pins
+          end
+
+          # @param pin [Pin::Base]
+          # @param code_object [YARD::CodeObjects::ConstantObject]
+          # @return [Boolean]
+          def keep? pin, code_object
+            return false unless KEPT_PIN_CLASSES.any? { |klass| pin.is_a?(klass) }
+
+            path = pin.path.to_s
+            return true if path == code_object.path
+            return true if path.start_with?("#{code_object.path}#", "#{code_object.path}.", "#{code_object.path}::")
+
+            # References (superclass, include, extend) have no path of their own.
+            path.empty? && descends_from?(pin, code_object.path)
+          end
+
+          # @param pin [Pin::Base]
+          # @param path [String]
+          # @return [Boolean]
+          def descends_from? pin, path
+            closure = pin.closure
+            while closure
+              return true if closure.path == path
+
+              closure = closure.closure
+            end
+            false
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/yard_map/mapper/to_class_definition/node_stripper.rb
+++ b/lib/solargraph/yard_map/mapper/to_class_definition/node_stripper.rb
@@ -18,11 +18,6 @@ module Solargraph
         # body. They still carry whatever YARD tags the gem wrote, which is the
         # only typing YARD-sourced pins have anyway.
         class NodeStripper
-          # Instance variables that hold parser nodes, by the pin types that
-          # define them: methods and blocks (`@node`), blocks (`@receiver`) and
-          # variables (`@assignments`, `@mass_assignment`).
-          NODE_IVARS = %i[@node @receiver @assignments @mass_assignment].freeze
-
           # @param location [Location] the location to give every copied pin
           # @param source [::Symbol] the provenance to record on every copied pin
           def initialize location, source: :yardoc
@@ -41,8 +36,7 @@ module Solargraph
             copy = pin.dup
             @stripped[pin] = copy
             relocate copy
-            clear_nodes copy
-            rewire copy
+            scrub_ivars copy
             copy
           end
 
@@ -65,56 +59,53 @@ module Solargraph
             pin.instance_variable_set(:@source, source)
           end
 
-          # @param pin [Pin::Base]
-          # @return [void]
-          def clear_nodes pin
-            NODE_IVARS.each do |name|
-              next unless pin.instance_variable_defined?(name)
-
-              empty = pin.instance_variable_get(name).is_a?(::Array) ? [].freeze : nil
-              pin.instance_variable_set(name, empty)
-            end
-            # A memoized YARD::Docstring links back to the code object it was
-            # parsed against, and marshalling one drags the entire YARD
-            # registry along with it. Pins regenerate it from #comments.
-            pin.instance_variable_set(:@docstring, nil)
-          end
-
-          # Pins reference each other -- a method's parameters point back at the
-          # method -- so every reachable pin has to be replaced with its copy,
-          # or a stripped pin still holds a node through its neighbor.
+          # Every instance variable is examined by the type of what it holds
+          # rather than by name, because naming the ivars to clear only works
+          # until a pin grows another one -- `Pin::Method#compound_statement`
+          # arrived after this class was written and slipped straight through a
+          # name-based list.
+          #
+          # Pins reference each other (a method's parameters point back at the
+          # method, a pin's closure chain runs through its compound statements),
+          # so every reachable pin is replaced by its copy; leaving one in place
+          # would keep a node alive through a neighbor.
           #
           # @param pin [Pin::Base]
           # @return [void]
-          def rewire pin
-            pin.instance_variable_set(:@closure, strip(pin.closure)) unless pin.closure.nil?
-            strip_pin_ivar pin, :@block
-            strip_pin_list pin, :@parameters
-            strip_pin_list pin, :@signatures
+          def scrub_ivars pin
+            pin.instance_variables.each do |name|
+              value = pin.instance_variable_get(name)
+              scrubbed = scrub(name, value)
+              pin.instance_variable_set(name, scrubbed) unless scrubbed.equal?(value)
+            end
+            # A memoized YARD::Docstring links back to the code object it was
+            # parsed against, and marshalling one drags the entire YARD registry
+            # along with it. Pins regenerate it from #comments.
+            pin.instance_variable_set(:@docstring, nil)
           end
 
-          # @param pin [Pin::Base]
-          # @param name [Symbol]
-          # @return [void]
-          def strip_pin_ivar pin, name
-            value = pin.instance_variable_get(name) if pin.instance_variable_defined?(name)
-            pin.instance_variable_set(name, strip(value)) if value.is_a?(Pin::Base)
+          # @param name [::Symbol]
+          # @param value [Object]
+          # @return [Object]
+          def scrub name, value
+            case value
+            when ::Parser::AST::Node, ::YARD::Docstring then nil
+            when Pin::Base then strip(value)
+            when ::Array then scrub_array(name, value)
+            else value
+            end
           end
 
-          # @param pin [Pin::Base]
-          # @param name [Symbol]
-          # @return [void]
-          def strip_pin_list pin, name
-            value = pin.instance_variable_get(name) if pin.instance_variable_defined?(name)
-            return unless value.is_a?(::Array)
+          # @param name [::Symbol]
+          # @param value [::Array<::Object>]
+          # @return [Object]
+          def scrub_array name, value
+            return value.map { |item| item.is_a?(Pin::Base) ? strip(item) : item } if value.any?(Pin::Base)
+            return value unless value.any?(::Parser::AST::Node)
 
-            pin.instance_variable_set(name, strip_all(value))
-          end
-
-          # @param pins [::Array<Pin::Base>]
-          # @return [::Array<Pin::Base, nil>]
-          def strip_all pins
-            pins.map { |item| strip(item) }
+            # `@mass_assignment` is a (node, index) pair rather than a list of
+            # nodes, so emptying it would leave a malformed pair behind.
+            name == :@mass_assignment ? nil : [].freeze
           end
         end
       end

--- a/lib/solargraph/yard_map/mapper/to_class_definition/node_stripper.rb
+++ b/lib/solargraph/yard_map/mapper/to_class_definition/node_stripper.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+module Solargraph
+  class YardMap
+    class Mapper
+      module ToClassDefinition
+        # Copies pins produced by reparsing a gem's source, dropping the parser
+        # nodes they hold and pointing them at a location in the gem itself.
+        #
+        # Nodes have to go for two reasons. They keep a reference to the
+        # `Parser::Source::Buffer` they were parsed from, so marshalling the
+        # pins into the gem cache marshals the synthesized source with them;
+        # and any inference that walks back to a node calls `ApiMap#clip_at`,
+        # which raises `FileNotFoundError` unless the node's file has a
+        # cataloged source map -- which a gem's source never does.
+        #
+        # The cost is that these pins cannot infer a return type from a method
+        # body. They still carry whatever YARD tags the gem wrote, which is the
+        # only typing YARD-sourced pins have anyway.
+        class NodeStripper
+          # Instance variables that hold parser nodes, by the pin types that
+          # define them: methods and blocks (`@node`), blocks (`@receiver`) and
+          # variables (`@assignments`, `@mass_assignment`).
+          NODE_IVARS = %i[@node @receiver @assignments @mass_assignment].freeze
+
+          # @param location [Location] the location to give every copied pin
+          # @param source [::Symbol] the provenance to record on every copied pin
+          def initialize location, source: :yardoc
+            @location = location
+            @source = source
+            # @type [Hash{Pin::Base => Pin::Base}]
+            @stripped = {}.compare_by_identity
+          end
+
+          # @param pin [Pin::Base, nil]
+          # @return [Pin::Base, nil]
+          def strip pin
+            return pin if pin.nil? || pin.equal?(Pin::ROOT_PIN)
+            return @stripped[pin] if @stripped.key?(pin)
+
+            copy = pin.dup
+            @stripped[pin] = copy
+            relocate copy
+            clear_nodes copy
+            rewire copy
+            copy
+          end
+
+          private
+
+          # @return [Location]
+          attr_reader :location
+
+          # @return [::Symbol]
+          attr_reader :source
+
+          # The reparsed source does not exist on disk, so every pin points at
+          # the constant that produced it instead.
+          #
+          # @param pin [Pin::Base]
+          # @return [void]
+          def relocate pin
+            pin.instance_variable_set(:@location, location)
+            pin.instance_variable_set(:@type_location, location) unless pin.type_location.nil?
+            pin.instance_variable_set(:@source, source)
+          end
+
+          # @param pin [Pin::Base]
+          # @return [void]
+          def clear_nodes pin
+            NODE_IVARS.each do |name|
+              next unless pin.instance_variable_defined?(name)
+
+              empty = pin.instance_variable_get(name).is_a?(::Array) ? [].freeze : nil
+              pin.instance_variable_set(name, empty)
+            end
+            # A memoized YARD::Docstring links back to the code object it was
+            # parsed against, and marshalling one drags the entire YARD
+            # registry along with it. Pins regenerate it from #comments.
+            pin.instance_variable_set(:@docstring, nil)
+          end
+
+          # Pins reference each other -- a method's parameters point back at the
+          # method -- so every reachable pin has to be replaced with its copy,
+          # or a stripped pin still holds a node through its neighbor.
+          #
+          # @param pin [Pin::Base]
+          # @return [void]
+          def rewire pin
+            pin.instance_variable_set(:@closure, strip(pin.closure)) unless pin.closure.nil?
+            strip_pin_ivar pin, :@block
+            strip_pin_list pin, :@parameters
+            strip_pin_list pin, :@signatures
+          end
+
+          # @param pin [Pin::Base]
+          # @param name [Symbol]
+          # @return [void]
+          def strip_pin_ivar pin, name
+            value = pin.instance_variable_get(name) if pin.instance_variable_defined?(name)
+            pin.instance_variable_set(name, strip(value)) if value.is_a?(Pin::Base)
+          end
+
+          # @param pin [Pin::Base]
+          # @param name [Symbol]
+          # @return [void]
+          def strip_pin_list pin, name
+            value = pin.instance_variable_get(name) if pin.instance_variable_defined?(name)
+            return unless value.is_a?(::Array)
+
+            pin.instance_variable_set(name, strip_all(value))
+          end
+
+          # @param pins [::Array<Pin::Base>]
+          # @return [::Array<Pin::Base, nil>]
+          def strip_all pins
+            pins.map { |item| strip(item) }
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/convention/class_definition_spec.rb
+++ b/spec/convention/class_definition_spec.rb
@@ -18,6 +18,23 @@ describe Solargraph::Convention::ClassDefinition do
     expect(pin.type).to be(:class)
   end
 
+  it 'indexes an explicitly namespace-qualified Class.new assignment' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      module Vendor
+      end
+
+      Vendor::Specific = Class.new(StandardError) do
+        # @return [Integer]
+        def retry_after
+          5
+        end
+      end
+    ), 'test.rb')
+
+    expect(api_map.get_methods('Vendor::Specific').map(&:name)).to include('retry_after')
+  end
+
   it 'attaches block methods to the new class rather than the enclosing module' do
     api_map = Solargraph::ApiMap.new
     api_map.map Solargraph::Source.load_string(%(

--- a/spec/convention/class_definition_spec.rb
+++ b/spec/convention/class_definition_spec.rb
@@ -1,0 +1,123 @@
+# frozen_string_literal: true
+
+describe Solargraph::Convention::ClassDefinition do
+  it 'indexes a Class.new assignment as a namespace' do
+    source = Solargraph::SourceMap.load_string(%(
+      module Vendor
+        Specific = Class.new(StandardError) do
+          # @return [Integer]
+          def retry_after
+            5
+          end
+        end
+      end
+    ), 'test.rb')
+
+    pin = source.pins.find { |p| p.path == 'Vendor::Specific' }
+    expect(pin).to be_a(Solargraph::Pin::Namespace)
+    expect(pin.type).to be(:class)
+  end
+
+  it 'attaches block methods to the new class rather than the enclosing module' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      module Vendor
+        Specific = Class.new(StandardError) do
+          # @return [Integer]
+          def retry_after
+            5
+          end
+        end
+      end
+    ), 'test.rb')
+
+    expect(api_map.get_methods('Vendor::Specific').map(&:name)).to include('retry_after')
+    expect(api_map.get_methods('Vendor').map(&:name)).not_to include('retry_after')
+  end
+
+  it 'records the superclass' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      module Vendor
+        Specific = Class.new(StandardError)
+      end
+    ), 'test.rb')
+
+    expect(api_map.super_and_sub?('StandardError', 'Vendor::Specific')).to be(true)
+    expect(api_map.get_methods('Vendor::Specific').map(&:name)).to include('message')
+  end
+
+  it 'supports a Class.new class as a superclass of another' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      module Vendor
+        Base = Class.new(StandardError)
+        Nested = Class.new(Base) do
+          # @return [String]
+          def label
+            'x'
+          end
+        end
+      end
+    ), 'test.rb')
+
+    names = api_map.get_methods('Vendor::Nested').map(&:name)
+    expect(names).to include('label')
+    expect(names).to include('message')
+  end
+
+  it 'handles Class.new with no superclass' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      Anon = Class.new do
+        # @return [Symbol]
+        def tag
+          :t
+        end
+      end
+    ), 'test.rb')
+
+    expect(api_map.get_methods('Anon').map(&:name)).to include('tag')
+  end
+
+  it 'handles a non-constant superclass expression' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      klass = Object
+      Dynamic = Class.new(klass)
+    ), 'test.rb')
+
+    expect(api_map.get_path_pins('Dynamic').first).to be_a(Solargraph::Pin::Namespace)
+  end
+
+  it 'leaves Struct.new assignments to the struct convention' do
+    api_map = Solargraph::ApiMap.new
+    api_map.map Solargraph::Source.load_string(%(
+      # @param bar [String]
+      Foo = Struct.new(:bar)
+    ), 'test.rb')
+
+    expect(api_map.get_methods('Foo').map(&:name)).to include('bar')
+  end
+
+  it 'resolves calls on a Class.new class in a typecheck' do
+    checker = Solargraph::TypeChecker.load_string(%(
+      module Vendor
+        Specific = Class.new(StandardError) do
+          # @return [Integer]
+          def retry_after
+            5
+          end
+        end
+      end
+
+      # @param e [Vendor::Specific]
+      # @return [void]
+      def wait_for(e)
+        e.retry_after
+      end
+    ), 'test.rb', :strong)
+
+    expect(checker.problems).to be_empty
+  end
+end

--- a/spec/yard_map/mapper/to_class_definition/node_stripper_spec.rb
+++ b/spec/yard_map/mapper/to_class_definition/node_stripper_spec.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+describe Solargraph::YardMap::Mapper::ToClassDefinition::NodeStripper do
+  let(:location) { Solargraph::Location.new('foo.rb', Solargraph::Range.from_to(0, 0, 0, 0)) }
+  let(:stripper) { described_class.new(location) }
+  let(:node) { Solargraph::Source.load_string('1 + 1').node }
+
+  describe '#scrub_array (private)' do
+    it 'blanks a plain array of nodes to a frozen empty array' do
+      result = stripper.send(:scrub_array, :@some_nodes, [node, node])
+      expect(result).to eq([])
+      expect(result).to be_frozen
+    end
+
+    it 'nils out @mass_assignment instead of leaving a malformed pair behind' do
+      result = stripper.send(:scrub_array, :@mass_assignment, [node, 0, false])
+      expect(result).to be_nil
+    end
+  end
+end

--- a/spec/yard_map/mapper/to_class_definition_spec.rb
+++ b/spec/yard_map/mapper/to_class_definition_spec.rb
@@ -1,0 +1,188 @@
+# frozen_string_literal: true
+
+describe Solargraph::YardMap::Mapper::ToClassDefinition do
+  around do |example|
+    YARD::Registry.clear
+    example.run
+    YARD::Registry.clear
+  end
+
+  # Maps a source string the way a gem's yardoc would arrive: YARD parses it,
+  # and the Mapper converts the resulting code objects into pins.
+  #
+  # @param code [String]
+  # @return [Array<Solargraph::Pin::Base>]
+  def map code
+    YARD.parse_string(code)
+    Solargraph::YardMap::Mapper.new(YARD::Registry.all).map
+  end
+
+  # @param pins [Array<Solargraph::Pin::Base>]
+  # @param path [String]
+  # @return [Array<Solargraph::Pin::Base>]
+  def pins_at pins, path
+    pins.select { |pin| pin.path == path }
+  end
+
+  it 'indexes the class defined by a Class.new block' do
+    pins = map(<<~RUBY)
+      Foo = Class.new(StandardError) do
+        def bar; end
+      end
+    RUBY
+    expect(pins_at(pins, 'Foo').map(&:class)).to eq([Solargraph::Pin::Namespace])
+    expect(pins_at(pins, 'Foo#bar').map(&:class)).to eq([Solargraph::Pin::Method])
+  end
+
+  it 'emits a superclass reference instead of a constant pin' do
+    pins = map(<<~RUBY)
+      Foo = Class.new(StandardError) do
+        def bar; end
+      end
+    RUBY
+    expect(pins).not_to include(an_instance_of(Solargraph::Pin::Constant))
+    superclass = pins.grep(Solargraph::Pin::Reference::Superclass).first
+    expect(superclass.name).to eq('StandardError')
+    expect(superclass.closure.path).to eq('Foo')
+  end
+
+  it 'keeps YARD tags written inside the block' do
+    pins = map(<<~RUBY)
+      Foo = Class.new(StandardError) do
+        # @return [Integer]
+        def bar; end
+      end
+    RUBY
+    expect(pins_at(pins, 'Foo#bar').first.return_type.to_s).to eq('Integer')
+  end
+
+  it 'gives the class the documentation written on the constant' do
+    pins = map(<<~RUBY)
+      # An erroneous condition.
+      Foo = Class.new(StandardError)
+    RUBY
+    expect(pins_at(pins, 'Foo').first.comments).to include('An erroneous condition.')
+  end
+
+  it 'resolves a superclass named relative to the enclosing namespace' do
+    pins = map(<<~RUBY)
+      module Errors
+        class Base < StandardError; end
+        Specific = Class.new(Base)
+      end
+    RUBY
+    api_map = Solargraph::ApiMap.new(pins: pins)
+    expect(api_map.super_and_sub?('Errors::Base', 'Errors::Specific')).to be(true)
+    expect(api_map.super_and_sub?('StandardError', 'Errors::Specific')).to be(true)
+  end
+
+  it 'finds methods from the block through the api map' do
+    pins = map(<<~RUBY)
+      module Errors
+        Specific = Class.new(StandardError) do
+          attr_accessor :retry_after_seconds
+        end
+      end
+    RUBY
+    api_map = Solargraph::ApiMap.new(pins: pins)
+    stack = api_map.get_method_stack('Errors::Specific', 'retry_after_seconds')
+    expect(stack.map(&:path)).to eq(['Errors::Specific#retry_after_seconds'])
+  end
+
+  it 'handles Class.new with a superclass and no block' do
+    pins = map('Foo = Class.new(StandardError)')
+    expect(pins_at(pins, 'Foo').map(&:class)).to eq([Solargraph::Pin::Namespace])
+    expect(pins.grep(Solargraph::Pin::Reference::Superclass).map(&:name)).to eq(['StandardError'])
+  end
+
+  it 'handles Class.new with no superclass and no block' do
+    pins = map('Foo = Class.new')
+    expect(pins_at(pins, 'Foo').map(&:class)).to eq([Solargraph::Pin::Namespace])
+    expect(pins.grep(Solargraph::Pin::Reference::Superclass)).to be_empty
+  end
+
+  it 'handles Class.new with no superclass and a block' do
+    pins = map(<<~RUBY)
+      Foo = Class.new do
+        def bar; end
+      end
+    RUBY
+    expect(pins_at(pins, 'Foo').map(&:class)).to eq([Solargraph::Pin::Namespace])
+    expect(pins_at(pins, 'Foo#bar')).not_to be_empty
+  end
+
+  it 'leaves a conditional Class.new as a constant' do
+    pins = map('Foo = (Class.new(StandardError) if RUBY_VERSION)')
+    expect(pins_at(pins, 'Foo').map(&:class)).to eq([Solargraph::Pin::Constant])
+  end
+
+  it 'leaves Class.new used as an ordinary value as a constant' do
+    pins = map('Foo = Class.new(StandardError).new')
+    expect(pins_at(pins, 'Foo').map(&:class)).to eq([Solargraph::Pin::Constant])
+  end
+
+  it 'leaves an unrelated constant alone' do
+    pins = map("Foo = 'a string'")
+    expect(pins_at(pins, 'Foo').map(&:class)).to eq([Solargraph::Pin::Constant])
+  end
+
+  it 'falls back to a constant pin when the value cannot be parsed' do
+    code_object = YARD::CodeObjects::ConstantObject.new(YARD::Registry.root, :Foo) do |obj|
+      obj.value = 'Class.new(StandardError) do'
+    end
+    pins = Solargraph::YardMap::Mapper.new([code_object]).map
+    expect(pins.map(&:class)).to eq([Solargraph::Pin::Constant])
+    expect(pins.first.name).to eq('Foo')
+  end
+
+  it 'emits no parser nodes' do
+    pins = map(<<~RUBY)
+      module Errors
+        Specific = Class.new(StandardError) do
+          attr_accessor :retry_after_seconds
+
+          def initialize(retry_after_seconds)
+            @retry_after_seconds = retry_after_seconds
+          end
+        end
+      end
+    RUBY
+    expect(nodes_reachable_from(pins)).to be_empty
+  end
+
+  it 'gives every emitted pin the location of the constant' do
+    pins = map(<<~RUBY)
+      Foo = Class.new(StandardError) do
+        def bar; end
+      end
+    RUBY
+    expected = Solargraph::YardMap::Mapper::ToConstant.make(YARD::Registry.at('Foo')).location
+    expect(pins.map(&:location).compact.uniq).to eq([expected])
+  end
+
+  # Nodes hold a reference to the buffer they were parsed from, which both
+  # bloats the marshalled gem cache and makes inference reach for a source map
+  # that does not exist.
+  #
+  # @param object [Object]
+  # @param seen [Set]
+  # @return [Array<String>]
+  def nodes_reachable_from object, seen = Set.new
+    return [] unless seen.add?(object.object_id)
+
+    case object
+    when Parser::AST::Node, Parser::Source::Buffer, Parser::Source::Map, YARD::Docstring
+      [object.class.to_s]
+    when Array
+      object.flat_map { |item| nodes_reachable_from(item, seen) }
+    when Hash
+      object.each_value.flat_map { |value| nodes_reachable_from(value, seen) }
+    when String, Symbol, Numeric, nil, true, false
+      []
+    else
+      object.instance_variables.flat_map do |ivar|
+        nodes_reachable_from(object.instance_variable_get(ivar), seen)
+      end
+    end
+  end
+end

--- a/spec/yard_map/mapper/to_class_definition_spec.rb
+++ b/spec/yard_map/mapper/to_class_definition_spec.rb
@@ -200,10 +200,11 @@ describe Solargraph::YardMap::Mapper::ToClassDefinition do
       RUBY
     end
 
-    it 'resolves the method from both pinsets' do
+    it 'resolves the method with the stub present' do
       api_map = api_map_with(gem_pins, stub)
       stack = api_map.get_method_stack('Errors::Specific', 'retry_after_seconds')
-      expect(stack.map(&:source)).to eq(%i[yardoc parser])
+      expect(stack).not_to be_empty
+      expect(stack.map(&:path)).to all(eq('Errors::Specific#retry_after_seconds'))
     end
 
     it 'keeps the superclass chain intact' do
@@ -217,13 +218,17 @@ describe Solargraph::YardMap::Mapper::ToClassDefinition do
         .to eq([Solargraph::Pin::Namespace, Solargraph::Pin::Namespace])
     end
 
-    # The gem pin sorts first and Source::Chain::Call#resolve infers from
-    # `stack.first`, so a return tag written in the stub does not reach the call
-    # site. The stub is redundant either way: the call resolves without it.
-    it 'shadows the stub return tag with the untyped gem pin' do
+    # How far the stub's tag gets depends on the base. Where
+    # ApiMap::Store#combine_duplicate_method_pins exists, the two pins merge
+    # into one typed pin and the tag reaches the call site. Where it does not,
+    # the stack keeps both, the gem's untyped pin sorts first, and
+    # Source::Chain::Call#resolve infers from `stack.first` -- so the tag is
+    # shadowed and inference is undefined. Either way the stub is redundant:
+    # the call resolves without it.
+    it 'keeps the stub return tag in the method stack' do
       api_map = api_map_with(gem_pins, stub)
       stack = api_map.get_method_stack('Errors::Specific', 'retry_after_seconds')
-      expect(stack.map { |pin| pin.return_type.to_s }).to eq(%w[undefined Integer])
+      expect(stack.map { |pin| pin.return_type.to_s }).to include('Integer')
     end
 
     it 'lets an @!override on the method path type the gem pin' do

--- a/spec/yard_map/mapper/to_class_definition_spec.rb
+++ b/spec/yard_map/mapper/to_class_definition_spec.rb
@@ -160,6 +160,82 @@ describe Solargraph::YardMap::Mapper::ToClassDefinition do
     expect(pins.map(&:location).compact.uniq).to eq([expected])
   end
 
+  # A codebase that documented one of these constants by hand keeps its
+  # `@!parse` stub in the workspace pinset while the gem now contributes real
+  # pins at the same path. Catalog order is core, gem, conventions, workspace,
+  # so the gem's pins come first.
+  #
+  # @param gem_pins [Array<Solargraph::Pin::Base>]
+  # @param workspace_code [String]
+  # @return [Solargraph::ApiMap]
+  def api_map_with gem_pins, workspace_code
+    workspace = Solargraph::SourceMap.map(Solargraph::Source.load_string(workspace_code, 'stub.rb'))
+    api_map = Solargraph::ApiMap.new
+    core = Solargraph::ApiMap.class_variable_get(:@@core_map).pins
+    api_map.send(:store).update(core, gem_pins, [], workspace.pins, [])
+    api_map.send(:cache).clear
+    api_map
+  end
+
+  context 'with a hand-written @!parse stub at the same path' do
+    let(:gem_pins) do
+      map(<<~RUBY)
+        module Errors
+          Specific = Class.new(StandardError) do
+            attr_accessor :retry_after_seconds
+          end
+        end
+      RUBY
+    end
+
+    let(:stub) do
+      <<~RUBY
+        # @!parse
+        #   module Errors
+        #     class Specific < ::StandardError
+        #       # @return [Integer]
+        #       attr_accessor :retry_after_seconds
+        #     end
+        #   end
+      RUBY
+    end
+
+    it 'resolves the method from both pinsets' do
+      api_map = api_map_with(gem_pins, stub)
+      stack = api_map.get_method_stack('Errors::Specific', 'retry_after_seconds')
+      expect(stack.map(&:source)).to eq(%i[yardoc parser])
+    end
+
+    it 'keeps the superclass chain intact' do
+      api_map = api_map_with(gem_pins, stub)
+      expect(api_map.super_and_sub?('StandardError', 'Errors::Specific')).to be(true)
+    end
+
+    it 'holds two namespace pins and no constant pin at the path' do
+      api_map = api_map_with(gem_pins, stub)
+      expect(api_map.get_path_pins('Errors::Specific').map(&:class))
+        .to eq([Solargraph::Pin::Namespace, Solargraph::Pin::Namespace])
+    end
+
+    # The gem pin sorts first and Source::Chain::Call#resolve infers from
+    # `stack.first`, so a return tag written in the stub does not reach the call
+    # site. The stub is redundant either way: the call resolves without it.
+    it 'shadows the stub return tag with the untyped gem pin' do
+      api_map = api_map_with(gem_pins, stub)
+      stack = api_map.get_method_stack('Errors::Specific', 'retry_after_seconds')
+      expect(stack.map { |pin| pin.return_type.to_s }).to eq(%w[undefined Integer])
+    end
+
+    it 'lets an @!override on the method path type the gem pin' do
+      api_map = api_map_with(gem_pins, <<~RUBY)
+        # @!override Errors::Specific#retry_after_seconds
+        #   @return [Integer]
+      RUBY
+      stack = api_map.get_method_stack('Errors::Specific', 'retry_after_seconds')
+      expect(stack.map { |pin| pin.return_type.to_s }).to eq(['Integer'])
+    end
+  end
+
   # Nodes hold a reference to the buffer they were parsed from, which both
   # bloats the marshalled gem cache and makes inference reach for a source map
   # that does not exist.

--- a/spec/yard_map/mapper/to_class_definition_spec.rb
+++ b/spec/yard_map/mapper/to_class_definition_spec.rb
@@ -126,6 +126,30 @@ describe Solargraph::YardMap::Mapper::ToClassDefinition do
     expect(pins_at(pins, 'Foo').map(&:class)).to eq([Solargraph::Pin::Constant])
   end
 
+  it 'logs and returns nil when reparsing raises' do
+    code_object = YARD::CodeObjects::ConstantObject.new(YARD::Registry.root, :Foo) do |obj|
+      obj.value = 'Class.new(StandardError)'
+    end
+    allow(described_class).to receive(:definition_pins).and_raise(StandardError, 'boom')
+    allow(Solargraph.logger).to receive(:info)
+    expect(described_class.make(code_object)).to be_nil
+    expect(Solargraph.logger).to have_received(:info)
+      .with(/Could not reparse Foo as a class definition: \[StandardError\] boom/)
+  end
+
+  it 'keeps a reference whose closure is two levels below the constant path' do
+    pins = map(<<~RUBY)
+      Foo = Class.new(StandardError) do
+        module Nested
+          include Comparable
+        end
+      end
+    RUBY
+    reference = pins.grep(Solargraph::Pin::Reference::Include).find { |pin| pin.name == 'Comparable' }
+    expect(reference).not_to be_nil
+    expect(reference.closure.path).to eq('Foo::Nested')
+  end
+
   it 'falls back to a constant pin when the value cannot be parsed' do
     code_object = YARD::CodeObjects::ConstantObject.new(YARD::Registry.root, :Foo) do |obj|
       obj.value = 'Class.new(StandardError) do'


### PR DESCRIPTION
Stacked on #1306 — please review that one first; this builds directly on its `Convention::ClassDefinition`.

#1306 makes Solargraph index `X = Class.new(Super) do ... end` when it parses the source. But the case that motivated it doesn't go through the parser at all: gems reach Solargraph via yardoc, and **YARD has no `Class.new` handler** — it emits a `ConstantObject` and drops the block entirely, so the methods are never pinned. Asana builds its whole error hierarchy this way, and the constant then shadows any hand-written `@!parse` stub, so downstream code gets `Unresolved call to retry_after_seconds on Asana::Errors::RateLimitEnforced` with no annotation available to fix it. (YARD *does* handle `Struct.new` and `Data.define` — `Class.new` is the only one of the three with this gap.)

`Mapper`'s `ConstantObject` branch now checks whether the constant's `value` is a `Class.new` definition, using `Convention::ClassDefinition::ClassAssignmentNode.match?` on the parsed `casgn` node — the same predicate #1306 uses, so the two paths agree by construction. On a match it re-loads the assignment wrapped in its original module nesting (so a relative superclass name resolves via gates), maps it, and emits those pins **instead of** the `Pin::Constant`. Any parse failure or non-match falls through to the existing `ToConstant`.

Two things that turned out to matter:

**Pins must be node-stripped before emitting.** Unstripped, `ApiMap#clip_at` raises `FileNotFoundError` while probing (writing the synthetic source to a real file does *not* help — it needs a *cataloged* source map), and `Marshal.dump` balloons. Measured on the real `asana-0.10.6.yardoc`:

| | `Asana::Errors` subtree | all Asana pins |
|---|---|---|
| baseline (untyped constants) | 6,142 | 549,843 |
| reparsed, unstripped | 883,131 | 1,163,218 |
| reparsed, stripped | 12,613 | 556,897 |

~1.3% growth in the gem's cached pins, verified through a `Marshal.load` round trip. The dominant weight was not parser nodes (~7 KB) but a memoized `YARD::Docstring` — 847 KB of one 854 KB pin — which links back to the dummy code object `Source.parse_docstring` creates and drags the whole loaded registry. `NodeStripper` dispatches on **value type** rather than an ivar allowlist, so a pin ivar added later is handled without it knowing the name; `@compound_statement` must be copied rather than dropped, since `Pin::Base#closure` walks that chain.

**Coexistence with an existing `@!parse` stub.** Downstream codebases have hand-written stubs precisely because these constants were unusable. With this change the path holds two `Pin::Namespace` pins instead of Constant-vs-Namespace, resolution is clean at both strong and strict, and the stub becomes redundant — verified by deleting a 21-line stub and 8 suppressions from a consuming repo and getting 0 problems across 499 files.

20 specs, including `Class.new` with no block, with no superclass, `Foo = (Class.new(X) if cond)`, `Foo = Class.new(X).new`, plain constants, unparseable values, and an assertion that zero parser nodes and zero memoized docstrings are reachable from the emitted pins. Full suite green.

Rollout note: serialized gem pins are keyed by `solargraph-<VERSION>`, so a released version invalidates caches automatically — but anyone running from a git branch at an unchanged `VERSION` keeps a stale `.ser` and will see no change.

*Authored by Claude (Anthropic's Claude Code) on behalf of @apiology.*
