### PR TITLE
Narrow types inside an until loop body

### DIFF
--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -190,6 +190,43 @@ module Solargraph
         process_expression(conditional_node, true_ranges, false_ranges)
       end
 
+      # @param until_node [Parser::AST::Node]
+      # @param true_ranges [Array<Range>]
+      # @param false_ranges [Array<Range>]
+      #
+      # @return [void]
+      def process_until until_node, true_ranges = [], false_ranges = []
+        return if until_node.type != :until
+
+        # [3] pry(main)> Parser::CurrentRuby.parse("until a; b; c; end")
+        # => s(:until,
+        #   s(:send, nil, :a),
+        #   s(:begin,
+        #     s(:send, nil, :b),
+        #     s(:send, nil, :c)))
+        # [4] pry(main)>
+        conditional_node = until_node.children[0]
+        return if conditional_node.nil?
+
+        # @type [Parser::AST::Node, nil]
+        do_clause = until_node.children[1]
+
+        unless do_clause.nil?
+          #
+          # The do clause runs only while the condition is false, so
+          # the condition's false facts hold throughout it.  Nothing
+          # is asserted after the loop - the body may run zero times,
+          # and a break can leave it with the condition still false.
+          #
+          before_do_clause_loc = do_clause.location.expression.adjust(begin_pos: -1)
+          before_do_clause_pos = Position.new(before_do_clause_loc.line, before_do_clause_loc.column)
+          false_ranges << Range.new(before_do_clause_pos,
+                                    get_node_end_position(do_clause))
+        end
+
+        process_expression(conditional_node, true_ranges, false_ranges)
+      end
+
       class << self
         include Logging
       end

--- a/lib/solargraph/parser/parser_gem/node_processors/until_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/until_node.rb
@@ -8,6 +8,11 @@ module Solargraph
           include ParserGem::NodeMethods
 
           def process
+            FlowSensitiveTyping.new(locals,
+                                    ivars,
+                                    enclosing_breakable_pin,
+                                    enclosing_compound_statement_pin).process_until(node)
+
             location = get_node_location(node)
             # Note - this should not be considered a block, as the
             # until statement doesn't create a closure - e.g.,

--- a/lib/solargraph/pin/common.rb
+++ b/lib/solargraph/pin/common.rb
@@ -99,7 +99,6 @@ module Solargraph
           elsif here.is_a?(Pin::Method)
             return here.context
           end
-          # @sg-ignore Need to add nil check here
           here = here.closure
         end
         ComplexType::ROOT

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -766,6 +766,86 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.rooted_tags).to eq('::Boolean, nil')
   end
 
+  it 'uses .nil? in an until condition to refine types in the loop body' do
+    source = Solargraph::Source.load_string(%(
+      class Foo
+        # @param baz [::Boolean, nil]
+        # @return [void]
+        def bar(baz: nil)
+          baz
+          until baz.nil?
+            baz
+            break
+          end
+          baz
+        end
+      end
+    ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [5, 10])
+    expect(clip.infer.rooted_tags).to eq('::Boolean, nil')
+
+    clip = api_map.clip_at('test.rb', [7, 12])
+    expect(clip.infer.rooted_tags).to eq('::Boolean')
+
+    # the body may run zero times and may break, so nothing is
+    # asserted once the loop is over
+    clip = api_map.clip_at('test.rb', [10, 10])
+    expect(clip.infer.rooted_tags).to eq('::Boolean, nil')
+  end
+
+  it 'uses .nil? in an until condition to refine types in a loop body which reassigns the variable' do
+    source = Solargraph::Source.load_string(%(
+      class Foo
+        # @param baz [::Boolean, nil]
+        # @param other [::Boolean, nil]
+        # @return [void]
+        def bar(baz: nil, other: nil)
+          baz
+          until baz.nil?
+            baz
+            baz = other
+          end
+          baz
+        end
+      end
+    ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [6, 10])
+    expect(clip.infer.rooted_tags).to eq('::Boolean, nil')
+
+    clip = api_map.clip_at('test.rb', [8, 12])
+    expect(clip.infer.rooted_tags).to eq('::Boolean')
+
+    clip = api_map.clip_at('test.rb', [11, 10])
+    expect(clip.infer.rooted_tags).to eq('::Boolean, nil')
+  end
+
+  it 'does not use a post-condition until to refine types in the loop body' do
+    source = Solargraph::Source.load_string(%(
+      class Foo
+        # @param baz [::Boolean, nil]
+        # @return [void]
+        def bar(baz: nil)
+          begin
+            baz
+          end until baz.nil?
+          baz
+        end
+      end
+    ), 'test.rb')
+
+    api_map = Solargraph::ApiMap.new.map(source)
+    # the body runs once before the condition is ever evaluated
+    clip = api_map.clip_at('test.rb', [6, 12])
+    expect(clip.infer.rooted_tags).to eq('::Boolean, nil')
+
+    clip = api_map.clip_at('test.rb', [8, 10])
+    expect(clip.infer.rooted_tags).to eq('::Boolean, nil')
+  end
+
   it 'uses .nil? in a return if() in an until to refine types using nil checks' do
     source = Solargraph::Source.load_string(%(
       class Foo


### PR DESCRIPTION
`until` loops got no flow-sensitive narrowing at all, so a guard that works in a `while` silently does nothing:

```ruby
until here.nil?
  here = here.closure   # Unresolved call to closure
end
```

Every `until x.nil?` or `until x.is_a?(Y)` body typechecks against the un-narrowed type, producing false "unresolved call" problems that can only be suppressed. `UntilNode#process` never constructed a `FlowSensitiveTyping`.

`process_until` mirrors `process_while` with the polarity inverted: the body runs only while the condition is false, so the condition's false facts are asserted over the body's range.

Two deliberate boundaries:

- **Nothing is asserted after the loop.** The body may run zero times, and `break` can leave the condition still false.
- **`:until_post` (`begin ... end until`) is left alone** ��� its body runs once before the condition is ever evaluated.

Solargraph's own `Pin::Common#find_context` uses this shape; its `@sg-ignore` is no longer needed and is removed here.

rspec 1624 ��� 1627, rubocop unchanged, `typecheck --level strong` unchanged at 526.

This PR was written by Claude Code on behalf of @apiology.
