### PR TITLE
Keep a block's reassignment of an outer local visible after the block

### DIFF
--- a/lib/solargraph/parser/parser_gem/node_processors/lvasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/lvasgn_node.rb
@@ -28,14 +28,8 @@ module Solargraph
 
           private
 
-          # The closure the assigned variable belongs to.
-          #
-          # An assignment inside a block writes through to a variable of the
-          # same name already in scope outside the block, so the pin belongs
-          # to that outer closure and stays visible after the block ends. A
-          # name the block introduces itself - a block parameter, a shadow
-          # arg, or an earlier assignment in the same block - is block-local
-          # and shadows anything outside.
+          # The closure `name` is already declared in, searching outward
+          # through enclosing blocks; defaults to the current block if none.
           #
           # @param name [String]
           # @param here [Position]

--- a/lib/solargraph/parser/parser_gem/node_processors/lvasgn_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/lvasgn_node.rb
@@ -9,19 +9,59 @@ module Solargraph
 
           def process
             here = get_node_start_position(node)
+            name = node.children[0].to_s
+            closure = assignment_closure(name, here)
             # @sg-ignore Need to add nil check here
-            presence = Range.new(here, region.closure.location.range.ending)
+            presence = Range.new(here, closure.location.range.ending)
             loc = get_node_location(node)
             locals.push Solargraph::Pin::LocalVariable.new(
               location: loc,
-              closure: region.closure,
-              name: node.children[0].to_s,
+              closure: closure,
+              name: name,
               assignment: node.children[1],
               comments: comments_for(node),
               presence: presence,
               source: :parser
             )
             process_children
+          end
+
+          private
+
+          # The closure the assigned variable belongs to.
+          #
+          # An assignment inside a block writes through to a variable of the
+          # same name already in scope outside the block, so the pin belongs
+          # to that outer closure and stays visible after the block ends. A
+          # name the block introduces itself - a block parameter, a shadow
+          # arg, or an earlier assignment in the same block - is block-local
+          # and shadows anything outside.
+          #
+          # @param name [String]
+          # @param here [Position]
+          # @return [Pin::Closure]
+          def assignment_closure name, here
+            scope = region.closure
+            loop do
+              return scope if declares_local?(scope, name, here)
+              break unless scope.is_a?(Pin::Block)
+
+              outer = scope.closure
+              break if outer.nil? || outer.location.nil?
+
+              scope = outer
+            end
+            region.closure
+          end
+
+          # @param scope [Pin::Closure]
+          # @param name [String]
+          # @param here [Position]
+          # @return [Boolean]
+          def declares_local? scope, name, here
+            locals.any? do |pin|
+              pin.name == name && pin.closure.equal?(scope) && pin.presence&.contain?(here)
+            end
           end
         end
       end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -191,13 +191,11 @@ module Solargraph
             p = p.with_single_signature(new_signature_pin) unless new_signature_pin.nil?
             next p.proxy(type) if type.defined?
             if !p.macros.empty?
-              result = process_macro(p, api_map, name_pin.context, locals)
-              # @sg-ignore flow sensitive typing should be able to handle redefinition
-              next result unless result.return_type.undefined?
+              macro_pin = process_macro(p, api_map, name_pin.context, locals)
+              next macro_pin unless macro_pin.return_type.undefined?
             elsif !p.directives.empty?
-              result = process_directive(p, api_map, name_pin.context, locals)
-              # @sg-ignore flow sensitive typing should be able to handle redefinition
-              next result unless result.return_type.undefined?
+              directive_pin = process_directive(p, api_map, name_pin.context, locals)
+              next directive_pin unless directive_pin.return_type.undefined?
             end
             p
           end

--- a/spec/pin/local_variable_spec.rb
+++ b/spec/pin/local_variable_spec.rb
@@ -192,4 +192,79 @@ describe Solargraph::Pin::LocalVariable do
       expect(i.visible_at?(each_block_pin, location)).to be true
     end
   end
+
+  describe 'assignment inside a block' do
+    # @param code [String]
+    # @param line [Integer]
+    # @param column [Integer]
+    # @return [String]
+    def infer_at code, line, column
+      source = Solargraph::Source.load_string(code, 'test.rb')
+      api_map = Solargraph::ApiMap.new
+      api_map.map source
+      api_map.clip_at('test.rb', [line, column]).infer.to_s
+    end
+
+    it 'unions the outer value with the value assigned in the block' do
+      # the block may run zero times, so the pre-block nil survives
+      expect(infer_at(%(
+        def foo
+          x = nil
+          [1].each do |_i|
+            x = ['a']
+          end
+          x
+        end
+      ), 6, 10)).to eq('nil, Array')
+    end
+
+    it 'reaches an outer local through nested blocks' do
+      expect(infer_at(%(
+        def foo
+          x = nil
+          [1].each do |_i|
+            [2].each do |_j|
+              x = ['a']
+            end
+          end
+          x
+        end
+      ), 8, 10)).to eq('nil, Array')
+    end
+
+    it 'keeps a block parameter of the same name block-local' do
+      expect(infer_at(%(
+        def foo
+          x = 'str'
+          [1].each do |x|
+            x = 2
+          end
+          x
+        end
+      ), 6, 10)).to eq('String')
+    end
+
+    it 'keeps a name first assigned inside the block out of the outer scope' do
+      expect(infer_at(%(
+        def foo
+          [1].each do |_i|
+            y = 2
+          end
+          y
+        end
+      ), 5, 10)).to eq('undefined')
+    end
+
+    it 'does not union an assignment that only follows the block' do
+      expect(infer_at(%(
+        def foo
+          [1].each do |_i|
+            w = 'str'
+          end
+          w = 5
+          w
+        end
+      ), 6, 10)).to eq('Integer')
+    end
+  end
 end

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -111,6 +111,25 @@ describe Solargraph::Source::Chain::Call do
     expect(type.tag).to eq('String')
   end
 
+  it 'expands a named macro reached through a non-macro directive that shares its name' do
+    source = Solargraph::Source.load_string(%(
+      class Foo
+        # @!macro mymacro
+        #   @return [$1]
+        def self.template; end
+
+        # @!method mymacro
+        def bar(arg); end
+      end
+      Foo.new.bar(String)
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map(source)
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(9, 17))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    expect(type.tag).to eq('String')
+  end
+
   it 'infers generic types from Array#reverse' do
     source = Solargraph::Source.load_string(%(
       # @type [Array<String>]


### PR DESCRIPTION
**Problem:** A local reassigned inside a block loses that assignment from its type once the block ends, so a call that is safe at runtime cannot be inferred.

```ruby
# @param lines [Array<String>]
# @return [Integer, nil]
def foo lines       # foo return type could not be inferred
  x = nil
  lines.each { |line| x = [line] }
  x&.length
end
```

The same assignment inside an `if` infers `nil, Array` and checks clean.

**Solution:** `LvasgnNode#process` attached the pin to the `Pin::Block`, whose presence ends at the block's closing token; it now walks outward to the enclosing closure already holding that name.

A name the block introduces itself — parameter, shadow arg, or first assignment — stays block-local.

Inference becomes `nil, Array`, not `Array`: the block is not assumed to run, so the pre-block value stays in the union and genuine nil errors survive.

`Call#inferred_pins` is here because its `pins.map` block shadowed the outer `result=` with two inner `result` assignments the new tracking now picks up; both are renamed.

This PR was written by Claude Code on behalf of @apiology.

