### PR TITLE
Strip nil from or-expression fallbacks in conditional branch values

### DIFF
--- a/lib/solargraph/parser/parser_gem/node_methods.rb
+++ b/lib/solargraph/parser/parser_gem/node_methods.rb
@@ -610,10 +610,6 @@ module Solargraph
                   # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
                   result.concat reduce_to_value_nodes([node.children[0]])
                 # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
-                elsif node.type == :or
-                  # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
-                  result.concat reduce_to_value_nodes(node.children)
-                # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
                 elsif node.type == :block
                   # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
                   result.concat explicit_return_values_from_compound_statement(node.children[2])

--- a/spec/parser/node_methods_spec.rb
+++ b/spec/parser/node_methods_spec.rb
@@ -121,6 +121,21 @@ describe Solargraph::Parser::NodeMethods do
     expect(returns.map(&:to_s)).to eq(['(true)', '(int 73)', '(false)', '(nil)', '(false)', '(true)'])
   end
 
+  it 'keeps an or-node whole when it is a conditional branch value' do
+    node = parse(%(
+      if m.nil?
+        fallback
+      else
+        m <= expected || fallback
+      end
+    ))
+    returns = described_class.returns_from_method_body(node)
+    # The or-node must stay intact so chain inference (Chain::Or) can
+    # strip nil from the left operand when the right operand is not
+    # nullable; flattening it into both operands loses that.
+    expect(returns.map(&:type)).to eq(%i[send or])
+  end
+
   it 'handles return nodes from case statements with boolean conditions' do
     node = parse(%(
       case true
@@ -166,9 +181,10 @@ describe Solargraph::Parser::NodeMethods do
   it "handles nested 'or' nodes" do
     node = parse('return 1 || "2"')
     rets = described_class.returns_from_method_body(node)
-    expect(rets.length).to eq(2)
-    expect(described_class.infer_literal_node_type(rets[0])).to eq('::Integer')
-    expect(described_class.infer_literal_node_type(rets[1])).to eq('::String')
+    # The or-node stays whole so Chain::Or can union the operands and
+    # strip nil from the left one when the right is not nullable
+    expect(rets.length).to eq(1)
+    expect(rets[0].type).to eq(:or)
   end
 
   it 'finds return nodes in blocks' do
@@ -295,7 +311,7 @@ describe Solargraph::Parser::NodeMethods do
   it "handles nested 'or' nodes from return" do
     node = parse('return 1 || "2"')
     rets = described_class.returns_from_method_body(node)
-    expect(rets.map(&:type)).to eq(%i[int str])
+    expect(rets.map(&:type)).to eq(%i[or])
   end
 
   it 'handles return nodes from case statements' do

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -299,6 +299,29 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.first.message).to include('Missing @return tag')
     end
 
+    it 'strips nil from an or-expression fallback in a conditional branch' do
+      checker = type_checker(%(
+        class Container
+          # @param m [Module, nil]
+          # @param expected [Module]
+          # @return [Boolean]
+          def check(m, expected)
+            if m.nil?
+              fallback
+            else
+              m <= expected || fallback
+            end
+          end
+
+          # @return [Boolean]
+          def fallback
+            true
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     it 'calls out keyword issues even when required arg count matches' do
       checker = type_checker(%(
         # @param a [String]


### PR DESCRIPTION
At strong level, a method whose declared `@return` is `::Boolean` is flagged `Declared return type ::Boolean does not match inferred type ::Boolean, nil` when an or-expression with a nullable left operand is the value of a conditional branch ��� even though nil can't escape the `||`:

```ruby
class Container
  # @param m [Module, nil]
  # @param expected [Module]
  # @return [Boolean]
  def check(m, expected)
    if m.nil?
      fallback
    else
      m <= expected || fallback  # Module#<= returns bool?
    end
  end

  # @return [Boolean]
  def fallback
    true
  end
end
```

| shape | inferred |
|---|---|
| `m <= expected \|\| fallback` as method tail | `::Boolean` ��� |
| same, after `return fallback if m.nil?` guard | `::Boolean` ��� |
| same, as the else-branch value of if/else | `::Boolean, nil` ��� |

Root cause: [`DeepInference.reduce_to_value_nodes`](https://github.com/castwide/solargraph/blob/8fda63384dcf19568fdbf591b6e17d239c499e20/lib/solargraph/parser/parser_gem/node_methods.rb#L613) flattens an `:or` node into both operand nodes, typing each independently and unioning ��� bypassing `Chain::Or#resolve`, which strips nil from the union unless every operand is nullable. Method-tail or-expressions go through NodeChainer ��� `Chain::Or` and get that treatment; conditional branch values go through `reduce_to_value_nodes` and don't.

The fix drops the `:or` special case so the node stays whole and routes through `Chain::Or` like any other or-expression. Two existing node-level specs pinned the flattening as a contract (`return 1 || "2"` ��� two literal nodes); updated to expect the intact `:or` node ��� the operand union is preserved by `Chain::Or`.

Test plan:
- New failing-first specs: node_methods_spec (or-node stays whole) and strong_spec (no false positive on the repro shape)
- Full suite: 1,626 examples, 0 failures, 60 pending

���� This PR was written by Claude (Anthropic's AI assistant) on behalf of @apiology.

���� Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1FEjW6nMpZrWPmeWX9miT
