### PR TITLE
Support blocks with implicit parameters (_1, it) and backtick commands

### DIFF
--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -56,7 +56,7 @@ module Solargraph
           return generate_links(n.children[0]) if n.type == :splat
           # @type [Array<Chain::Link>]
           result = []
-          if n.type == :block
+          if %i[block numblock].include?(n.type)
             result.concat NodeChainer.chain(n.children[0], @filename, n).links
           elsif n.type == :send
             if n.children[0].is_a?(::Parser::AST::Node)
@@ -171,7 +171,7 @@ module Solargraph
         # @param node [Parser::AST::Node]
         # @return [Source::Chain, nil]
         def passed_block node
-          return unless node == @node && @parent&.type == :block
+          return unless node == @node && %i[block numblock].include?(@parent&.type)
 
           # @sg-ignore Need to add nil check here
           NodeChainer.chain(@parent.children[2], @filename)

--- a/lib/solargraph/parser/parser_gem/node_methods.rb
+++ b/lib/solargraph/parser/parser_gem/node_methods.rb
@@ -203,7 +203,7 @@ module Solargraph
         def call_nodes_from node
           return [] unless node.is_a?(::Parser::AST::Node)
           result = []
-          if node.type == :block
+          if %i[block numblock].include?(node.type)
             result.push node
             if Parser.is_ast_node?(node.children[0]) && node.children[0].children.length > 2
               # @sg-ignore Need to add nil check here
@@ -444,7 +444,7 @@ module Solargraph
             FIRST_TWO_CHILDREN = [:rescue].freeze
             COMPOUND_STATEMENTS = %i[begin kwbegin].freeze
             SKIPPABLE = %i[def defs class sclass module].freeze
-            FUNCTION_VALUE = [:block].freeze
+            FUNCTION_VALUE = %i[block numblock].freeze
             CASE_STATEMENT = [:case].freeze
 
             # @param node [AST::Node] a method body compound statement
@@ -534,7 +534,7 @@ module Solargraph
               result = []
               nodes = parent.children.select { |n| n.is_a?(AST::Node) }
               nodes.each_with_index do |node, idx|
-                if node.type == :block
+                if FUNCTION_VALUE.include?(node.type)
                   result.concat explicit_return_values_from_compound_statement(node.children[2])
                 elsif node.type == :rescue
                   # body statements
@@ -614,7 +614,7 @@ module Solargraph
                   # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
                   result.concat reduce_to_value_nodes(node.children)
                 # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
-                elsif node.type == :block
+                elsif FUNCTION_VALUE.include?(node.type)
                   # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
                   result.concat explicit_return_values_from_compound_statement(node.children[2])
                 # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check

--- a/lib/solargraph/parser/parser_gem/node_methods.rb
+++ b/lib/solargraph/parser/parser_gem/node_methods.rb
@@ -42,7 +42,7 @@ module Solargraph
         # @return [String, nil]
         def infer_literal_node_type node
           return nil unless node.is_a?(AST::Node)
-          if %i[str dstr].include?(node.type)
+          if %i[str dstr xstr].include?(node.type)
             return '::String'
           elsif node.type == :array
             return '::Array'

--- a/lib/solargraph/parser/parser_gem/node_processors.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors.rb
@@ -61,6 +61,7 @@ module Solargraph
       register :args,         ParserGem::NodeProcessors::ArgsNode
       register :forward_args, ParserGem::NodeProcessors::ArgsNode
       register :block,        ParserGem::NodeProcessors::BlockNode
+      register :numblock,     ParserGem::NodeProcessors::BlockNode
       register :or_asgn,      ParserGem::NodeProcessors::OrasgnNode
       register :op_asgn,      ParserGem::NodeProcessors::OpasgnNode
       register :sym,          ParserGem::NodeProcessors::SymNode

--- a/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
@@ -28,10 +28,35 @@ module Solargraph
               source: :parser
             )
             pins.push block_pin
+            add_numbered_parameters block_pin if node.type == :numblock
             process_children region.update(closure: block_pin)
           end
 
           private
+
+          # A numblock node stores the highest numbered parameter used in
+          # its body (e.g., 2 for `_2`) instead of an args node, so the
+          # parameter pins have to be synthesized here.
+          #
+          # @param block_pin [Pin::Block]
+          # @return [void]
+          def add_numbered_parameters block_pin
+            count = node.children[1]
+            return unless count.is_a?(::Integer)
+
+            (1..count).each do |number|
+              locals.push Solargraph::Pin::Parameter.new(
+                location: block_pin.location,
+                closure: block_pin,
+                name: "_#{number}",
+                # @sg-ignore Need to add nil check here
+                presence: block_pin.location.range,
+                decl: :arg,
+                source: :parser
+              )
+              block_pin.parameters.push locals.last
+            end
+          end
 
           def other_class_eval?
             node.children[0].type == :send &&

--- a/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
@@ -28,34 +28,107 @@ module Solargraph
               source: :parser
             )
             pins.push block_pin
-            add_numbered_parameters block_pin if node.type == :numblock
+            add_implicit_parameters block_pin
             process_children region.update(closure: block_pin)
           end
 
           private
 
-          # A numblock node stores the highest numbered parameter used in
-          # its body (e.g., 2 for `_2`) instead of an args node, so the
-          # parameter pins have to be synthesized here.
+          # Blocks written with implicit parameters carry no args node for
+          # ArgsNode to work from, so their parameter pins are synthesized
+          # here instead.
           #
           # @param block_pin [Pin::Block]
           # @return [void]
-          def add_numbered_parameters block_pin
-            count = node.children[1]
-            return unless count.is_a?(::Integer)
-
-            (1..count).each do |number|
-              locals.push Solargraph::Pin::Parameter.new(
-                location: block_pin.location,
-                closure: block_pin,
-                name: "_#{number}",
-                # @sg-ignore Need to add nil check here
-                presence: block_pin.location.range,
-                decl: :arg,
-                source: :parser
-              )
-              block_pin.parameters.push locals.last
+          def add_implicit_parameters block_pin
+            if node.type == :numblock
+              numbered_parameter_count.times { |idx| add_parameter block_pin, "_#{idx + 1}" }
+            elsif implicit_it_parameter?
+              add_parameter block_pin, 'it'
             end
+          end
+
+          # A numblock stores the highest numbered parameter its body uses
+          # (2 for `_2`) where an ordinary block stores its args node.
+          #
+          # @sg-ignore flow sensitive typing does not narrow the return value through the is_a? guard
+          # @return [Integer]
+          def numbered_parameter_count
+            count = node.children[1]
+            return 0 unless count.is_a?(::Integer)
+
+            count
+          end
+
+          # An `it` block reaches us as an ordinary block with an empty args
+          # node, so the node itself records nothing about the parameter and
+          # the only available signal is an `it` reference in the body.
+          #
+          # Mixing `it` with ordinary parameters is a syntax error, so an
+          # empty args node is a precondition rather than a guess. A local
+          # variable named `it` in an enclosing scope does take precedence
+          # over the implicit parameter, and is parsed identically, so it has
+          # to be excluded here.
+          #
+          # @return [Boolean]
+          def implicit_it_parameter?
+            args = node.children[1]
+            return false unless Parser.is_ast_node?(args)
+            # @sg-ignore Translate to something flow sensitive typing understands
+            return false unless args.type == :args && args.children.empty?
+            return false if shadowed_it_local?
+            references_it?(node.children[2])
+          end
+
+          # Only a local variable declared outside any block shadows the
+          # implicit parameter. A block's own `it` must not stop a nested
+          # block from having one: in `xs.map { it.map { it.upcase } }` each
+          # `it` belongs to the block it appears in.
+          #
+          # @return [Boolean]
+          def shadowed_it_local?
+            loc = get_node_location(node)
+            locals.any? do |pin|
+              pin.name == 'it' && !pin.closure.is_a?(Pin::Block) && pin.visible_at?(region.closure, loc)
+            end
+          end
+
+          # `it` inside a nested block belongs to that block, so the search
+          # skips a nested block's body. Its receiver and arguments are still
+          # searched, since those sit in the enclosing block: the `it` in
+          # `xs.map { it.map { |y| y } }` is the outer block's parameter.
+          #
+          # @param subject [BasicObject, nil]
+          # @return [Boolean]
+          def references_it? subject
+            return false unless Parser.is_ast_node?(subject)
+            # @sg-ignore Translate to something flow sensitive typing understands
+            return true if subject.type == :lvar && subject.children[0] == :it
+            # @sg-ignore Translate to something flow sensitive typing understands
+            children = if %i[block numblock].include?(subject.type)
+                         # @sg-ignore Translate to something flow sensitive typing understands
+                         subject.children[0..1]
+                       else
+                         # @sg-ignore Translate to something flow sensitive typing understands
+                         subject.children
+                       end
+            children.any? { |child| references_it?(child) }
+          end
+
+          # @param block_pin [Pin::Block]
+          # @param name [String]
+          # @return [void]
+          def add_parameter block_pin, name
+            locals.push Solargraph::Pin::Parameter.new(
+              location: block_pin.location,
+              closure: block_pin,
+              name: name,
+              # @sg-ignore Need to add nil check here
+              presence: block_pin.location.range,
+              decl: :arg,
+              source: :parser
+            )
+            block_pin.parameters.push locals.last
           end
 
           def other_class_eval?

--- a/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
@@ -34,9 +34,7 @@ module Solargraph
 
           private
 
-          # Blocks written with implicit parameters (numblocks, `it`)
-          # carry no args node for ArgsNode to work from, so their
-          # parameter pins are synthesized here instead.
+          # Numblocks and `it` blocks have no args node for ArgsNode to work from.
           #
           # @param block_pin [Pin::Block]
           # @return [void]
@@ -48,10 +46,9 @@ module Solargraph
             end
           end
 
-          # A numblock stores its highest numbered parameter (2 for `_2`)
-          # where an ordinary block stores its args node.
+          # A numblock stores its highest numbered parameter (2 for `_2`) where a block stores its args node.
           #
-          # @sg-ignore flow sensitive typing does not narrow the return value through the is_a? guard
+          # @sg-ignore flow sensitive typing needs to narrow down type with an if is_a? check
           # @return [Integer]
           def numbered_parameter_count
             count = node.children[1]
@@ -60,42 +57,23 @@ module Solargraph
             count
           end
 
-          # An `it` block reaches us as an ordinary block with an empty args
-          # node, so the node itself records nothing about the parameter and
-          # the only available signal is an `it` reference in the body.
-          #
-          # Mixing `it` with ordinary parameters is a syntax error, so an
-          # empty args node is a precondition rather than a guess. A local
-          # variable named `it` in an enclosing scope does take precedence
-          # over the implicit parameter, and is parsed identically, so it has
-          # to be excluded here.
+          # An `it` block parses as an ordinary block with an empty args node, so the only
+          # signal is an `it` reference in the body. Mixing `it` with named parameters is a
+          # syntax error, so the empty args node is a precondition rather than a guess.
           #
           # @return [Boolean]
           def implicit_it_parameter?
             args = node.children[1]
             return false unless Parser.is_ast_node?(args)
-            # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper -
-            #   flow-sensitive typing only recognizes a literal is_a? call
-            #   on the guarded variable, not one wrapped in a helper
-            #   predicate method like Parser.is_ast_node? above. No
-            #   upstream issue filed yet.
+            # @sg-ignore flow sensitive typing needs to narrow through a predicate method like Parser.is_ast_node?
             return false unless args.type == :args && args.children.empty?
             return false if shadowed_it_local?
             references_it?(node.children[2])
           end
 
-          # Only a local variable declared outside any block shadows the
-          # implicit parameter. A block's own `it` must not stop a nested
-          # block from having one: in `xs.map { it.map { it.upcase } }` each
-          # `it` belongs to the block it appears in.
-          #
-          # This diverges from Ruby for an enclosing block with an
-          # explicit `it` parameter: `xs.map { |it| ys.map { it } }`
-          # reads the inner `it` as the outer parameter, but here the
-          # inner block gets its own. A synthesized `it` pin looks
-          # identical to an explicit one, so honoring the explicit case
-          # would also stop `[[1]].each { it.each { it } }`'s inner block
-          # from getting its own `it`.
+          # Only a local declared outside any block shadows the implicit parameter, so a
+          # nested block still gets its own. A synthesized `it` is indistinguishable from an
+          # explicit `|it|`, so an outer `|it|` does not shadow either, unlike in Ruby.
           #
           # @return [Boolean]
           def shadowed_it_local?
@@ -105,24 +83,21 @@ module Solargraph
             end
           end
 
-          # `it` inside a nested block belongs to that block, so the search
-          # skips a nested block's body. Its receiver and arguments are still
-          # searched, since those sit in the enclosing block: the `it` in
-          # `xs.map { it.map { |y| y } }` is the outer block's parameter.
+          # Skips a nested block's body, whose `it` belongs to that block, but still searches
+          # its receiver and arguments: those sit in the enclosing block.
           #
           # @param subject [BasicObject, nil]
           # @return [Boolean]
           def references_it? subject
             return false unless Parser.is_ast_node?(subject)
-            # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper -
-            #   same Parser.is_ast_node? gap as in #implicit_it_parameter?
+            # @sg-ignore flow sensitive typing needs to narrow through a predicate method like Parser.is_ast_node?
             return true if subject.type == :lvar && subject.children[0] == :it
-            # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
+            # @sg-ignore flow sensitive typing needs to narrow through a predicate method like Parser.is_ast_node?
             children = if %i[block numblock].include?(subject.type)
-                         # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
+                         # @sg-ignore flow sensitive typing needs to narrow through a predicate method like Parser.is_ast_node?
                          subject.children[0..1]
                        else
-                         # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
+                         # @sg-ignore flow sensitive typing needs to narrow through a predicate method like Parser.is_ast_node?
                          subject.children
                        end
             children.any? { |child| references_it?(child) }

--- a/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
@@ -85,6 +85,13 @@ module Solargraph
           # block from having one: in `xs.map { it.map { it.upcase } }` each
           # `it` belongs to the block it appears in.
           #
+          # This diverges from Ruby for an enclosing block with an explicit
+          # parameter named `it`. In `xs.map { |it| ys.map { it } }` Ruby
+          # reads the inner `it` as the outer parameter; this gives the
+          # inner block its own. Treating a block parameter as a shadow
+          # instead would break every nested implicit `it`, which is the
+          # far more common shape.
+          #
           # @return [Boolean]
           def shadowed_it_local?
             loc = get_node_location(node)

--- a/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
@@ -34,12 +34,9 @@ module Solargraph
 
           private
 
-          # Blocks written with implicit parameters carry no args node for
-          # ArgsNode to work from, so their parameter pins are synthesized
-          # here instead. A numblock is a regular block that has no args
-          # node - it stores its highest numbered parameter where an
-          # ordinary block stores that node instead (see
-          # #numbered_parameter_count).
+          # Blocks written with implicit parameters (numblocks, `it`)
+          # carry no args node for ArgsNode to work from, so their
+          # parameter pins are synthesized here instead.
           #
           # @param block_pin [Pin::Block]
           # @return [void]
@@ -51,14 +48,8 @@ module Solargraph
             end
           end
 
-          # A numblock stores the highest numbered parameter its body uses
-          # (2 for `_2`) where an ordinary block stores its args node, e.g.
-          # `[1, 2].each { _1 + _2 }` parses as:
-          #
-          #   s(:numblock,
-          #     s(:send, s(:array, s(:int, 1), s(:int, 2)), :each),
-          #     2,
-          #     s(:send, s(:lvar, :_1), :+, s(:lvar, :_2)))
+          # A numblock stores its highest numbered parameter (2 for `_2`)
+          # where an ordinary block stores its args node.
           #
           # @sg-ignore flow sensitive typing does not narrow the return value through the is_a? guard
           # @return [Integer]
@@ -98,12 +89,13 @@ module Solargraph
           # block from having one: in `xs.map { it.map { it.upcase } }` each
           # `it` belongs to the block it appears in.
           #
-          # This diverges from Ruby for an enclosing block with an explicit
-          # parameter named `it`. In `xs.map { |it| ys.map { it } }` Ruby
-          # reads the inner `it` as the outer parameter; this gives the
-          # inner block its own. Treating a block parameter as a shadow
-          # instead would break every nested implicit `it`, which is the
-          # far more common shape.
+          # This diverges from Ruby for an enclosing block with an
+          # explicit `it` parameter: `xs.map { |it| ys.map { it } }`
+          # reads the inner `it` as the outer parameter, but here the
+          # inner block gets its own. A synthesized `it` pin looks
+          # identical to an explicit one, so honoring the explicit case
+          # would also stop `[[1]].each { it.each { it } }`'s inner block
+          # from getting its own `it`.
           #
           # @return [Boolean]
           def shadowed_it_local?

--- a/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/block_node.rb
@@ -36,20 +36,29 @@ module Solargraph
 
           # Blocks written with implicit parameters carry no args node for
           # ArgsNode to work from, so their parameter pins are synthesized
-          # here instead.
+          # here instead. A numblock is a regular block that has no args
+          # node - it stores its highest numbered parameter where an
+          # ordinary block stores that node instead (see
+          # #numbered_parameter_count).
           #
           # @param block_pin [Pin::Block]
           # @return [void]
           def add_implicit_parameters block_pin
             if node.type == :numblock
-              numbered_parameter_count.times { |idx| add_parameter block_pin, "_#{idx + 1}" }
+              numbered_parameter_count.times { |idx| add_implicit_parameter block_pin, "_#{idx + 1}" }
             elsif implicit_it_parameter?
-              add_parameter block_pin, 'it'
+              add_implicit_parameter block_pin, 'it'
             end
           end
 
           # A numblock stores the highest numbered parameter its body uses
-          # (2 for `_2`) where an ordinary block stores its args node.
+          # (2 for `_2`) where an ordinary block stores its args node, e.g.
+          # `[1, 2].each { _1 + _2 }` parses as:
+          #
+          #   s(:numblock,
+          #     s(:send, s(:array, s(:int, 1), s(:int, 2)), :each),
+          #     2,
+          #     s(:send, s(:lvar, :_1), :+, s(:lvar, :_2)))
           #
           # @sg-ignore flow sensitive typing does not narrow the return value through the is_a? guard
           # @return [Integer]
@@ -74,7 +83,11 @@ module Solargraph
           def implicit_it_parameter?
             args = node.children[1]
             return false unless Parser.is_ast_node?(args)
-            # @sg-ignore Translate to something flow sensitive typing understands
+            # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper -
+            #   flow-sensitive typing only recognizes a literal is_a? call
+            #   on the guarded variable, not one wrapped in a helper
+            #   predicate method like Parser.is_ast_node? above. No
+            #   upstream issue filed yet.
             return false unless args.type == :args && args.children.empty?
             return false if shadowed_it_local?
             references_it?(node.children[2])
@@ -109,14 +122,15 @@ module Solargraph
           # @return [Boolean]
           def references_it? subject
             return false unless Parser.is_ast_node?(subject)
-            # @sg-ignore Translate to something flow sensitive typing understands
+            # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper -
+            #   same Parser.is_ast_node? gap as in #implicit_it_parameter?
             return true if subject.type == :lvar && subject.children[0] == :it
-            # @sg-ignore Translate to something flow sensitive typing understands
+            # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
             children = if %i[block numblock].include?(subject.type)
-                         # @sg-ignore Translate to something flow sensitive typing understands
+                         # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
                          subject.children[0..1]
                        else
-                         # @sg-ignore Translate to something flow sensitive typing understands
+                         # @sg-ignore tool-limitation:is_a-narrowing:predicate-wrapper
                          subject.children
                        end
             children.any? { |child| references_it?(child) }
@@ -125,7 +139,7 @@ module Solargraph
           # @param block_pin [Pin::Block]
           # @param name [String]
           # @return [void]
-          def add_parameter block_pin, name
+          def add_implicit_parameter block_pin, name
             locals.push Solargraph::Pin::Parameter.new(
               location: block_pin.location,
               closure: block_pin,

--- a/lib/solargraph/type_checker.rb
+++ b/lib/solargraph/type_checker.rb
@@ -327,7 +327,7 @@ module Solargraph
         chain = Solargraph::Parser.chain(call, filename)
         # @sg-ignore Need to add nil check here
         closure_pin = source_map.locate_closure_pin(rng.start.line, rng.start.column)
-        if call.type == :block
+        if %i[block numblock].include?(call.type)
           # blocks in the AST include the method call as well, so the
           # node returned by #call_nodes_from needs to be backed out
           # one closure

--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -14,8 +14,6 @@ Gem::Specification.new do |s|
   s.authors     = ['Fred Snyder']
   s.email       = 'admin@castwide.com'
   s.files       = Dir.chdir(File.expand_path(__dir__)) do
-    # @sg-ignore Need backtick support
-    # @type [String]
     all_files = `git ls-files -z`
     all_files.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end

--- a/spec/parser/node_methods_spec.rb
+++ b/spec/parser/node_methods_spec.rb
@@ -17,6 +17,18 @@ describe Solargraph::Parser::NodeMethods do
     expect(described_class.infer_literal_node_type(ast.children[1])).to eq '::String'
   end
 
+  it 'infers backticks as strings' do
+    ast = parse('x = `echo hi`')
+    expect(described_class.infer_literal_node_type(ast.children[1])).to eq '::String'
+  end
+
+  it 'infers interpolated backticks as strings' do
+    ast = parse(<<~'RUBY')
+      x = `echo #{y}`
+    RUBY
+    expect(described_class.infer_literal_node_type(ast.children[1])).to eq '::String'
+  end
+
   it 'infers literal hashes' do
     ast = parse('x = {}')
     expect(described_class.infer_literal_node_type(ast.children[1])).to eq '::Hash'

--- a/spec/parser/node_processor_spec.rb
+++ b/spec/parser/node_processor_spec.rb
@@ -79,4 +79,15 @@ describe Solargraph::Parser::NodeProcessor do
 
     expect(map.pins.last.type.to_s).to eq('Array<String>')
   end
+
+  it 'creates block pins with synthesized parameters for numbered blocks' do
+    map = Solargraph::SourceMap.load_string(%(
+      [1, 2].each { _2 }
+    ), 'test.rb')
+
+    block = map.pins.find { |pin| pin.is_a?(Solargraph::Pin::Block) }
+    expect(block).not_to be_nil
+    expect(block.parameters.map(&:name)).to eq(%w[_1 _2])
+    expect(map.locals.map(&:name)).to include('_1', '_2')
+  end
 end

--- a/spec/parser/node_processor_spec.rb
+++ b/spec/parser/node_processor_spec.rb
@@ -90,4 +90,34 @@ describe Solargraph::Parser::NodeProcessor do
     expect(block.parameters.map(&:name)).to eq(%w[_1 _2])
     expect(map.locals.map(&:name)).to include('_1', '_2')
   end
+
+  it 'creates block pins with a synthesized parameter for implicit `it` blocks' do
+    map = Solargraph::SourceMap.load_string(%(
+      [1, 2].each { it }
+    ), 'test.rb')
+
+    block = map.pins.find { |pin| pin.is_a?(Solargraph::Pin::Block) }
+    expect(block).not_to be_nil
+    expect(block.parameters.map(&:name)).to eq(['it'])
+  end
+
+  it 'leaves a parameterless block without parameters' do
+    map = Solargraph::SourceMap.load_string(%(
+      [1, 2].each { puts 'x' }
+    ), 'test.rb')
+
+    block = map.pins.find { |pin| pin.is_a?(Solargraph::Pin::Block) }
+    expect(block).not_to be_nil
+    expect(block.parameters).to be_empty
+  end
+
+  it 'gives each nested block its own implicit `it` parameter' do
+    map = Solargraph::SourceMap.load_string(%(
+      [[1]].each { it.each { it } }
+    ), 'test.rb')
+
+    blocks = map.pins.grep(Solargraph::Pin::Block)
+    expect(blocks.length).to eq(2)
+    expect(blocks.map { |b| b.parameters.map(&:name) }).to eq([['it'], ['it']])
+  end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -971,5 +971,84 @@ describe Solargraph::TypeChecker do
       ))
       expect(checker.problems.map(&:message)).to include('Unresolved call to no_such_method on String')
     end
+
+    it 'infers the type of an implicit `it` block parameter' do
+      checker = type_checker(%(
+        # @param xs [Array<String>]
+        # @return [Array<String>]
+        def it_map(xs)
+          xs.map { it.upcase }
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'catches a return tag that disagrees with an `it` block' do
+      checker = type_checker(%(
+        # @param xs [Array<String>]
+        # @return [Array<Integer>]
+        def it_mismatch(xs)
+          xs.map { it }
+        end
+      ))
+      expect(checker.problems.map(&:message))
+        .to include('Declared return type ::Array<::Integer> does not match inferred type ::Array<::String> for #it_mismatch')
+    end
+
+    it 'catches a return tag that disagrees with an explicit block parameter' do
+      checker = type_checker(%(
+        # @param xs [Array<String>]
+        # @return [Array<Integer>]
+        def ex_mismatch(xs)
+          xs.map { |s| s }
+        end
+      ))
+      expect(checker.problems.map(&:message))
+        .to include('Declared return type ::Array<::Integer> does not match inferred type ::Array<::String> for #ex_mismatch')
+    end
+
+    it 'accepts `it` used as an argument' do
+      checker = type_checker(%(
+        # @param xs [Array<String>]
+        # @param x [String]
+        # @return [Boolean]
+        def with_it(xs, x)
+          xs.any? { x.include?(it) }
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'lets a local variable named `it` take precedence over the implicit parameter' do
+      checker = type_checker(%(
+        # @return [Array<Integer>]
+        def shadowed
+          it = 5
+          ['a'].map { it }
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'gives a nested block its own parameter alongside an outer `it`' do
+      checker = type_checker(%(
+        # @param xs [Array<Array<String>>]
+        # @return [Array<Array<String>>]
+        def nested(xs)
+          xs.map { it.map { |s| s.upcase } }
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'does not invent a parameter for a block that takes none' do
+      checker = type_checker(%(
+        # @return [Array<Integer>]
+        def plain
+          [1].map { 5 }
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
   end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -925,5 +925,51 @@ describe Solargraph::TypeChecker do
       # an error when trying to declare sub as Subclass
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
+
+    it 'infers the return type of a call with a numbered block parameter' do
+      checker = type_checker(%(
+        # @param xs [Array<String>]
+        # @param x [String]
+        # @return [Boolean]
+        def numbered(xs, x)
+          xs.any? { x.include?(_1) }
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'infers the return type of a call with an explicit block parameter' do
+      checker = type_checker(%(
+        # @param xs [Array<String>]
+        # @param x [String]
+        # @return [Boolean]
+        def explicit(xs, x)
+          xs.any? { |s| x.include?(s) }
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'treats a numbered block as a block instead of a blockless call' do
+      checker = type_checker(%(
+        # @param xs [Array<String>]
+        # @return [Array<String>]
+        def numbered_map(xs)
+          xs.map { _1.upcase }
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'infers the type of a numbered block parameter' do
+      checker = type_checker(%(
+        # @param xs [Array<String>]
+        # @return [Array<String>]
+        def numbered_map(xs)
+          xs.map { _1.no_such_method }
+        end
+      ))
+      expect(checker.problems.map(&:message)).to include('Unresolved call to no_such_method on String')
+    end
   end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1050,5 +1050,30 @@ describe Solargraph::TypeChecker do
       ))
       expect(checker.problems).to be_empty
     end
+
+    it 'infers String from a backtick command' do
+      checker = type_checker(%(
+        class Foo
+          # @return [String]
+          def bar
+            `echo hi`.strip
+          end
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
+    it 'infers String from an interpolated backtick command' do
+      checker = type_checker(%q(
+        class Foo
+          # @return [String]
+          def bar
+            cmd = 'echo hi'
+            `#{cmd}`.strip
+          end
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
   end
 end


### PR DESCRIPTION
Three block and literal forms have no type at `--level strong`, so calls on them are unresolved and enclosing methods lose their return type.

```ruby
# @return [Array<String>]
def numbered
  'a,b'.split(',').map { _1.upcase }   # Unresolved call to _1
end

# @return [Array<String>]
def implicit_it
  'a,b'.split(',').map { it.upcase }   # Unresolved call to it
end

# @return [String]
def backticks
  `hostname`.strip                     # Unresolved call to strip
end
```

All are clean in explicit form. A wrong tag also passes silently on the implicit block form: `@return [Array<Integer>]` on `'a,b'.split(',').map { it }` reports nothing.

`_1` produces a `numblock` node, so the call was chained as though no block were passed. `it` arrives as an ordinary block missing only its parameter — hence the silent pass. Backticks produce an `xstr` node, absent from the literal type table. Neither block form records parameters as an args node does, so both are synthesized; a local named `it` still wins, matching Ruby.

This PR was written by Claude Code on behalf of @apiology.

