### PR TITLE
Degrade an unparseable Struct attribute tag instead of raising

### DIFF
--- a/lib/solargraph/convention/struct_definition.rb
+++ b/lib/solargraph/convention/struct_definition.rb
@@ -59,7 +59,7 @@ module Solargraph
               [attribute_name, "#{attribute_name}="].each do |name|
                 docs = docstring.tags.find { |t| t.tag_name == 'param' && t.name == attribute_name }
 
-                attribute_type = ComplexType.parse(tag_string(docs))
+                attribute_type = ComplexType.try_parse(tag_string(docs))
                 return_type_comment = attribute_comment(docs, false)
                 param_comment = attribute_comment(docs, true)
 

--- a/spec/convention/struct_definition_spec.rb
+++ b/spec/convention/struct_definition_spec.rb
@@ -148,5 +148,17 @@ describe Solargraph::Convention::StructDefinition do
       ))
       expect { checker.problems }.not_to raise_error
     end
+
+    it 'maps a Struct whose attribute tag will not parse, giving that attribute an undefined type' do
+      source = nil
+      expect do
+        source = Solargraph::SourceMap.load_string(%(
+          # @param dimensions [Hash{Symbol => Integer]
+          Box = Struct.new(:dimensions)
+        ), 'test.rb')
+      end.not_to raise_error
+
+      expect(source.pins.find { |p| p.path == 'Box#dimensions' }.return_type.tag).to eql('undefined')
+    end
   end
 end


### PR DESCRIPTION
A YARD type tag that YARD accepts but Solargraph cannot parse, on a `Struct.new` attribute, aborts the whole typecheck run rather than reporting a problem in the one file.

```ruby
# @param dimensions [Hash{Symbol => Integer]
Box = Struct.new(:dimensions)
```

```
$ solargraph typecheck --level strong repro.rb
lib/solargraph/complex_type.rb:514:in `block in parse': Unclosed subtype in Hash{Symbol => Integer] (Solargraph::ComplexTypeError)
	from lib/solargraph/convention/struct_definition.rb:62:in `block (2 levels) in process'
```

The closing `]` ends the tag as far as YARD is concerned, so the type text arrives here with an unclosed `{`. `Convention::StructDefinition` is the one docstring path still calling `ComplexType.parse`; every other one uses `try_parse` and degrades to an undefined type. This makes it match, so the attribute is untyped and the run completes.

The same tag on an ordinary method already degrades. `Data.define` is unaffected, because `StructAssignmentNode.match?` requires the constant `Struct` and the method `new`, so `Data` never reaches this code.

This PR was written by Claude Code on behalf of @apiology.
