### PR TITLE
Make `rbs validate` a blocking CI check again

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -97,8 +97,6 @@ jobs:
 
     - name: Run rbs validate
       run: bundle exec rbs validate
-      # @todo Temporary, expect to revert in 0.60
-      continue-on-error: true
   rubocop_todo:
     name: .rubocop_todo.yml
     runs-on: ubuntu-latest


### PR DESCRIPTION
`rbs validate` in the Linting workflow carries `continue-on-error: true` from https://github.com/castwide/solargraph/pull/1200, marked `# @todo Temporary, expect to revert in 0.60`. 0.60 has since shipped through 0.60.3.

Unlike the other steps stubbed in that commit, this one passes — on master and on every recent PR run sampled, none of which contain `Process completed with exit code`. So removing the flag suppresses nothing and changes no outcome today; it only lets the check report what it finds from here on.

Out of scope: the `solargraph typecheck --level strong` flag is handled by https://github.com/castwide/solargraph/pull/1240, the two `rubocop_todo` flags by https://github.com/castwide/solargraph/pull/1260. The rest still exit non-zero and each needs its own fix.

This PR was written by Claude Code on behalf of @apiology.
