### PR TITLE
Resolve a self return type per union member

### DIFF
--- a/lib/solargraph/diagnostics/type_check.rb
+++ b/lib/solargraph/diagnostics/type_check.rb
@@ -11,7 +11,6 @@ module Solargraph
         # return [] unless args.include?('always') || api_map.workspaced?(source.filename)
         severity = Diagnostics::Severities::ERROR
         level = args.reverse.find { |a| %w[normal typed strict strong].include?(a) } || :normal
-        # @sg-ignore sensitive typing needs to handle || on nil types
         checker = Solargraph::TypeChecker.new(source.filename, api_map: api_map, level: level.to_sym)
         checker.problems
                .sort { |a, b| a.location.range.start.line <=> b.location.range.start.line }

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -55,18 +55,31 @@ module Solargraph
           # chain.rb#maybe_nil will add the nil type later, we just
           # need to worry about the not-nil case
 
-          # @sg-ignore Need to handle duck-typed method calls on union types
           binder = binder.without_nil if nullable?
-          # @sg-ignore Need to handle duck-typed method calls on union types
-          pin_groups = binder.each_unique_type.map do |context|
+          # Resolve each arm of a union receiver against that arm alone. A
+          # method whose declared return type is `self` must resolve to the
+          # arm that supplied the method pin, not to the entire union - e.g.
+          # for a String, Symbol receiver, Symbol#to_sym (RBS `-> self`) is
+          # Symbol, not String, Symbol.
+          # @type [::Array<Pin::Base>]
+          resolved = []
+          unresolved_arm = false
+          binder.each_unique_type do |context|
             ns_tag = context.namespace == '' ? '' : context.namespace_type.tag
             stack = api_map.get_method_stack(ns_tag, word, scope: context.scope)
-            [stack.first].compact
+            pin = stack.first
+            if pin.nil?
+              unresolved_arm = true
+              next
+            end
+            resolved.concat inferred_pins([pin], api_map, name_pin, locals, context)
           end
-          pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:empty?)
-          pins = pin_groups.flatten.uniq(&:path)
-          return [] if pins.empty?
-          inferred_pins(pins, api_map, name_pin, locals)
+          return [] if unresolved_arm && !api_map.loose_unions
+          return [] if resolved.empty?
+          # Different arms can resolve to the same pin path (a method
+          # inherited from a shared ancestor); dedup on the resolved return
+          # type too, so a real union doesn't lose every arm but the first.
+          resolved.uniq { |pin| [pin.path, pin.return_type.tag] }
         end
 
         private
@@ -75,8 +88,13 @@ module Solargraph
         # @param api_map [ApiMap]
         # @param name_pin [Pin::Base]
         # @param locals [::Array<Solargraph::Pin::LocalVariable, Solargraph::Pin::Parameter>]
+        # @param self_binder [ComplexType, ComplexType::UniqueType, nil] The
+        #   type that `self` refers to in the resolved pins' declarations. For a
+        #   union receiver this is the single arm which supplied `pins`, not the
+        #   whole union.
         # @return [::Array<Pin::Base>]
-        def inferred_pins pins, api_map, name_pin, locals
+        def inferred_pins pins, api_map, name_pin, locals, self_binder = nil
+          self_binder ||= name_pin.binder
           result = pins.map do |p|
             next p unless p.is_a?(Pin::Method)
             overloads = p.signatures
@@ -131,11 +149,11 @@ module Solargraph
                                                                                     blocktype)
                 # @todo It shouldn't be necessary to choose either generics or macros
                 new_return_type = if new_signature_pin.return_type.defined?
-                  new_signature_pin.return_type
-                else
-                  named_types = p.parameter_names.zip(arguments.map { |arg| ComplexType.try_parse(simple_convert(arg.node).to_s) }).to_h
-                  p.typify(api_map).expand(named_types)
-                end
+                                    new_signature_pin.return_type
+                                  else
+                                    named_types = p.parameter_names.zip(arguments.map { |arg| ComplexType.try_parse(simple_convert(arg.node).to_s) }).to_h
+                                    p.typify(api_map).expand(named_types)
+                                  end
                 self_type = if head?
                               # If we're at the head of the chain, we called a
                               # method somewhere that marked itself as returning
@@ -149,7 +167,7 @@ module Solargraph
                               # declaration - we can't just use the type of the
                               # method pin, as this might be a subclass of the
                               # place where the method is defined
-                              name_pin.binder
+                              self_binder
                             end
                 # This same logic applies to the YARD work done by
                 # 'with_params()'.
@@ -179,7 +197,7 @@ module Solargraph
               # @sg-ignore Need to add nil check here
               next pin if pin.return_type.undefined?
               # @sg-ignore Need to add nil check here
-              selfy = pin.return_type.self_to_type(name_pin.binder)
+              selfy = pin.return_type.self_to_type(self_binder)
               # @sg-ignore Need to add nil check here
               selfy == pin.return_type ? pin : pin.proxy(selfy)
             end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -56,11 +56,7 @@ module Solargraph
           # need to worry about the not-nil case
 
           binder = binder.without_nil if nullable?
-          # Resolve each arm of a union receiver against that arm alone. A
-          # method whose declared return type is `self` must resolve to the
-          # arm that supplied the method pin, not to the entire union - e.g.
-          # for a String, Symbol receiver, Symbol#to_sym (RBS `-> self`) is
-          # Symbol, not String, Symbol.
+          # Resolve each arm alone, so a `self` return type narrows to that arm, not the whole union.
           # @type [::Array<Pin::Base>]
           resolved = []
           unresolved_arm = false
@@ -72,10 +68,7 @@ module Solargraph
               unresolved_arm = true
               next
             end
-            # Give this arm's resolution a name_pin whose #binder is this
-            # arm alone, not the whole union - every name_pin.binder read
-            # inside #inferred_pins (including the Class#new special case)
-            # then sees only this arm, with nothing extra to keep in sync.
+            # This arm's name_pin binds only this arm, so #inferred_pins (incl. Class#new) sees just it.
             arm_name_pin = Pin::ProxyType.anonymous(name_pin.context,
                                                     closure: name_pin.closure,
                                                     gates: name_pin.gates,
@@ -85,9 +78,7 @@ module Solargraph
           end
           return [] if unresolved_arm && !api_map.loose_unions
           return [] if resolved.empty?
-          # Different arms can resolve to the same pin path (a method
-          # inherited from a shared ancestor); dedup on the resolved return
-          # type too, so a real union doesn't lose every arm but the first.
+          # Dedup on return type too, so arms sharing an inherited pin path don't collapse to just the first.
           resolved.uniq { |pin| [pin.path, pin.return_type.tag] }
         end
 

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -72,7 +72,16 @@ module Solargraph
               unresolved_arm = true
               next
             end
-            resolved.concat inferred_pins([pin], api_map, name_pin, locals, context)
+            # Give this arm's resolution a name_pin whose #binder is this
+            # arm alone, not the whole union - every name_pin.binder read
+            # inside #inferred_pins (including the Class#new special case)
+            # then sees only this arm, with nothing extra to keep in sync.
+            arm_name_pin = Pin::ProxyType.anonymous(name_pin.context,
+                                                    closure: name_pin.closure,
+                                                    gates: name_pin.gates,
+                                                    binder: context,
+                                                    source: :chain)
+            resolved.concat inferred_pins([pin], api_map, arm_name_pin, locals)
           end
           return [] if unresolved_arm && !api_map.loose_unions
           return [] if resolved.empty?
@@ -86,15 +95,13 @@ module Solargraph
 
         # @param pins [::Enumerable<Pin::Base>]
         # @param api_map [ApiMap]
-        # @param name_pin [Pin::Base]
-        # @param locals [::Array<Solargraph::Pin::LocalVariable, Solargraph::Pin::Parameter>]
-        # @param self_binder [ComplexType, ComplexType::UniqueType, nil] The
-        #   type that `self` refers to in the resolved pins' declarations. For a
-        #   union receiver this is the single arm which supplied `pins`, not the
+        # @param name_pin [Pin::Base] name_pin.binder resolves `self` in the
+        #   resolved pins' declarations. For a union receiver, callers pass a
+        #   name_pin bound to the single arm that supplied `pins`, not the
         #   whole union.
+        # @param locals [::Array<Solargraph::Pin::LocalVariable, Solargraph::Pin::Parameter>]
         # @return [::Array<Pin::Base>]
-        def inferred_pins pins, api_map, name_pin, locals, self_binder = nil
-          self_binder ||= name_pin.binder
+        def inferred_pins pins, api_map, name_pin, locals
           result = pins.map do |p|
             next p unless p.is_a?(Pin::Method)
             overloads = p.signatures
@@ -167,7 +174,7 @@ module Solargraph
                               # declaration - we can't just use the type of the
                               # method pin, as this might be a subclass of the
                               # place where the method is defined
-                              self_binder
+                              name_pin.binder
                             end
                 # This same logic applies to the YARD work done by
                 # 'with_params()'.
@@ -197,7 +204,7 @@ module Solargraph
               # @sg-ignore Need to add nil check here
               next pin if pin.return_type.undefined?
               # @sg-ignore Need to add nil check here
-              selfy = pin.return_type.self_to_type(self_binder)
+              selfy = pin.return_type.self_to_type(name_pin.binder)
               # @sg-ignore Need to add nil check here
               selfy == pin.return_type ? pin : pin.proxy(selfy)
             end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -56,29 +56,31 @@ module Solargraph
           # need to worry about the not-nil case
 
           binder = binder.without_nil if nullable?
-          # Resolve each arm alone, so a `self` return type narrows to that arm, not the whole union.
+          # Resolve one unique type at a time, so a `self` return type narrows to the one that supplied the pin.
           # @type [::Array<Pin::Base>]
           resolved = []
-          unresolved_arm = false
+          unresolved_type = false
           binder.each_unique_type do |context|
             ns_tag = context.namespace == '' ? '' : context.namespace_type.tag
             stack = api_map.get_method_stack(ns_tag, word, scope: context.scope)
             pin = stack.first
             if pin.nil?
-              unresolved_arm = true
+              unresolved_type = true
               next
             end
-            # This arm's name_pin binds only this arm, so #inferred_pins (incl. Class#new) sees just it.
-            arm_name_pin = Pin::ProxyType.anonymous(name_pin.context,
-                                                    closure: name_pin.closure,
-                                                    gates: name_pin.gates,
-                                                    binder: context,
-                                                    source: :chain)
-            resolved.concat inferred_pins([pin], api_map, arm_name_pin, locals)
+            # Bind name_pin to this type alone, so #inferred_pins (incl. Class#new) cannot see the others.
+            type_name_pin = Pin::ProxyType.anonymous(name_pin.context,
+                                                     closure: name_pin.closure,
+                                                     gates: name_pin.gates,
+                                                     binder: context,
+                                                     source: :chain)
+            resolved.concat inferred_pins([pin], api_map, type_name_pin, locals)
           end
-          return [] if unresolved_arm && !api_map.loose_unions
+          return [] if unresolved_type && !api_map.loose_unions
           return [] if resolved.empty?
-          # Dedup on return type too, so arms sharing an inherited pin path don't collapse to just the first.
+          # Accumulating every type's result treats the binder as a union, which is the only
+          # multi-type binder ComplexType builds; dedup on return type as well as path so that
+          # types sharing an inherited pin do not collapse to just the first.
           resolved.uniq { |pin| [pin.path, pin.return_type.tag] }
         end
 
@@ -175,10 +177,7 @@ module Solargraph
 
         # @param pins [::Enumerable<Pin::Base>]
         # @param api_map [ApiMap]
-        # @param name_pin [Pin::Base] name_pin.binder resolves `self` in the
-        #   resolved pins' declarations. For a union receiver, callers pass a
-        #   name_pin bound to the single arm that supplied `pins`, not the
-        #   whole union.
+        # @param name_pin [Pin::Base] its #binder resolves `self` in the declarations of `pins`
         # @param locals [::Array<Solargraph::Pin::LocalVariable, Solargraph::Pin::Parameter>]
         # @return [::Array<Pin::Base>]
         def inferred_pins pins, api_map, name_pin, locals

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -372,6 +372,57 @@ describe Solargraph::Source::Chain::Call do
     expect(type.rooted_tags).to eq('::String, ::Symbol')
   end
 
+  it 'resolves a YARD @return [self] to the union arm that supplied the method' do
+    source = Solargraph::Source.load_string(%(
+      class Alpha
+        # @return [Symbol]
+        def to_thing; end
+      end
+
+      class Beta
+        # @return [self]
+        def to_thing; end
+      end
+
+      # @type [Alpha, Beta]
+      thing = alpha_or_beta
+      thing.to_thing
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(13, 14))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    # `self` in a YARD @return tag reaches the same resolution as an RBS `self`
+    # return type, so Beta#to_thing narrows to Beta instead of expanding to the
+    # whole Alpha, Beta receiver.
+    expect(type.rooted_tags).to eq('::Symbol, ::Beta')
+  end
+
+  it 'distributes a YARD self nested in a generic across union arms' do
+    source = Solargraph::Source.load_string(%(
+      class Base
+        # @return [Array<self>]
+        def many; end
+      end
+
+      class Alpha < Base; end
+      class Beta < Base; end
+
+      # @type [Alpha, Beta]
+      thing = alpha_or_beta
+      thing.many
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(11, 14))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    # Base#many is one pin shared by both arms, so `self` inside the generic
+    # resolves once per arm rather than collapsing to Array<Alpha, Beta>.
+    expect(type.rooted_tags).to eq('::Array<::Alpha>, ::Array<::Beta>')
+  end
+
   it 'allows calls off of nilable objects by default' do
     source = Solargraph::Source.load_string(%(
       # @type [String, nil]

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -361,9 +361,7 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(4, 11))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # Array#each's enumerator overload is `() -> ::Enumerator[Elem, self]`, so
-    # `self` resolves to the Array<Integer> arm that supplied the pin rather
-    # than to the whole String, Array<Integer> union.
+    # Array#each's `-> Enumerator[Elem, self]` narrows to the Array<Integer> arm, not the union.
     expect(type.tag).to eq('Enumerator<Integer, Array<Integer>>')
   end
 

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -376,8 +376,7 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(3, 11))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # String#to_sym is `-> Symbol`; Symbol#to_sym is `-> self`, which narrows
-    # to Symbol rather than expanding to the String, Symbol receiver.
+    # Symbol#to_sym is `-> self` and String#to_sym is `-> Symbol`, so both arms give Symbol.
     expect(type.tag).to eq('Symbol')
   end
 
@@ -392,8 +391,7 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(3, 11))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # Kernel#itself is `-> self` and is the same pin for both arms, so the
-    # result is the union of each arm's own self type.
+    # Kernel#itself is `-> self` and one pin for both arms, so each arm contributes its own self.
     expect(type.rooted_tags).to eq('::String, ::Symbol')
   end
 
@@ -418,9 +416,7 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(13, 14))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # `self` in a YARD @return tag reaches the same resolution as an RBS `self`
-    # return type, so Beta#to_thing narrows to Beta instead of expanding to the
-    # whole Alpha, Beta receiver.
+    # A YARD `@return [self]` resolves like an RBS `self`, so Beta#to_thing narrows to Beta.
     expect(type.rooted_tags).to eq('::Symbol, ::Beta')
   end
 
@@ -443,8 +439,7 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(11, 14))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # Base#many is one pin shared by both arms, so `self` inside the generic
-    # resolves once per arm rather than collapsing to Array<Alpha, Beta>.
+    # Base#many is one shared pin, so the nested `self` resolves per arm, not to Array<Alpha, Beta>.
     expect(type.rooted_tags).to eq('::Array<::Alpha>, ::Array<::Beta>')
   end
 
@@ -461,11 +456,7 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(5, 13))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # Class<Beta>'s own `.new` resolves separately to Beta; the bare `Class`
-    # arm falls back to the generic Class#new, which cannot know the
-    # constructed type. The gate for that fallback must read only this
-    # arm's binder - a Class<Beta> arm elsewhere in the union must not leak
-    # Beta into the bare Class arm's result.
+    # The bare `Class` arm cannot know what its #new constructs, and Beta must not leak in from the other arm.
     expect(type.rooted_tags).to eq('undefined')
   end
 
@@ -482,8 +473,6 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(5, 13))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # Same union as the Class<Beta>, Class case with the arms reversed; the
-    # result must not depend on declaration order.
     expect(type.rooted_tags).to eq('undefined')
   end
 

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -423,6 +423,45 @@ describe Solargraph::Source::Chain::Call do
     expect(type.rooted_tags).to eq('::Array<::Alpha>, ::Array<::Beta>')
   end
 
+  it 'does not leak one union arm into a Class#new call resolved on another arm' do
+    source = Solargraph::Source.load_string(%(
+      class Beta; end
+
+      # @type [Class<Beta>, Class]
+      klass = beta_class_or_generic_class
+      klass.new
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(5, 13))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    # Class<Beta>'s own `.new` resolves separately to Beta; the bare `Class`
+    # arm falls back to the generic Class#new, which cannot know the
+    # constructed type. The gate for that fallback must read only this
+    # arm's binder - a Class<Beta> arm elsewhere in the union must not leak
+    # Beta into the bare Class arm's result.
+    expect(type.rooted_tags).to eq('undefined')
+  end
+
+  it 'resolves Class#new the same way regardless of union arm order' do
+    source = Solargraph::Source.load_string(%(
+      class Beta; end
+
+      # @type [Class, Class<Beta>]
+      klass = generic_or_beta_class
+      klass.new
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(5, 13))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    # Same union as the Class<Beta>, Class case with the arms reversed; the
+    # result must not depend on declaration order.
+    expect(type.rooted_tags).to eq('undefined')
+  end
+
   it 'allows calls off of nilable objects by default' do
     source = Solargraph::Source.load_string(%(
       # @type [String, nil]

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -334,8 +334,42 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(4, 11))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # @todo It would be more accurate to return `Enumerator<Array<Integer>>` here
-    expect(type.tag).to eq('Enumerator<Integer, String, Array<Integer>>')
+    # Array#each's enumerator overload is `() -> ::Enumerator[Elem, self]`, so
+    # `self` resolves to the Array<Integer> arm that supplied the pin rather
+    # than to the whole String, Array<Integer> union.
+    expect(type.tag).to eq('Enumerator<Integer, Array<Integer>>')
+  end
+
+  it 'resolves an RBS self return type to the union arm that supplied the method' do
+    source = Solargraph::Source.load_string(%(
+      # @type [String, Symbol]
+      name = string_or_symbol
+      name.to_sym
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(3, 11))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    # String#to_sym is `-> Symbol`; Symbol#to_sym is `-> self`, which narrows
+    # to Symbol rather than expanding to the String, Symbol receiver.
+    expect(type.tag).to eq('Symbol')
+  end
+
+  it 'resolves a shared self-returning method separately for each union arm' do
+    source = Solargraph::Source.load_string(%(
+      # @type [String, Symbol]
+      name = string_or_symbol
+      name.itself
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(3, 11))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    # Kernel#itself is `-> self` and is the same pin for both arms, so the
+    # result is the union of each arm's own self type.
+    expect(type.rooted_tags).to eq('::String, ::Symbol')
   end
 
   it 'allows calls off of nilable objects by default' do

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -361,11 +361,11 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(4, 11))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # Array#each's `-> Enumerator[Elem, self]` narrows to the Array<Integer> arm, not the union.
+    # Array#each's `-> Enumerator[Elem, self]` narrows to the Array<Integer> member, not the union.
     expect(type.tag).to eq('Enumerator<Integer, Array<Integer>>')
   end
 
-  it 'resolves an RBS self return type to the union arm that supplied the method' do
+  it 'resolves an RBS self return type to the union member that supplied the method' do
     source = Solargraph::Source.load_string(%(
       # @type [String, Symbol]
       name = string_or_symbol
@@ -376,11 +376,11 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(3, 11))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # Symbol#to_sym is `-> self` and String#to_sym is `-> Symbol`, so both arms give Symbol.
+    # Symbol#to_sym is `-> self` and String#to_sym is `-> Symbol`, so both members give Symbol.
     expect(type.tag).to eq('Symbol')
   end
 
-  it 'resolves a shared self-returning method separately for each union arm' do
+  it 'resolves a shared self-returning method separately for each union member' do
     source = Solargraph::Source.load_string(%(
       # @type [String, Symbol]
       name = string_or_symbol
@@ -391,11 +391,11 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(3, 11))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # Kernel#itself is `-> self` and one pin for both arms, so each arm contributes its own self.
+    # Kernel#itself is `-> self` and one pin for both members, so each contributes its own self.
     expect(type.rooted_tags).to eq('::String, ::Symbol')
   end
 
-  it 'resolves a YARD @return [self] to the union arm that supplied the method' do
+  it 'resolves a YARD @return [self] to the union member that supplied the method' do
     source = Solargraph::Source.load_string(%(
       class Alpha
         # @return [Symbol]
@@ -420,7 +420,7 @@ describe Solargraph::Source::Chain::Call do
     expect(type.rooted_tags).to eq('::Symbol, ::Beta')
   end
 
-  it 'distributes a YARD self nested in a generic across union arms' do
+  it 'distributes a YARD self nested in a generic across union members' do
     source = Solargraph::Source.load_string(%(
       class Base
         # @return [Array<self>]
@@ -439,11 +439,11 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(11, 14))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # Base#many is one shared pin, so the nested `self` resolves per arm, not to Array<Alpha, Beta>.
+    # Base#many is one shared pin, so the nested `self` resolves per member, not to Array<Alpha, Beta>.
     expect(type.rooted_tags).to eq('::Array<::Alpha>, ::Array<::Beta>')
   end
 
-  it 'does not leak one union arm into a Class#new call resolved on another arm' do
+  it 'does not leak one union member into a Class#new call resolved on another' do
     source = Solargraph::Source.load_string(%(
       class Beta; end
 
@@ -456,11 +456,11 @@ describe Solargraph::Source::Chain::Call do
 
     chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(5, 13))
     type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
-    # The bare `Class` arm cannot know what its #new constructs, and Beta must not leak in from the other arm.
+    # The bare `Class` member cannot know what its #new constructs, and Beta must not leak in from the other.
     expect(type.rooted_tags).to eq('undefined')
   end
 
-  it 'resolves Class#new the same way regardless of union arm order' do
+  it 'resolves Class#new the same way regardless of union member order' do
     source = Solargraph::Source.load_string(%(
       class Beta; end
 


### PR DESCRIPTION
A method that declares a `self` return type, called on a union receiver, infers the whole union instead of the member that supplied the method.

```ruby
class Counter
  # @return [self]
  def to_sym
    self
  end
end

# @param x [String, Counter]
# @return [Symbol, Counter]
def probe_union(x)
  x.to_sym
end
```

```
before:  probe.rb:10: Declared return type ::Symbol, ::Counter does not match
                      inferred type ::Symbol, ::String, ::Counter for #probe_union
after:   0 problems found.
```

Any method declaring `self` is affected, in any position — `@return [Array<self>]` on an `Alpha, Beta` receiver collapsed the same way.

`Chain::Call#resolve` used to split the binder only to collect method pins, then flatten them and call `#inferred_pins` once with `name_pin` still bound to the whole union. It now resolves one unique type at a time against a `name_pin` bound to that type alone, so `self` can only mean the type that supplied the pin. Results dedupe on path and resolved return type, so a `self`-returning method shared by every member still yields each one: `(String | Symbol)#itself` stays `String, Symbol`.

It also removes an `@sg-ignore`: `Diagnostics::TypeCheck#diagnose` calls `level.to_sym` where `level` is `String, Symbol`, which needed suppressing and now resolves to `Symbol`.

This PR was written by Claude Code on behalf of @apiology.
