### PR TITLE
Re-opened classes should not reset superclass to 'Object'

### DIFF
--- a/lib/solargraph/yard_map/mapper.rb
+++ b/lib/solargraph/yard_map/mapper.rb
@@ -50,7 +50,16 @@ module Solargraph
                          else
                            code_object.superclass.to_s
                          end
-            result.push Solargraph::Pin::Reference::Superclass.new(name: superclass, closure: nspin, source: :yard_map)
+            # YARD fills in `Object` for every class whose definition it never
+            # saw a superclass clause on - including a bare `class Foo`
+            # reopening, which asserts nothing about ancestry - and keeps no
+            # record of which case it was. A class with no superclass reference
+            # already resolves to Object, so recording this one adds nothing and
+            # can shadow a superclass declared in another source.
+            unless superclass.delete_prefix('::') == 'Object'
+              result.push Solargraph::Pin::Reference::Superclass.new(name: superclass, closure: nspin,
+                                                                     source: :yard_map)
+            end
           end
           # @sg-ignore flow sensitive typing ought to be able to handle 'when ClassName'
           code_object.class_mixins.each do |m|

--- a/spec/fixtures/yard_map/superclass.rb
+++ b/spec/fixtures/yard_map/superclass.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class SuperclassBase; end
+
+class SuperclassDeclared < SuperclassBase; end
+
+# A reopening with no superclass clause. YARD records `Object` here, the same
+# as it would for a first definition with no superclass.
+class SuperclassReopened
+  def reopened; end
+end

--- a/spec/yard_map/mapper_spec.rb
+++ b/spec/yard_map/mapper_spec.rb
@@ -58,6 +58,20 @@ describe Solargraph::YardMap::Mapper do
     expect(pin.closure.path).to eq('YARD::CodeObjects::ClassObject')
   end
 
+  it 'skips the Object superclass YARD records when no clause was seen' do
+    dir = File.absolute_path(File.join('spec', 'fixtures', 'yard_map'))
+    pins = Dir.chdir dir do
+      YARD::Registry.load([File.join(dir, 'superclass.rb')], true)
+      described_class.new(YARD::Registry.all).map
+    end
+    FileUtils.remove_entry_secure File.join(dir, '.yardoc')
+    refs = pins.select do |pin|
+      pin.is_a?(Solargraph::Pin::Reference::Superclass) && pin.closure.path.start_with?('Superclass')
+    end
+    expect(refs.map { |ref| [ref.closure.path, ref.name] })
+      .to eq([%w[SuperclassDeclared SuperclassBase]])
+  end
+
   it 'adds include references' do
     # Asssuming the ast gem exists because it's a known dependency
     inc = pins_with('ast').find do |pin|


### PR DESCRIPTION
With activesupport in the bundle, Solargraph reports the wrong superclass for `DateTime`:

```ruby
DateTime.superclass                # => Date, at runtime
get_superclass('DateTime')         # => Object
```

`DateTime` is then cut off from `Date` and from everything above it.

The `Object` comes from activesupport reopening the class:

```ruby
# active_support/core_ext/date_time/blank.rb
class DateTime # :nodoc:
  def blank?
    false
  end
end
```

A reopening with no superclass clause asserts nothing about ancestry — and it cannot, because Ruby fixes a class's superclass at its first definition and refuses to let anything restate it differently:

```ruby
class DateTime < Object; end       # TypeError: superclass mismatch for class DateTime
```

A class with no superclass reference already resolves to `Object` via `Store#try_special_superclasses`, so the mapper now skips recording an `Object` reference at all, leaving only the specific one that carries a claim. `get_superclass` is untouched — it stays a plain `.first` with no tie-break, because there is no longer a conflict to arbitrate. `BasicObject` references are kept, since the only class YARD defaults to `BasicObject` is `Object` itself, where the reference is correct either way.

Suite: 1625 examples, 0 failures, 60 pending. Opening as a draft.

*This PR was written by Claude (Anthropic's Claude Code) on behalf of @apiology.*

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01H1FEjW6nMpZrWPmeWX9miT
