### PR TITLE
Name where inference stopped in typecheck inference errors

### DIFF
--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -180,14 +180,15 @@ module Solargraph
       # @param api_map [ApiMap]
       # @return [Source::Chain::LinkResolution, nil]
       def probe_blame api_map
-        return nil if closure.nil?
+        return nil if closure.nil? || location.nil?
 
         assignments.each do |parent_node|
           value_position_nodes_only(parent_node).each do |node|
             next if node.nil? || node.type == :NIL || node.type == :nil
             rng = Range.from_node(node)
             next if rng.nil?
-            # @sg-ignore Need to add nil check here
+            # @sg-ignore location nil-guarded at method entry; return-guard
+            #   narrowing not tracked - https://github.com/castwide/solargraph/issues/1254
             clip = api_map.clip_at(location.filename, rng.ending)
             chain = Parser.chain(node, nil, nil)
             # @sg-ignore closure nil-guarded at method entry; return-guard

--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -172,6 +172,33 @@ module Solargraph
         types
       end
 
+      # Locate where inference broke for this variable's assignment: the
+      # first link of the assigned expression's chain whose type resolved
+      # undefined. Diagnostic-only; returns nil when the assignment infers
+      # cleanly (or there is no assignment to walk).
+      #
+      # @param api_map [ApiMap]
+      # @return [Source::Chain::LinkResolution, nil]
+      def probe_blame api_map
+        return nil if closure.nil?
+
+        assignments.each do |parent_node|
+          value_position_nodes_only(parent_node).each do |node|
+            next if node.nil? || node.type == :NIL || node.type == :nil
+            rng = Range.from_node(node)
+            next if rng.nil?
+            # @sg-ignore Need to add nil check here
+            clip = api_map.clip_at(location.filename, rng.ending)
+            chain = Parser.chain(node, nil, nil)
+            # @sg-ignore closure nil-guarded at method entry; return-guard
+            #   narrowing not tracked - https://github.com/castwide/solargraph/issues/1254
+            failure = chain.first_undefined_link(api_map, closure, clip.locals)
+            return failure unless failure.nil?
+          end
+        end
+        nil
+      end
+
       # @param api_map [ApiMap]
       # @return [ComplexType, ComplexType::UniqueType]
       def probe api_map

--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -187,12 +187,10 @@ module Solargraph
             next if node.nil? || node.type == :NIL || node.type == :nil
             rng = Range.from_node(node)
             next if rng.nil?
-            # @sg-ignore location nil-guarded at method entry; return-guard
-            #   narrowing not tracked - https://github.com/castwide/solargraph/issues/1254
+            # @sg-ignore https://github.com/castwide/solargraph/issues/1254
             clip = api_map.clip_at(location.filename, rng.ending)
             chain = Parser.chain(node, nil, nil)
-            # @sg-ignore closure nil-guarded at method entry; return-guard
-            #   narrowing not tracked - https://github.com/castwide/solargraph/issues/1254
+            # @sg-ignore https://github.com/castwide/solargraph/issues/1254
             failure = chain.first_undefined_link(api_map, closure, clip.locals)
             return failure unless failure.nil?
           end

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -452,6 +452,37 @@ module Solargraph
         api_map.get_method_stack(method_namespace, method_name, scope: scope).reject { |pin| pin.path == path }
       end
 
+      # Locate where inference broke for this method's return value: the
+      # first failing link among its return-node chains. A failing
+      # bare-variable return delegates to that variable's own assignment,
+      # since the real failure is usually there. Diagnostic-only; nil when
+      # nothing failed or there is nothing to walk.
+      #
+      # @param api_map [ApiMap]
+      # @return [Source::Chain::LinkResolution, nil]
+      def probe_blame api_map
+        return nil if node.nil? || method_body_node.nil? || location.nil?
+        returns_from_method_body(method_body_node).each do |n|
+          next if n.nil? || %i[NIL nil].include?(n.type)
+          rng = Range.from_node(n)
+          next unless rng
+          # @sg-ignore location nil-guarded at method entry; return-guard
+          #   narrowing not tracked - https://github.com/castwide/solargraph/issues/1254
+          clip = api_map.clip_at(location.filename, rng.ending)
+          # @sg-ignore see above
+          chain = Solargraph::Parser.chain(n, location.filename)
+          failure = chain.first_undefined_link(api_map, self, clip.locals)
+          next if failure.nil?
+          if chain.links.one?
+            local = clip.locals.find { |l| l.is_a?(BaseVariable) && l.name == failure.link.word }
+            deeper = local&.probe_blame(api_map)
+            failure = deeper unless deeper.nil?
+          end
+          return failure
+        end
+        nil
+      end
+
       protected
 
       attr_writer :block, :signature_help, :documentation, :return_type

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -466,10 +466,9 @@ module Solargraph
           next if n.nil? || %i[NIL nil].include?(n.type)
           rng = Range.from_node(n)
           next unless rng
-          # @sg-ignore location nil-guarded at method entry; return-guard
-          #   narrowing not tracked - https://github.com/castwide/solargraph/issues/1254
+          # @sg-ignore https://github.com/castwide/solargraph/issues/1254
           clip = api_map.clip_at(location.filename, rng.ending)
-          # @sg-ignore see above
+          # @sg-ignore https://github.com/castwide/solargraph/issues/1254
           chain = Solargraph::Parser.chain(n, location.filename)
           failure = chain.first_undefined_link(api_map, self, clip.locals)
           next if failure.nil?

--- a/lib/solargraph/source/chain.rb
+++ b/lib/solargraph/source/chain.rb
@@ -177,6 +177,81 @@ module Solargraph
         out
       end
 
+      # One link's resolution outcome within a chain walk: which pins the
+      # link matched, the receiver (binder) type it was resolved against,
+      # and the type inferred from those pins. Undefined `type` (or zero
+      # pins) on a non-final record means every later link was skipped.
+      class LinkResolution
+        # @return [Chain::Link]
+        attr_reader :link
+
+        # @return [Integer] zero-based position of the link in its chain
+        attr_reader :index
+
+        # @return [Integer] number of links in the chain
+        attr_reader :total
+
+        # @return [ComplexType, ComplexType::UniqueType, nil] binder type the link was resolved against
+        attr_reader :receiver_type
+
+        # @return [Integer] pins the link matched
+        attr_reader :pin_count
+
+        # @return [ComplexType, ComplexType::UniqueType] type inferred from the matched pins
+        attr_reader :type
+
+        # @param link [Chain::Link]
+        # @param index [Integer]
+        # @param total [Integer]
+        # @param receiver_type [ComplexType, ComplexType::UniqueType, nil]
+        # @param pin_count [Integer]
+        # @param type [ComplexType, ComplexType::UniqueType]
+        def initialize link:, index:, total:, receiver_type:, pin_count:, type:
+          @link = link
+          @index = index
+          @total = total
+          @receiver_type = receiver_type
+          @pin_count = pin_count
+          @type = type
+        end
+      end
+
+      # Re-walk the chain the same way #define does, recording each link's
+      # resolution until the first link whose type is undefined. Uncached
+      # and intended for diagnostics on the error path, not inference.
+      #
+      # @param api_map [ApiMap]
+      # @param name_pin [Pin::Base]
+      # @param locals [::Array<Pin::LocalVariable>]
+      # @return [::Array<LinkResolution>]
+      def trace api_map, name_pin, locals
+        records = []
+        working_pin = name_pin
+        links.each_with_index do |link, index|
+          link.last_context = working_pin if index == links.length - 1
+          pins = link.resolve(api_map, working_pin, locals)
+          type = infer_from_definitions(pins, working_pin, api_map, locals)
+          records.push LinkResolution.new(link: link, index: index, total: links.length,
+                                          receiver_type: working_pin&.binder, pin_count: pins.length,
+                                          type: type)
+          return records if type.undefined?
+          working_pin = Pin::ProxyType.anonymous(name_pin.context, binder: type, closure: name_pin, source: :chain)
+        end
+        records
+      end
+
+      # The first link at which this chain's inference fails, or nil if
+      # every link resolves to a defined type.
+      #
+      # @param api_map [ApiMap]
+      # @param name_pin [Pin::Base]
+      # @param locals [::Array<Pin::LocalVariable>]
+      # @return [LinkResolution, nil]
+      def first_undefined_link api_map, name_pin, locals
+        failure = trace(api_map, name_pin, locals).last
+        failure if failure&.type&.undefined?
+      end
+
       # @return [Boolean]
       def literal?
         links.last.is_a?(Chain::Literal)

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -697,17 +697,14 @@ module Solargraph
     end
 
     # A short plain-language cause for the first failing link of a chain.
-    # The pin count picks the wording: zero pins means the name did not
-    # resolve at all; otherwise a definition exists but its return type
-    # could not be determined.
+    # Zero pins means the name did not resolve; otherwise a definition
+    # exists but its return type could not be determined.
     #
     # @param blame [Source::Chain::LinkResolution]
     # @return [String, nil] nil when the failing link has no name to report
     def blame_description blame
-      # The parser produced an undefined placeholder rather than a named
-      # link, so there is no name to report - say nothing rather than
-      # guessing. (Numbered block parameters land here.)
-      return nil if blame.link.word == '<undefined>'
+      # No name to report for an undefined link (e.g. a numbered block parameter).
+      return nil if blame.link.undefined?
 
       receiver = blame.receiver_type&.defined? ? " on #{blame.receiver_type}" : ''
       if blame.pin_count.zero?

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -706,7 +706,7 @@ module Solargraph
     def blame_description blame
       # The parser produced an undefined placeholder rather than a named
       # link, so there is no name to report - say nothing rather than
-      # guessing. (Numbered block parameters land here; see #NNNN.)
+      # guessing. (Numbered block parameters land here.)
       return nil if blame.link.word == '<undefined>'
 
       receiver = blame.receiver_type&.defined? ? " on #{blame.receiver_type}" : ''

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -175,7 +175,7 @@ module Solargraph
             # mixin, metaprogramming, etc.) isn't a tag/inference mismatch - just
             # unproven. Only methods with an actual body get flagged for this.
             unless rules.ignore_all_undefined? || external?(pin) || pin.attribute?
-              result.push Problem.new(pin.location, "#{pin.path} return type could not be inferred", pin: pin)
+              result.push Problem.new(pin.location, method_inference_message(pin), pin: pin)
             end
           else
             unless return_type_conforms_to?(inferred, declared)
@@ -267,7 +267,7 @@ module Solargraph
                 if declared_externally?(pin)
                   ignored_pins.push pin
                 else
-                  result.push Problem.new(pin.location, "Variable type could not be inferred for #{pin.name}", pin: pin)
+                  result.push Problem.new(pin.location, variable_inference_message(pin), pin: pin)
                 end
               else
                 unless assignment_conforms_to?(inferred, declared)
@@ -362,9 +362,9 @@ module Solargraph
           # @todo remove the internal_or_core? check at a higher-than-strict level
           if (!found || found.is_a?(Pin::BaseVariable) || (closest.defined? && internal_or_core?(found))) && !(closest.generic? || ignored_pins.include?(found))
             if closest.defined?
-              result.push Problem.new(location, "Unresolved call to #{missing.links.last.word} on #{closest}")
+              result.push Problem.new(location, "Unresolved call to #{missing.links.last&.word} on #{closest}")
             else
-              result.push Problem.new(location, "Unresolved call to #{missing.links.last.word}")
+              result.push Problem.new(location, "Unresolved call to #{missing.links.last&.word}")
             end
             @marked_ranges.push rng
           end
@@ -674,6 +674,47 @@ module Solargraph
       return false if pin.nil?
       # @sg-ignore flow sensitive typing needs to handle attrs
       pin.location && api_map.bundled?(pin.location.filename)
+    end
+
+    # @param pin [Pin::Method]
+    # @return [String]
+    def method_inference_message pin
+      message = "#{pin.path} return type could not be inferred"
+      blame = pin.probe_blame(api_map)
+      cause = blame_description(blame) unless blame.nil?
+      message += ": #{cause}" unless cause.nil?
+      message
+    end
+
+    # @param pin [Pin::BaseVariable]
+    # @return [String]
+    def variable_inference_message pin
+      message = "Variable type could not be inferred for #{pin.name}"
+      blame = pin.probe_blame(api_map)
+      cause = blame_description(blame) unless blame.nil?
+      message += ": #{cause}" unless cause.nil?
+      message
+    end
+
+    # A short plain-language cause for the first failing link of a chain.
+    # The pin count picks the wording: zero pins means the name did not
+    # resolve at all; otherwise a definition exists but its return type
+    # could not be determined.
+    #
+    # @param blame [Source::Chain::LinkResolution]
+    # @return [String, nil] nil when the failing link has no name to report
+    def blame_description blame
+      # The parser produced an undefined placeholder rather than a named
+      # link, so there is no name to report - say nothing rather than
+      # guessing. (Numbered block parameters land here; see #NNNN.)
+      return nil if blame.link.word == '<undefined>'
+
+      receiver = blame.receiver_type&.defined? ? " on #{blame.receiver_type}" : ''
+      if blame.pin_count.zero?
+        "`#{blame.link.word}` could not be resolved#{receiver}"
+      else
+        "could not determine the return type of `#{blame.link.word}`#{receiver}"
+      end
     end
 
     # True if the pin is either internal (part of the workspace) or from the core/stdlib

--- a/spec/pin/base_variable_spec.rb
+++ b/spec/pin/base_variable_spec.rb
@@ -61,4 +61,30 @@ describe Solargraph::Pin::BaseVariable do
     checker = Solargraph::TypeChecker.load_string(code, 'test.rb', :alpha)
     expect(checker.problems.map(&:message)).to eq([])
   end
+
+  describe '#probe_blame' do
+    # @param assigned [String] the expression assigned to @baz
+    # @return [Array(Solargraph::ApiMap, Solargraph::Pin::BaseVariable)]
+    def ivar_pin_for assigned
+      api_map = Solargraph::ApiMap.new
+      api_map.map Solargraph::Source.load_string(%(
+        class Foo
+          def bar
+            @baz = #{assigned}
+          end
+        end
+      ), 'test.rb')
+      [api_map, api_map.get_instance_variable_pins('Foo').first]
+    end
+
+    it 'returns nil when every assignment infers cleanly' do
+      api_map, pin = ivar_pin_for('String.new.upcase')
+      expect(pin.probe_blame(api_map)).to be_nil
+    end
+
+    it 'reports the failing link of the assigned expression' do
+      api_map, pin = ivar_pin_for('String.new.no_such_method')
+      expect(pin.probe_blame(api_map).link.word).to eq('no_such_method')
+    end
+  end
 end

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -786,4 +786,30 @@ describe Solargraph::Pin::Method do
       expect { pin.signatures }.not_to raise_error
     end
   end
+
+  describe '#probe_blame' do
+    # @param body [String] the body of Foo#bar
+    # @return [Array(Solargraph::ApiMap, Solargraph::Pin::Method)]
+    def bar_pin_for body
+      api_map = Solargraph::ApiMap.new
+      api_map.map Solargraph::Source.load_string(%(
+        class Foo
+          def bar
+            #{body}
+          end
+        end
+      ), 'test.rb')
+      [api_map, api_map.get_path_pins('Foo#bar').first]
+    end
+
+    it 'returns nil when every return value infers cleanly' do
+      api_map, pin = bar_pin_for('String.new.upcase')
+      expect(pin.probe_blame(api_map)).to be_nil
+    end
+
+    it 'reports the failing link of the returned expression' do
+      api_map, pin = bar_pin_for('String.new.no_such_method')
+      expect(pin.probe_blame(api_map).link.word).to eq('no_such_method')
+    end
+  end
 end

--- a/spec/source/chain_spec.rb
+++ b/spec/source/chain_spec.rb
@@ -435,4 +435,36 @@ describe Solargraph::Source::Chain do
     type = chain.infer(api_map, obj_fn_pin, api_map.source_map('test.rb').locals)
     expect(type.to_s).to eq('String')
   end
+
+  describe '#first_undefined_link' do
+    it 'returns nil for a fully defined chain' do
+      api_map = Solargraph::ApiMap.new
+      chain = described_class.new([Solargraph::Source::Chain::Constant.new('String'),
+                                   Solargraph::Source::Chain::Call.new('new', nil),
+                                   Solargraph::Source::Chain::Call.new('upcase', nil)])
+      expect(chain.first_undefined_link(api_map, Solargraph::Pin::ROOT_PIN, [])).to be_nil
+    end
+
+    it 'reports the first failing link, not the last' do
+      api_map = Solargraph::ApiMap.new
+      chain = described_class.new([Solargraph::Source::Chain::Constant.new('String'),
+                                   Solargraph::Source::Chain::Call.new('no_such_method', nil),
+                                   Solargraph::Source::Chain::Call.new('upcase', nil)])
+      failure = chain.first_undefined_link(api_map, Solargraph::Pin::ROOT_PIN, [])
+      expect(failure).not_to be_nil
+      expect(failure.link.word).to eq('no_such_method')
+      expect(failure.index).to eq(1)
+      expect(failure.total).to eq(3)
+      expect(failure.pin_count).to eq(0)
+      expect(failure.receiver_type.to_s).to include('String')
+    end
+  end
+
+  it 'chains a numbered-parameter block like an ordinary block' do
+    pending 'NodeChainer#generate_links has no :numblock branch, so a `_1` block produces ' \
+            'no links and the whole expression resolves to the undefined-call placeholder'
+    node = Solargraph::Parser.parse('[1].map { _1.to_s }.compact')
+    chain = Solargraph::Parser.chain(node, 'test.rb')
+    expect(chain.links.map(&:word)).to eq(%w[map compact])
+  end
 end

--- a/spec/source/chain_spec.rb
+++ b/spec/source/chain_spec.rb
@@ -461,8 +461,7 @@ describe Solargraph::Source::Chain do
   end
 
   it 'chains a numbered-parameter block like an ordinary block' do
-    pending 'NodeChainer#generate_links has no :numblock branch, so a `_1` block produces ' \
-            'no links and the whole expression resolves to the undefined-call placeholder'
+    pending 'https://github.com/castwide/solargraph/pull/1320'
     node = Solargraph::Parser.parse('[1].map { _1.to_s }.compact')
     chain = Solargraph::Parser.chain(node, 'test.rb')
     expect(chain.links.map(&:word)).to eq(%w[map compact])

--- a/spec/type_checker/levels/alpha_spec.rb
+++ b/spec/type_checker/levels/alpha_spec.rb
@@ -136,7 +136,8 @@ describe Solargraph::TypeChecker do
         end
       ))
 
-      expect(checker.problems.map(&:message)).to eq(['Foo#bar return type could not be inferred',
+      expect(checker.problems.map(&:message)).to eq(['Foo#bar return type could not be inferred: ' \
+                                                     '`round` could not be resolved on Integer, nil',
                                                      'Unresolved call to round on Integer, nil'])
     end
 

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -215,7 +215,8 @@ describe Solargraph::TypeChecker do
           baz.upcase # ERROR: Unresolved call to upcase on String, nil
         end
       ))
-      expect(checker.problems.map(&:message)).to eq(['#quux return type could not be inferred',
+      expect(checker.problems.map(&:message)).to eq(['#quux return type could not be inferred: ' \
+                                                     '`upcase` could not be resolved on String, nil',
                                                      'Unresolved call to upcase on String, nil'])
     end
 
@@ -828,7 +829,8 @@ describe Solargraph::TypeChecker do
         end
       ))
 
-      expect(checker.problems.map(&:message)).to eq(['Foo#bar return type could not be inferred',
+      expect(checker.problems.map(&:message)).to eq(['Foo#bar return type could not be inferred: ' \
+                                                     '`round` could not be resolved on Integer, nil',
                                                      'Unresolved call to round on Integer, nil'])
     end
 
@@ -924,6 +926,214 @@ describe Solargraph::TypeChecker do
       # expect 'sub' to be treated as 'Subclass' inside the block, and
       # an error when trying to declare sub as Subclass
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
+    end
+
+    # Message matrix for inference-failure blame: one spec per common failure
+    # shape, each asserting the complete rendered message. Each shape is given
+    # first without a @type tag on the assigned local - the form most code is
+    # written in - and then with one.
+
+    it 'blames the return expression when the local has no @type tag' do
+      checker = type_checker(%(
+        class Report
+          # @return [Array<String>]
+          def rows
+            ys = fetch.to_a.compact
+            ys
+          end
+
+          # @return [Rows::Unknown]
+          def fetch
+            fetch
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to include(
+        'Report#rows return type could not be inferred: could not determine the return type of `fetch` on Report'
+      )
+    end
+
+    it 'blames a mid-chain method whose declared return type cannot resolve' do
+      checker = type_checker(%(
+        class Report
+          # @return [Array<String>]
+          def rows
+            # @type [Array<String>]
+            ys = fetch.to_a.compact
+            ys
+          end
+
+          # @return [Rows::Unknown]
+          def fetch
+            fetch
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to include(
+        'Variable type could not be inferred for ys: could not determine the return type of `fetch` on Report'
+      )
+    end
+
+    it 'emits no variable message for an untagged local whose expression fails' do
+      checker = type_checker(%(
+        class Report
+          # @return [void]
+          def run
+            v = 'a'.no_such.upcase
+            v
+            nil
+          end
+        end
+      ))
+      # Without a declared tag there is no variable-validation message at all;
+      # the failure is silent rather than mis-blamed.
+      expect(checker.problems.map(&:message)).to all(satisfy { |m| !m.include?('could not be inferred for v') })
+    end
+
+    it 'reports a diagnostic for a nonexistent method called on an untagged local' do
+      pending 'A plain typo passes the typechecker: call_problems suppresses the ' \
+              'unresolved-call report when the walk\'s `found` pin is an internal method ' \
+              'whose type is undefined, and with no declared tag there is no ' \
+              'variable-validation path to fire instead, so nothing is reported. The ' \
+              'boundary is not yet mapped - the six-call chain in the spec below ' \
+              '(xs.first.to_s.no_such.upcase.size, also untagged) does report ' \
+              '"Unresolved call to no_such on String", so something about the receiver ' \
+              'decides it, and that difference is unexplained.'
+      checker = type_checker(%(
+        class Report
+          # @return [void]
+          def run
+            v = 'a'.no_such.upcase
+            v
+            nil
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to include(a_string_including('no_such'))
+    end
+
+    it 'blames a mid-chain call that matches no method' do
+      checker = type_checker(%(
+        class Report
+          # @return [void]
+          def run
+            # @type [String]
+            v = 'a'.no_such.upcase
+            v
+            nil
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to include(
+        'Variable type could not be inferred for v: `no_such` could not be resolved on String'
+      )
+    end
+
+    it 'leaves an already-correct unresolved-call message alone without a @type tag' do
+      checker = type_checker(%(
+        class Report
+          # @return [void]
+          def run
+            # @type [Array<String>]
+            xs = []
+            n = xs.first.to_s.no_such.upcase.size
+            n
+            nil
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to include('Unresolved call to no_such on String')
+    end
+
+    it 'blames the failing call in a longer chain off a typed local' do
+      checker = type_checker(%(
+        class Report
+          # @return [void]
+          def run
+            # @type [Array<String>]
+            xs = []
+            # @type [Integer]
+            n = xs.first.to_s.no_such.upcase.size
+            n
+            nil
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to include(
+        'Variable type could not be inferred for n: `no_such` could not be resolved on String'
+      )
+    end
+
+    it 'blames a misspelled method in a return expression with no @type tag' do
+      checker = type_checker(%(
+        class Report
+          # @return [Integer]
+          def run
+            names.lenght
+          end
+
+          # @return [Array<String>]
+          def names
+            ['a']
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to include(
+        'Report#run return type could not be inferred: `lenght` could not be resolved on Array<String>'
+      )
+    end
+
+    it 'reports nothing once the misspelled method name is corrected' do
+      checker = type_checker(%(
+        class Report
+          # @return [Integer]
+          def run
+            names.length
+          end
+
+          # @return [Array<String>]
+          def names
+            ['a']
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
+    it 'blames a misspelled method assigned to a tagged local' do
+      checker = type_checker(%(
+        class Report
+          # @return [void]
+          def run
+            # @type [Integer]
+            n = names.lenght
+            n
+            nil
+          end
+
+          # @return [Array<String>]
+          def names
+            ['a']
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to include(
+        'Variable type could not be inferred for n: `lenght` could not be resolved on Array<String>'
+      )
+    end
+
+    it 'leaves the message unchanged when only the final call fails' do
+      checker = type_checker(%(
+        class NoBlame
+          # @return [void]
+          def run
+            'a'.upcase.no_such_method
+            nil
+          end
+        end
+      ))
+      msg = checker.problems.map(&:message).find { |m| m.include?('no_such_method') }
+      expect(msg).to eq('Unresolved call to no_such_method on String')
     end
   end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -991,14 +991,17 @@ describe Solargraph::TypeChecker do
     end
 
     it 'reports a diagnostic for a nonexistent method called on an untagged local' do
-      pending 'A plain typo passes the typechecker: call_problems suppresses the ' \
-              'unresolved-call report when the walk\'s `found` pin is an internal method ' \
-              'whose type is undefined, and with no declared tag there is no ' \
-              'variable-validation path to fire instead, so nothing is reported. The ' \
-              'boundary is not yet mapped - the six-call chain in the spec below ' \
-              '(xs.first.to_s.no_such.upcase.size, also untagged) does report ' \
-              '"Unresolved call to no_such on String", so something about the receiver ' \
-              'decides it, and that difference is unexplained.'
+      # A plain typo passes the typechecker: call_problems suppresses the
+      # unresolved-call report when the walk's `found` pin is an internal
+      # method whose type is undefined, and with no declared tag there is
+      # no variable-validation path to fire instead, so nothing is
+      # reported. The boundary is not yet mapped - the six-call chain in
+      # the spec below (xs.first.to_s.no_such.upcase.size, also untagged)
+      # does report "Unresolved call to no_such on String", so something
+      # about the receiver decides it, and that difference is unexplained.
+      pending <<~REASON
+        A plain typo passes the typechecker; see the comment above.
+      REASON
       checker = type_checker(%(
         class Report
           # @return [void]


### PR DESCRIPTION
**Problem**

A local whose expression calls a method that does not exist reports only the variable's name:

```ruby
# @type [String]
v = 'a'.no_such.upcase
```

```
example1.rb:5: Variable type could not be inferred for v
```

Nothing says whether inference stopped at `'a'`, `no_such`, or `upcase`, so diagnosing it means bisecting the expression by hand. The same gap affects `... return type could not be inferred`, which names the method but not the part of the expression responsible.

**Solution**

Both messages now name where inference stopped and what it was called on:

```
example1.rb:5: Variable type could not be inferred for v: `no_such` could not be resolved on String
example2.rb:3: Report#rows return type could not be inferred: could not determine the return type of `fetch` on Report
```

`Chain#first_undefined_link` re-walks the chain, on the error path only.

A bare-variable return walks into that variable's own assignment, so the cause can name a call appearing nowhere in the return expression itself.

Messages stay byte-identical when no cause can be named, and when the failing call is the one already named.

*Written by Claude (Anthropic's Claude Code) on behalf of @apiology.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)
