### PR TITLE
Fix unresolved method-level generic block parameters

### DIFF
--- a/lib/solargraph/pin/callable.rb
+++ b/lib/solargraph/pin/callable.rb
@@ -143,13 +143,17 @@ module Solargraph
                                         resolved_generic_values: {}
         callable = super(generics_to_resolve, return_type_context, resolved_generic_values: resolved_generic_values)
         callable.parameters = callable.parameters.each_with_index.map do |param, i|
-          if arg_types.nil?
-            param.dup
-          else
-            param.resolve_generics_from_context(generics_to_resolve,
-                                                arg_types[i],
-                                                resolved_generic_values: resolved_generic_values)
-          end
+          # Even when we have no argument type to bind a generic
+          # *from* at this level (arg_types is nil, e.g. a yielded
+          # block's own parameter list), a method-level generic used
+          # here may already have been bound from context elsewhere
+          # (e.g. the enclosing method call's own arguments) and
+          # recorded in resolved_generic_values. Still route through
+          # resolve_generics_from_context so that value gets applied,
+          # rather than leaving the parameter as an unresolved generic.
+          param.resolve_generics_from_context(generics_to_resolve,
+                                              arg_types&.[](i),
+                                              resolved_generic_values: resolved_generic_values)
         end
         if callable.block?
           callable.block = block.resolve_generics_from_context(generics_to_resolve,

--- a/lib/solargraph/pin/callable.rb
+++ b/lib/solargraph/pin/callable.rb
@@ -143,14 +143,12 @@ module Solargraph
                                         resolved_generic_values: {}
         callable = super(generics_to_resolve, return_type_context, resolved_generic_values: resolved_generic_values)
         callable.parameters = callable.parameters.each_with_index.map do |param, i|
-          # Even when we have no argument type to bind a generic
-          # *from* at this level (arg_types is nil, e.g. a yielded
-          # block's own parameter list), a method-level generic used
-          # here may already have been bound from context elsewhere
-          # (e.g. the enclosing method call's own arguments) and
-          # recorded in resolved_generic_values. Still route through
-          # resolve_generics_from_context so that value gets applied,
-          # rather than leaving the parameter as an unresolved generic.
+          # arg_types[i] may be nil (e.g. a yielded block's own
+          # parameter list has no argument type to bind from), but a
+          # method-level generic can already be bound in
+          # resolved_generic_values from elsewhere (the enclosing
+          # call's own arguments) - resolve_generics_from_context
+          # still applies that binding.
           param.resolve_generics_from_context(generics_to_resolve,
                                               arg_types&.[](i),
                                               resolved_generic_values: resolved_generic_values)

--- a/lib/solargraph/pin/callable.rb
+++ b/lib/solargraph/pin/callable.rb
@@ -143,14 +143,10 @@ module Solargraph
                                         resolved_generic_values: {}
         callable = super(generics_to_resolve, return_type_context, resolved_generic_values: resolved_generic_values)
         callable.parameters = callable.parameters.each_with_index.map do |param, i|
-          # arg_types[i] may be nil (e.g. a yielded block's own
-          # parameter list has no argument type to bind from), but a
-          # method-level generic can already be bound in
-          # resolved_generic_values from elsewhere (the enclosing
-          # call's own arguments) - resolve_generics_from_context
-          # still applies that binding.
+          # nil defers to any binding resolved_generic_values already has.
+          arg_type_for_param = arg_types&.[](i)
           param.resolve_generics_from_context(generics_to_resolve,
-                                              arg_types&.[](i),
+                                              arg_type_for_param,
                                               resolved_generic_values: resolved_generic_values)
         end
         if callable.block?

--- a/spec/pin/callable_spec.rb
+++ b/spec/pin/callable_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+describe Solargraph::Pin::Callable do
+  it 'infers a method-level generic block parameter from the argument bound to it' do
+    # Enumerable#each_with_object is declared in RBS as
+    #   [U] (obj U) { [U] (arg_0 Elem, obj U) -> untyped } -> U
+    # `U` is a method-level generic bound by the `obj` argument passed
+    # to each_with_object, not by the receiver's own `Elem` generic.
+    source = Solargraph::Source.load_string(%(
+      # @type [Array<Integer>]
+      a = [1, 2, 3]
+      a.each_with_object({}) do |e, memo|
+        memo
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [4, 8])
+    type = clip.infer
+    expect(type.to_s).to eq('Hash')
+  end
+
+  it 'infers a method-level generic block parameter from the argument bound to it (Enumerable#inject)' do
+    # Enumerable#inject has the same method-level-generic shape as
+    # each_with_object: [U] (U init) { (U, Elem) -> U } -> U
+    source = Solargraph::Source.load_string(%(
+      # @type [Array<Integer>]
+      a = [1, 2, 3]
+      a.inject(0) do |acc, e|
+        acc
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [4, 8])
+    type = clip.infer
+    expect(type.to_s).to eq('Integer')
+  end
+
+  it 'still infers the receiver-level generic block parameter for each_with_index' do
+    # Negative control: Array#each_with_index has no method-level
+    # generic in its block signature, only the receiver's own Elem.
+    source = Solargraph::Source.load_string(%(
+      # @type [Array<Integer>]
+      a = [1, 2, 3]
+      a.each_with_index do |e, i|
+        e
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [4, 8])
+    type = clip.infer
+    expect(type.to_s).to eq('Integer')
+  end
+end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1856,56 +1856,6 @@ describe Solargraph::SourceMap::Clip do
     expect(type.to_s).to eq('String')
   end
 
-  it 'infers a method-level generic block parameter from the argument bound to it' do
-    # Enumerable#each_with_object is declared in RBS as
-    #   [U] (obj U) { [U] (arg_0 Elem, obj U) -> untyped } -> U
-    # `U` is a method-level generic bound by the `obj` argument passed
-    # to each_with_object, not by the receiver's own `Elem` generic.
-    source = Solargraph::Source.load_string(%(
-      # @type [Array<Integer>]
-      a = [1, 2, 3]
-      a.each_with_object({}) do |e, memo|
-        memo
-      end
-    ), 'test.rb')
-    api_map = Solargraph::ApiMap.new.map(source)
-    clip = api_map.clip_at('test.rb', [4, 8])
-    type = clip.infer
-    expect(type.to_s).to eq('Hash')
-  end
-
-  it 'infers a method-level generic block parameter from the argument bound to it (Enumerable#inject)' do
-    # Enumerable#inject has the same method-level-generic shape as
-    # each_with_object: [U] (U init) { (U, Elem) -> U } -> U
-    source = Solargraph::Source.load_string(%(
-      # @type [Array<Integer>]
-      a = [1, 2, 3]
-      a.inject(0) do |acc, e|
-        acc
-      end
-    ), 'test.rb')
-    api_map = Solargraph::ApiMap.new.map(source)
-    clip = api_map.clip_at('test.rb', [4, 8])
-    type = clip.infer
-    expect(type.to_s).to eq('Integer')
-  end
-
-  it 'still infers the receiver-level generic block parameter for each_with_index' do
-    # Negative control: Array#each_with_index has no method-level
-    # generic in its block signature, only the receiver's own Elem.
-    source = Solargraph::Source.load_string(%(
-      # @type [Array<Integer>]
-      a = [1, 2, 3]
-      a.each_with_index do |e, i|
-        e
-      end
-    ), 'test.rb')
-    api_map = Solargraph::ApiMap.new.map(source)
-    clip = api_map.clip_at('test.rb', [4, 8])
-    type = clip.infer
-    expect(type.to_s).to eq('Integer')
-  end
-
   it 'infers Object<self> from Class.new in core classes' do
     # Correct inference of Class.new depends on CoreFills, but we're testing
     # it here because it should eventually work from the core RBS alone.

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1856,6 +1856,56 @@ describe Solargraph::SourceMap::Clip do
     expect(type.to_s).to eq('String')
   end
 
+  it 'infers a method-level generic block parameter from the argument bound to it' do
+    # Enumerable#each_with_object is declared in RBS as
+    #   [U] (obj U) { [U] (arg_0 Elem, obj U) -> untyped } -> U
+    # `U` is a method-level generic bound by the `obj` argument passed
+    # to each_with_object, not by the receiver's own `Elem` generic.
+    source = Solargraph::Source.load_string(%(
+      # @type [Array<Integer>]
+      a = [1, 2, 3]
+      a.each_with_object({}) do |e, memo|
+        memo
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [4, 8])
+    type = clip.infer
+    expect(type.to_s).to eq('Hash')
+  end
+
+  it 'infers a method-level generic block parameter from the argument bound to it (Enumerable#inject)' do
+    # Enumerable#inject has the same method-level-generic shape as
+    # each_with_object: [U] (U init) { (U, Elem) -> U } -> U
+    source = Solargraph::Source.load_string(%(
+      # @type [Array<Integer>]
+      a = [1, 2, 3]
+      a.inject(0) do |acc, e|
+        acc
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [4, 8])
+    type = clip.infer
+    expect(type.to_s).to eq('Integer')
+  end
+
+  it 'still infers the receiver-level generic block parameter for each_with_index' do
+    # Negative control: Array#each_with_index has no method-level
+    # generic in its block signature, only the receiver's own Elem.
+    source = Solargraph::Source.load_string(%(
+      # @type [Array<Integer>]
+      a = [1, 2, 3]
+      a.each_with_index do |e, i|
+        e
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [4, 8])
+    type = clip.infer
+    expect(type.to_s).to eq('Integer')
+  end
+
   it 'infers Object<self> from Class.new in core classes' do
     # Correct inference of Class.new depends on CoreFills, but we're testing
     # it here because it should eventually work from the core RBS alone.


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

## Problem

Enumerable#each_with_object is typed in core RBS as:

    [U] (obj U) { [U] (arg_0 Elem, obj U) -> untyped } -> U

`U` is a method-level generic bound by the `obj` argument passed to `each_with_object`. Inside the block, `arg_0` (typed `Elem`, the receiver's own generic) resolves correctly, but `obj` (typed `U`) resolves to no type at all:

```ruby
class Repro
  # @return [void]
  def scratch
    # @type [Array<Integer>]
    arr = [1, 2, 3]
    arr.each_with_object({}) { |e, memo| memo[e] = e }
  end
end
```

`solargraph typecheck --level strong` reports `Unresolved call to []=` on `memo`. The same shape of bug affects any method with a method-level generic bound via an argument passed alongside a block, e.g. `Enumerable#inject`.

## Root cause

`Pin::Callable#resolve_generics_from_context` resolves a method-level generic from the method's own argument types into a shared `resolved_generic_values` hash, then recurses into the yielded block's parameter list to resolve that signature too. That recursive call is made with no per-parameter argument types available (`nil`), and the code took a shortcut for that case: it `dup`'d each block parameter instead of running it through `resolve_generics_from_context`. So even though `resolved_generic_values["U"]` was already populated from the method's own `obj` argument, the block's own `obj` parameter (typed `generic<U>`) never picked it up.

## Fix

Always route block parameters through `resolve_generics_from_context`, passing `arg_types&.[](i)` instead of skipping resolution when `arg_types` is nil. `ComplexType::UniqueType#resolve_generics_from_context` already handles a nil context type by falling back to `resolved_generic_values[type_param] || self`, so this is a pure bug fix with no behavior change for the case where argument types are available.

## Testing

Added spec cases in `spec/source_map/clip_spec.rb` covering `each_with_object`, `inject`, and a negative control (`each_with_index`, which has no method-level generic in its block signature and must be unaffected). Full suite: 0 failures.
