### PR TITLE
Apply implicitly-returns-nil per signature/overload, rather than per method

### DIFF
--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -538,16 +538,16 @@ module Solargraph
       # @param pin [Pin::Method]
       # @return [void]
       def method_def_to_sigs decl, pin
-        # rubocop:disable Style/SafeNavigationChainLength
-        implicit_nil = decl.overloads.first&.annotations&.map(&:string)&.include?('implicitly-returns-nil') || false
-        # rubocop:enable Style/SafeNavigationChainLength
         # @param overload [RBS::AST::Members::MethodDefinition::Overload]
         decl.overloads.map do |overload|
+          # RBS attaches this annotation to a single overload, not to the method as a whole
+          implicit_nil = overload.annotations.map(&:string).include?('implicitly-returns-nil')
           type_location = location_decl_to_pin_location(overload.method_type.location)
           generics = overload.method_type.type_params.map(&:name).map(&:to_s)
           signature_parameters, signature_return_type = parts_of_function(overload.method_type, pin, implicit_nil)
           block = if overload.method_type.block
-                    block_parameters, block_return_type = parts_of_function(overload.method_type.block, pin, implicit_nil)
+                    # the annotation describes the method's return value, not the block's
+                    block_parameters, block_return_type = parts_of_function(overload.method_type.block, pin, false)
                     Pin::Signature.new(generics: generics, parameters: block_parameters, return_type: block_return_type, source: :rbs,
                                        type_location: type_location, closure: pin)
                   end

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -93,6 +93,37 @@ describe Solargraph::RbsMap::Conversions do
         expect(method_pin.return_type.tag).to eq('undefined')
       end
     end
+
+    context 'with implicitly-returns-nil on some overloads' do
+      subject(:method_pin) { conversions.pins.find { |pin| pin.path == 'Foo#bar' } }
+
+      let(:rbs) do
+        <<~RBS
+          class Foo
+            def bar: %a{implicitly-returns-nil} () -> String
+                   | %a{implicitly-returns-nil} () { (String a) -> Integer } -> String
+                   | (Integer n) -> Array[String]
+                   | (Integer n) { (String a) -> Integer? } -> Array[String]
+          end
+        RBS
+      end
+
+      it 'adds nil to the return type of the annotated overloads' do
+        expect(method_pin.signatures[0..1].map { |sig| sig.return_type.to_s }).to eq(['String, nil'] * 2)
+      end
+
+      it 'leaves the return type of the unannotated overloads alone' do
+        expect(method_pin.signatures[2..3].map { |sig| sig.return_type.to_s }).to eq(['Array<String>'] * 2)
+      end
+
+      it 'does not add nil to a block return type' do
+        expect(method_pin.signatures[1].block.return_type.to_s).to eq('Integer')
+      end
+
+      it 'keeps nil in a block return type declared optional in RBS' do
+        expect(method_pin.signatures[3].block.return_type.to_s).to eq('Integer, nil')
+      end
+    end
   end
 
   context 'with standard loads for solargraph project' do


### PR DESCRIPTION
`Array#max(1)` comes back with a spurious `, nil` appended, so this fails at `--level strong`:

```ruby
# @return [Array<String>]
def probe
  a = ['x', 'y']
  a.max(1)
end

# probe.rb:2: Declared return type ::Array<::String> does not match
#             inferred type ::Array, nil for #probe
```

RBS declares no nil there. `%a{implicitly-returns-nil}` is attached to an individual overload, and rbs 4.1.3's `core/array.rbs` puts it only on the zero-argument ones:

```rbs
def max: %a{implicitly-returns-nil} () -> E
       | %a{implicitly-returns-nil} () { (E a, E b) -> _CompareToZero } -> E
       | %a{implicitly-returns-nil} %a{warning: ...} () { (E a, E b) -> _CompareToZero? } -> E
       | (::int count) -> ::Array[E]
       | (::int count) { (E a, E b) -> _CompareToZero } -> ::Array[E]
       | %a{warning: ...} (::int count) { (E a, E b) -> _CompareToZero? } -> ::Array[E]
```

The annotation is also no longer passed down to block return types: it describes what the method returns, not what the block returns, and a block that may return nil says so with `?` ��� as the third and sixth overloads above do.

This PR was written by Claude Code on behalf of @apiology.
