### PR TITLE
Let solargraph-rails spec failures fail CI again

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -235,5 +235,3 @@ jobs:
         ALLOW_IMPROVEMENTS=true bundle exec rake spec
       env:
         MATRIX_RAILS_VERSION: "7.0"
-      # @todo Temporary, expect to revert in 0.60
-      continue-on-error: true


### PR DESCRIPTION
**Claude:**

A solargraph-rails regression caught by `run_solargraph_rails_specs` is still reported as a green check: the step has carried `continue-on-error: true` since #1200, whose `@todo` named 0.60 as the revert point. Solargraph is now at 0.60.4.

This removes the stub from that one step; the others #1200 added are untouched.

This PR was written by Claude Code on behalf of @apiology.

