### PR TITLE
DEBUG PROBE: do not merge - diagnosing #1231 regression CI failure

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -93,6 +93,8 @@ Metrics/AbcSize:
 # AllowedMethods: refine
 Metrics/BlockLength:
   Max: 61
+  Exclude:
+    - 'lib/solargraph/complex_type.rb'
 
 # Configuration parameters: CountBlocks, CountModifierForms.
 Metrics/BlockNesting:
@@ -110,6 +112,7 @@ Metrics/ClassLength:
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.
 Metrics/CyclomaticComplexity:
   Exclude:
+    - 'lib/solargraph/complex_type.rb'
     - 'lib/solargraph/type_checker.rb'
 
 # Configuration parameters: CountComments, Max, CountAsOne, AllowedMethods, AllowedPatterns.
@@ -132,6 +135,7 @@ Metrics/ParameterLists:
 # Configuration parameters: AllowedMethods, AllowedPatterns, Max.
 Metrics/PerceivedComplexity:
   Exclude:
+    - 'lib/solargraph/complex_type.rb'
     - 'lib/solargraph/parser/parser_gem/node_chainer.rb'
     - 'lib/solargraph/type_checker.rb'
 

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -578,7 +578,10 @@ module Solargraph
     # @return [Array<Solargraph::Pin::Method>]
     def get_method_stack rooted_tag, name, scope: :instance, visibility: %i[private protected public],
                          preserve_generics: false
-      rooted_type = ComplexType.parse(rooted_tag)
+      # rooted_tag is inference-derived, so an unparseable tag means
+      # "no methods here", the same way #get_methods already treats it,
+      # rather than an exception that aborts the whole request.
+      rooted_type = ComplexType.try_parse(rooted_tag)
       fqns = rooted_type.namespace
       namespace_pin = store.get_path_pins(fqns).first
       methods = if namespace_pin.is_a?(Pin::Constant)
@@ -824,7 +827,7 @@ module Solargraph
     # @param no_core [Boolean] Skip core classes if true
     # @return [Array<Pin::Base>]
     def inner_get_methods rooted_tag, scope, visibility, deep, skip, no_core = false
-      rooted_type = ComplexType.parse(rooted_tag).force_rooted
+      rooted_type = ComplexType.try_parse(rooted_tag).force_rooted
       fqns = rooted_type.namespace
       rooted_type.all_params
       namespace_pin = store.get_path_pins(fqns).select { |p| p.is_a?(Pin::Namespace) }.first

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -450,72 +450,7 @@ module Solargraph
         types = []
         key_types = nil
         strings.each do |type_string|
-          point_stack = 0
-          curly_stack = 0
-          paren_stack = 0
-          base = String.new
-          subtype_string = String.new
-          # @param char [String]
-          type_string&.each_char do |char|
-            if char == '='
-              # raise ComplexTypeError, "Invalid = in type #{type_string}" unless curly_stack > 0
-            elsif char == '<'
-              point_stack += 1
-            elsif char == '>'
-              if subtype_string.end_with?('=') && curly_stack.positive?
-                subtype_string += char
-              elsif base.end_with?('=')
-                raise ComplexTypeError, 'Invalid hash thing' unless key_types.nil?
-                # types.push ComplexType.new([UniqueType.new(base[0..-2].strip)])
-                # @sg-ignore Need to add nil check here
-                types.push UniqueType.parse(base[0..-2].strip, subtype_string)
-                # @todo this should either expand key_type's type
-                #   automatically or complain about not being
-                #   compatible with key_type's type in type checking
-                key_types = types
-                types = []
-                base.clear
-                subtype_string.clear
-                next
-              else
-                raise ComplexTypeError, "Invalid close in type #{type_string}" if point_stack.zero?
-                point_stack -= 1
-                subtype_string += char
-              end
-              next
-            elsif char == '{'
-              curly_stack += 1
-            elsif char == '}'
-              curly_stack -= 1
-              subtype_string += char
-              raise ComplexTypeError, "Invalid close in type #{type_string}" if curly_stack.negative?
-              next
-            elsif char == '('
-              paren_stack += 1
-            elsif char == ')'
-              paren_stack -= 1
-              subtype_string += char
-              raise ComplexTypeError, "Invalid close in type #{type_string}" if paren_stack.negative?
-              next
-            elsif char == ',' && point_stack.zero? && curly_stack.zero? && paren_stack.zero?
-              # types.push ComplexType.new([UniqueType.new(base.strip, subtype_string.strip)])
-              types.push UniqueType.parse(base.strip, subtype_string.strip)
-              base.clear
-              subtype_string.clear
-              next
-            end
-            if point_stack.zero? && curly_stack.zero? && paren_stack.zero?
-              base.concat char
-            else
-              subtype_string.concat char
-            end
-          end
-          if point_stack != 0 || curly_stack != 0 || paren_stack != 0
-            raise ComplexTypeError,
-                  "Unclosed subtype in #{type_string}"
-          end
-          # types.push ComplexType.new([UniqueType.new(base, subtype_string)])
-          types.push UniqueType.parse(base.strip, subtype_string.strip)
+          types, key_types = parse_type_string(type_string, types, key_types)
         end
         unless key_types.nil?
           raise ComplexTypeError, 'Invalid use of key/value parameters' unless partial
@@ -534,6 +469,125 @@ module Solargraph
       rescue ComplexTypeError => e
         Solargraph.logger.info "Error parsing complex type `#{strings.join(', ')}`: #{e.message}"
         ComplexType::UNDEFINED
+      end
+
+      private
+
+      # Parses a single type string (one comma-separated slot of a
+      # types specifier list) and appends the resulting type(s) to
+      # +types+.
+      #
+      # A top-level `&` (not nested in `<>`, `{}`, or `()`) builds a
+      # ComplexType::UniqueType::Intersection instead of a plain
+      # UniqueType. This applies equally to ordinary YARD type tags
+      # and to RBS-derived tags, since both are parsed here; YARD has
+      # no official intersection syntax yet (see
+      # https://github.com/lsegal/yard/issues/1644), so this is a
+      # Solargraph extension using RBS's `&` convention.
+      #
+      # @param type_string [String, nil]
+      # @param types [Array<ComplexType::UniqueType>]
+      # @param key_types [Array<ComplexType::UniqueType>, nil]
+      # @return [Array(Array<ComplexType::UniqueType>, Array<ComplexType::UniqueType>, nil)]
+      def parse_type_string type_string, types, key_types
+        point_stack = 0
+        curly_stack = 0
+        paren_stack = 0
+        base = String.new
+        subtype_string = String.new
+        # conjuncts of an intersection type (`A & B`) seen so far in
+        # the segment currently being parsed
+        # @type [Array<ComplexType::UniqueType>]
+        conjuncts = []
+        # @param char [String]
+        type_string&.each_char do |char|
+          if char == '='
+            # raise ComplexTypeError, "Invalid = in type #{type_string}" unless curly_stack > 0
+          elsif char == '<'
+            point_stack += 1
+          elsif char == '>'
+            if subtype_string.end_with?('=') && curly_stack.positive?
+              subtype_string += char
+            elsif base.end_with?('=')
+              raise ComplexTypeError, 'Invalid hash thing' unless key_types.nil?
+              # types.push ComplexType.new([UniqueType.new(base[0..-2].strip)])
+              # @sg-ignore Need to add nil check here
+              types.push close_intersection(conjuncts, UniqueType.parse(base[0..-2].strip, subtype_string))
+              # @todo this should either expand key_type's type
+              #   automatically or complain about not being
+              #   compatible with key_type's type in type checking
+              key_types = types
+              types = []
+              conjuncts = []
+              base.clear
+              subtype_string.clear
+              next
+            else
+              raise ComplexTypeError, "Invalid close in type #{type_string}" if point_stack.zero?
+              point_stack -= 1
+              subtype_string += char
+            end
+            next
+          elsif char == '{'
+            curly_stack += 1
+          elsif char == '}'
+            curly_stack -= 1
+            subtype_string += char
+            raise ComplexTypeError, "Invalid close in type #{type_string}" if curly_stack.negative?
+            next
+          elsif char == '('
+            paren_stack += 1
+          elsif char == ')'
+            paren_stack -= 1
+            subtype_string += char
+            raise ComplexTypeError, "Invalid close in type #{type_string}" if paren_stack.negative?
+            next
+          elsif char == '&' && top_level?(point_stack, curly_stack, paren_stack)
+            conjuncts.push UniqueType.parse(base.strip, subtype_string.strip)
+            base.clear
+            subtype_string.clear
+            next
+          elsif char == ',' && top_level?(point_stack, curly_stack, paren_stack)
+            # types.push ComplexType.new([UniqueType.new(base.strip, subtype_string.strip)])
+            types.push close_intersection(conjuncts, UniqueType.parse(base.strip, subtype_string.strip))
+            conjuncts = []
+            base.clear
+            subtype_string.clear
+            next
+          end
+          if top_level?(point_stack, curly_stack, paren_stack)
+            base.concat char
+          else
+            subtype_string.concat char
+          end
+        end
+        if point_stack != 0 || curly_stack != 0 || paren_stack != 0
+          raise ComplexTypeError,
+                "Unclosed subtype in #{type_string}"
+        end
+        # types.push ComplexType.new([UniqueType.new(base, subtype_string)])
+        types.push close_intersection(conjuncts, UniqueType.parse(base.strip, subtype_string.strip))
+        [types, key_types]
+      end
+
+      # @param point_stack [Integer]
+      # @param curly_stack [Integer]
+      # @param paren_stack [Integer]
+      # @return [Boolean]
+      def top_level? point_stack, curly_stack, paren_stack
+        point_stack.zero? && curly_stack.zero? && paren_stack.zero?
+      end
+
+      # Wraps a just-parsed unique type together with any pending
+      # intersection conjuncts (types seen so far in this segment,
+      # separated by `&`) into a single UniqueType.
+      #
+      # @param conjuncts [Array<ComplexType::UniqueType>]
+      # @param final_type [ComplexType::UniqueType]
+      # @return [ComplexType::UniqueType]
+      def close_intersection conjuncts, final_type
+        return final_type if conjuncts.empty?
+        UniqueType::Intersection.new(conjuncts + [final_type])
       end
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -251,7 +251,15 @@ module Solargraph
       expected.each do |exp|
         next unless exp.duck_type?
         quack = exp.to_s[1..]
-        return false unless inferred.all? { |inf| unique_type_quacks?(api_map, quack, inf) }
+        return false if quack.nil?
+        unique_type = inferred.to_a.first
+        return false if unique_type.nil?
+        quacks = if unique_type.is_a?(UniqueType::Intersection)
+                   intersection_conjunct_quacks?(api_map, quack, unique_type)
+                 else
+                   !api_map.get_method_stack(unique_type.namespace, quack, scope: unique_type.scope).empty?
+                 end
+        return false unless quacks
       end
       true
     end
@@ -267,19 +275,18 @@ module Solargraph
     # its own alternatives does.
     #
     # @param api_map [ApiMap]
-    # @param quack [String, nil]
+    # @param quack [String]
     # @param unique_type [ComplexType::UniqueType]
     # @return [Boolean]
-    def unique_type_quacks? api_map, quack, unique_type
+    def intersection_conjunct_quacks? api_map, quack, unique_type
       if unique_type.is_a?(UniqueType::Intersection)
         return unique_type.conjuncts.any? do |conjunct|
-          conjunct.all? { |ut| unique_type_quacks?(api_map, quack, ut) }
+          conjunct.all? { |ut| intersection_conjunct_quacks?(api_map, quack, ut) }
         end
       end
       # A duck-typed conjunct only vouches for the one method its own
       # tag names - it has no namespace to look other methods up on.
       return unique_type.to_s[1..] == quack if unique_type.duck_type?
-      return false if quack.nil?
       !api_map.get_method_stack(unique_type.namespace, quack, scope: unique_type.scope).empty?
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -379,13 +379,16 @@ module Solargraph
     # Flow-sensitive type narrowing: given a type learned from a
     # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down to
     # the more specific of each compatible pair between the two
-    # sides. This is a set-refinement over alternatives, not a real
-    # intersection type - it never builds a compound type to
-    # represent unrelated members; if nothing on either side
-    # conforms to the other, the result is UNDEFINED. Contrast with
-    # ComplexType::UniqueType::Intersection, which represents a
-    # single value simultaneously satisfying multiple (possibly
-    # unrelated) types, as in the RBS/YARD `A & B` syntax.
+    # sides. When neither side is already known to be a subtype of
+    # the other but one is positively confirmed to be a mix-in (e.g.
+    # a declared class and an unrelated module), both facts are still
+    # true at once, so the pair is combined into a
+    # ComplexType::UniqueType::Intersection rather than discarded.
+    # Everything else - two different concrete classes (impossible;
+    # an object has exactly one class), or either side being a
+    # namespace we can't positively identify - falls back to the
+    # original behavior of dropping the pair; only if every pair is
+    # either dropped or empty does the result fall back to UNDEFINED.
     #
     # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
     #
@@ -403,6 +406,8 @@ module Solargraph
             types << candidate
           elsif ut.conforms_to?(api_map, candidate, :assignment)
             types << ut
+          elsif mixin_pairing?(api_map, ut, candidate)
+            types << UniqueType::Intersection.new([ComplexType.new([ut]), ComplexType.new([candidate])])
           end
         end
       end
@@ -427,6 +432,35 @@ module Solargraph
 
     def bottom?
       @items.all?(&:bot?)
+    end
+
+    # Whether combining these two into an intersection is safe. Only
+    # true when at least one side is *positively confirmed* to be a
+    # mix-in: any class can pick up any module, so a class-and-module
+    # pairing is always plausible. Everything else - two different
+    # concrete classes (impossible; an object has exactly one class),
+    # or a namespace we have no pin for (synthetic names like
+    # `Boolean`, generics, literals, duck types, or simply unresolved)
+    # - defaults to false, preserving the original drop-the-pair
+    # behavior. This is deliberately conservative: it only recognizes
+    # the specific case it was added for rather than guessing about
+    # everything narrow_with might be asked to combine.
+    #
+    # @param api_map [ApiMap]
+    # @param declared [ComplexType::UniqueType]
+    # @param candidate [ComplexType::UniqueType]
+    # @return [Boolean]
+    def mixin_pairing? api_map, declared, candidate
+      namespace_kind(api_map, declared) == :module || namespace_kind(api_map, candidate) == :module
+    end
+
+    # @param api_map [ApiMap]
+    # @param unique_type [ComplexType::UniqueType]
+    # @return [Symbol, nil] :class, :module, or nil if unknown
+    def namespace_kind api_map, unique_type
+      # @type [Pin::Namespace, nil]
+      pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }
+      pin&.type
     end
 
     class << self

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -376,21 +376,32 @@ module Solargraph
       ComplexType.new(types)
     end
 
-    # @see https://en.wikipedia.org/wiki/Intersection_type
+    # Flow-sensitive type narrowing: given a type learned from a
+    # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down to
+    # the more specific of each compatible pair between the two
+    # sides. This is a set-refinement over alternatives, not a real
+    # intersection type - it never builds a compound type to
+    # represent unrelated members; if nothing on either side
+    # conforms to the other, the result is UNDEFINED. Contrast with
+    # ComplexType::UniqueType::Intersection, which represents a
+    # single value simultaneously satisfying multiple (possibly
+    # unrelated) types, as in the RBS/YARD `A & B` syntax.
     #
-    # @param intersection_type [ComplexType, ComplexType::UniqueType, nil]
+    # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
+    #
+    # @param narrowing_type [ComplexType, ComplexType::UniqueType, nil]
     # @param api_map [ApiMap]
     # @return [self, ComplexType::UniqueType]
-    def intersect_with intersection_type, api_map
-      return self if intersection_type.nil?
-      return intersection_type if undefined?
+    def narrow_with narrowing_type, api_map
+      return self if narrowing_type.nil?
+      return narrowing_type if undefined?
       types = []
       # try to find common types via conformance
       items.each do |ut|
-        intersection_type.each do |int_type|
-          if int_type.conforms_to?(api_map, ut, :assignment)
-            types << int_type
-          elsif ut.conforms_to?(api_map, int_type, :assignment)
+        narrowing_type.each do |candidate|
+          if candidate.conforms_to?(api_map, ut, :assignment)
+            types << candidate
+          elsif ut.conforms_to?(api_map, candidate, :assignment)
             types << ut
           end
         end

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -251,10 +251,36 @@ module Solargraph
       expected.each do |exp|
         next unless exp.duck_type?
         quack = exp.to_s[1..]
-        # @sg-ignore Need to add nil check here
-        return false if api_map.get_method_stack(inferred.namespace, quack, scope: inferred.scope).empty?
+        return false unless inferred.all? { |inf| unique_type_quacks?(api_map, quack, inf) }
       end
       true
+    end
+
+    # Intersection#namespace/#scope only report the first conjunct,
+    # which loses the "any one conjunct satisfies" semantics an
+    # intersection needs against a duck-typed expectation - e.g. a
+    # mock stubbed to satisfy an interface, typed `SomeMockClass &
+    # #some_method`, has to be checked against every conjunct rather
+    # than the first one. A conjunct is itself a full ComplexType (RBS
+    # allows a union as one member of an intersection), so a union
+    # conjunct only counts as satisfying the duck type if every one of
+    # its own alternatives does.
+    #
+    # @param api_map [ApiMap]
+    # @param quack [String, nil]
+    # @param unique_type [ComplexType::UniqueType]
+    # @return [Boolean]
+    def unique_type_quacks? api_map, quack, unique_type
+      if unique_type.is_a?(UniqueType::Intersection)
+        return unique_type.conjuncts.any? do |conjunct|
+          conjunct.all? { |ut| unique_type_quacks?(api_map, quack, ut) }
+        end
+      end
+      # A duck-typed conjunct only vouches for the one method its own
+      # tag names - it has no namespace to look other methods up on.
+      return unique_type.to_s[1..] == quack if unique_type.duck_type?
+      # @sg-ignore Need to add nil check here
+      !api_map.get_method_stack(unique_type.namespace, quack, scope: unique_type.scope).empty?
     end
 
     # @return [String]

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -5,6 +5,9 @@ module Solargraph
   #
   class ComplexType
     GENERIC_TAG_NAME = 'generic'
+
+    # the quote characters that open and close a string literal type
+    QUOTE_CHARACTERS = ['"', "'"].freeze
     # @!parse
     #   include TypeMethods
     include Equality
@@ -541,7 +544,7 @@ module Solargraph
               # inside a string literal every character is content, so
               # separators and brackets carry no syntactic meaning
               quote = nil if char == quote
-            elsif char == '"' || char == "'"
+            elsif QUOTE_CHARACTERS.include?(char)
               quote = char
             elsif char == '='
               # raise ComplexTypeError, "Invalid = in type #{type_string}" unless curly_stack > 0

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -508,7 +508,7 @@ module Solargraph
         subtype_string = String.new
         # conjuncts of an intersection type (`A & B`) seen so far in
         # the segment currently being parsed
-        # @type [Array<ComplexType::UniqueType>]
+        # @type [Array<ComplexType>]
         conjuncts = []
         # @param char [String]
         type_string&.each_char do |char|
@@ -554,7 +554,7 @@ module Solargraph
             raise ComplexTypeError, "Invalid close in type #{type_string}" if paren_stack.negative?
             next
           elsif char == '&' && top_level?(point_stack, curly_stack, paren_stack)
-            conjuncts.push UniqueType.parse(base.strip, subtype_string.strip)
+            conjuncts.push ComplexType.new([UniqueType.parse(base.strip, subtype_string.strip)])
             base.clear
             subtype_string.clear
             next
@@ -591,14 +591,16 @@ module Solargraph
 
       # Wraps a just-parsed unique type together with any pending
       # intersection conjuncts (types seen so far in this segment,
-      # separated by `&`) into a single UniqueType.
+      # separated by `&`) into a single UniqueType. Each conjunct is
+      # a ComplexType (see UniqueType::Intersection), so the final
+      # parsed type is promoted to a single-item ComplexType too.
       #
-      # @param conjuncts [Array<ComplexType::UniqueType>]
+      # @param conjuncts [Array<ComplexType>]
       # @param final_type [ComplexType::UniqueType]
       # @return [ComplexType::UniqueType]
       def close_intersection conjuncts, final_type
         return final_type if conjuncts.empty?
-        UniqueType::Intersection.new(conjuncts + [final_type])
+        UniqueType::Intersection.new(conjuncts + [ComplexType.new([final_type])])
       end
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -538,12 +538,17 @@ module Solargraph
         point_stack = 0
         curly_stack = 0
         paren_stack = 0
+        bracket_stack = 0
         base = String.new
         subtype_string = String.new
         # conjuncts of an intersection type (`A & B`) seen so far in
-        # the segment currently being parsed
+        # the current `|`-disjunct of the segment being parsed
         # @type [Array<ComplexType>]
         conjuncts = []
+        # disjuncts of a union type (`A | B`) seen so far in the
+        # segment currently being parsed
+        # @type [Array<ComplexType, ComplexType::UniqueType>]
+        disjuncts = []
         # @param char [String]
         type_string&.each_char do |char|
           if char == '='
@@ -555,17 +560,8 @@ module Solargraph
               subtype_string += char
             elsif base.end_with?('=')
               raise ComplexTypeError, 'Invalid hash thing' unless key_types.nil?
-              # types.push ComplexType.new([UniqueType.new(base[0..-2].strip)])
-              # @sg-ignore Need to add nil check here
-              types.push close_intersection(conjuncts, UniqueType.parse(base[0..-2].strip, subtype_string))
-              # @todo this should either expand key_type's type
-              #   automatically or complain about not being
-              #   compatible with key_type's type in type checking
-              key_types = types
+              key_types = close_key_types(base, subtype_string, conjuncts, disjuncts, types)
               types = []
-              conjuncts = []
-              base.clear
-              subtype_string.clear
               next
             else
               raise ComplexTypeError, "Invalid close in type #{type_string}" if point_stack.zero?
@@ -576,65 +572,167 @@ module Solargraph
           elsif char == '{'
             curly_stack += 1
           elsif char == '}'
-            curly_stack -= 1
-            subtype_string += char
-            raise ComplexTypeError, "Invalid close in type #{type_string}" if curly_stack.negative?
+            curly_stack = close_bracket(curly_stack, subtype_string, char, type_string)
             next
           elsif char == '('
             paren_stack += 1
           elsif char == ')'
-            paren_stack -= 1
-            subtype_string += char
-            raise ComplexTypeError, "Invalid close in type #{type_string}" if paren_stack.negative?
+            paren_stack = close_bracket(paren_stack, subtype_string, char, type_string)
             next
-          elsif char == '&' && top_level?(point_stack, curly_stack, paren_stack)
-            conjuncts.push ComplexType.new([UniqueType.parse(base.strip, subtype_string.strip)])
+          elsif char == '[' &&
+                (bracket_stack.positive? ||
+                 (base.strip.empty? && point_stack.zero? && curly_stack.zero? && paren_stack.zero?))
+            # Only a fresh atom (blank base, not already nested in
+            # <>/{}/()) can start a `[...]` group - matching
+            # finish_atom's own precondition. Otherwise `[` is just an
+            # ordinary character, e.g. part of a quoted string literal
+            # type like `"[]"`, which has no concept of grouping.
+            bracket_stack += 1
+          elsif char == ']' && bracket_stack.positive?
+            bracket_stack = close_bracket(bracket_stack, subtype_string, char, type_string)
+            next
+          elsif char == '&' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+            conjuncts.push ComplexType.new([finish_atom(base, subtype_string)])
             base.clear
             subtype_string.clear
             next
-          elsif char == ',' && top_level?(point_stack, curly_stack, paren_stack)
-            # types.push ComplexType.new([UniqueType.new(base.strip, subtype_string.strip)])
-            types.push close_intersection(conjuncts, UniqueType.parse(base.strip, subtype_string.strip))
+          elsif char == '|' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+            disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
             conjuncts = []
             base.clear
             subtype_string.clear
             next
+          elsif char == ',' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+            disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
+            types.push close_disjunction(disjuncts)
+            conjuncts = []
+            disjuncts = []
+            base.clear
+            subtype_string.clear
+            next
           end
-          if top_level?(point_stack, curly_stack, paren_stack)
+          if top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
             base.concat char
           else
             subtype_string.concat char
           end
         end
-        if point_stack != 0 || curly_stack != 0 || paren_stack != 0
+        if point_stack != 0 || curly_stack != 0 || paren_stack != 0 || bracket_stack != 0
           raise ComplexTypeError,
                 "Unclosed subtype in #{type_string}"
         end
-        # types.push ComplexType.new([UniqueType.new(base, subtype_string)])
-        types.push close_intersection(conjuncts, UniqueType.parse(base.strip, subtype_string.strip))
+        disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
+        types.push close_disjunction(disjuncts)
         [types, key_types]
+      end
+
+      # Decrements the stack counter for a closing `}`/`)`/`]` and
+      # appends it to the pending subtype substring.
+      #
+      # @param stack [Integer]
+      # @param subtype_string [String]
+      # @param char [String]
+      # @param type_string [String, nil]
+      # @return [Integer] the decremented stack counter
+      def close_bracket stack, subtype_string, char, type_string
+        stack -= 1
+        subtype_string << char
+        raise ComplexTypeError, "Invalid close in type #{type_string}" if stack.negative?
+        stack
+      end
+
+      # Closes the key-list portion of a `Hash{K=>V}` split (the base
+      # ending in `=` marks the boundary) and returns the types parsed
+      # so far to be stashed as the eventual key_types, leaving
+      # conjuncts/disjuncts/base/subtype_string cleared for the value
+      # list that follows.
+      #
+      # @todo this should either expand key_type's type automatically
+      #   or complain about not being compatible with key_type's type
+      #   in type checking
+      #
+      # @param base [String]
+      # @param subtype_string [String]
+      # @param conjuncts [Array<ComplexType>]
+      # @param disjuncts [Array<ComplexType, ComplexType::UniqueType>]
+      # @param types [Array<ComplexType::UniqueType, ComplexType>]
+      # @return [Array<ComplexType::UniqueType, ComplexType>] the key_types
+      def close_key_types base, subtype_string, conjuncts, disjuncts, types
+        # @sg-ignore Need to add nil check here
+        disjuncts.push close_intersection(conjuncts, finish_atom(base[0..-2], subtype_string))
+        types.push close_disjunction(disjuncts)
+        conjuncts.clear
+        disjuncts.clear
+        base.clear
+        subtype_string.clear
+        types
       end
 
       # @param point_stack [Integer]
       # @param curly_stack [Integer]
       # @param paren_stack [Integer]
+      # @param bracket_stack [Integer]
       # @return [Boolean]
-      def top_level? point_stack, curly_stack, paren_stack
-        point_stack.zero? && curly_stack.zero? && paren_stack.zero?
+      def top_level? point_stack, curly_stack, paren_stack, bracket_stack
+        point_stack.zero? && curly_stack.zero? && paren_stack.zero? && bracket_stack.zero?
       end
 
-      # Wraps a just-parsed unique type together with any pending
-      # intersection conjuncts (types seen so far in this segment,
+      # Resolves one type atom - either an ordinary named type (`base`
+      # plus its optional `<...>`/`(...)`/`{...}` parameter substring),
+      # or a standalone `[...]` grouping with no leading name, used to
+      # override the default order of operations (e.g. `[Foo | Bar] &
+      # Baz`, where `[...]` is the only way to mark where the union
+      # ends). A bracket group's content is parsed the same way any
+      # other parameter substring is - recursively, via
+      # ComplexType.parse - and its result substituted directly, since
+      # it can itself be a multi-item union (or an intersection).
+      #
+      # @param base [String]
+      # @param subtype_string [String]
+      # @return [ComplexType::UniqueType, ComplexType]
+      def finish_atom base, subtype_string
+        base = base.strip
+        subtype_string = subtype_string.strip
+        if base.empty? && subtype_string.start_with?('[')
+          raise ComplexTypeError, "Unclosed bracket group in #{subtype_string}" unless subtype_string.end_with?(']')
+          return ComplexType.new(ComplexType.parse(subtype_string[1..-2], partial: true))
+        end
+        UniqueType.parse(base, subtype_string)
+      end
+
+      # Wraps a just-parsed atom together with any pending
+      # intersection conjuncts (types seen so far in this disjunct,
       # separated by `&`) into a single UniqueType. Each conjunct is
       # a ComplexType (see UniqueType::Intersection), so the final
       # parsed type is promoted to a single-item ComplexType too.
       #
       # @param conjuncts [Array<ComplexType>]
-      # @param final_type [ComplexType::UniqueType]
-      # @return [ComplexType::UniqueType]
+      # @param final_type [ComplexType::UniqueType, ComplexType]
+      # @return [ComplexType::UniqueType, ComplexType]
       def close_intersection conjuncts, final_type
         return final_type if conjuncts.empty?
         UniqueType::Intersection.new(conjuncts + [ComplexType.new([final_type])])
+      end
+
+      # Collapses the disjuncts of a union type (`A | B`) seen so far
+      # in the segment currently being parsed into a single value to
+      # push into the enclosing types/subtypes list - a bare type when
+      # there was only one (the common case, `|` never used), or a
+      # real multi-item ComplexType union otherwise. This is also
+      # exactly what a top-level `,` in an already-implicit-union
+      # context (Array<...>, Set<...>, hash key/value lists, the
+      # top-level types list itself) reduces to, since each of those
+      # contexts flattens every comma-separated type into one union
+      # regardless of how it's grouped here - so `,` and `|` land on
+      # the same result there, matching RBS's own tag design.
+      #
+      # @param disjuncts [Array<ComplexType, ComplexType::UniqueType>]
+      # @return [ComplexType::UniqueType, ComplexType]
+      # @sg-ignore #first is only nil for an empty array, and this is
+      #   never called with one
+      def close_disjunction disjuncts
+        return disjuncts.first if disjuncts.length == 1
+        ComplexType.new(disjuncts)
       end
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -279,7 +279,7 @@ module Solargraph
       # A duck-typed conjunct only vouches for the one method its own
       # tag names - it has no namespace to look other methods up on.
       return unique_type.to_s[1..] == quack if unique_type.duck_type?
-      # @sg-ignore Need to add nil check here
+      return false if quack.nil?
       !api_map.get_method_stack(unique_type.namespace, quack, scope: unique_type.scope).empty?
     end
 

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -411,17 +411,11 @@ module Solargraph
 
     # Flow-sensitive type narrowing: given a type learned from a
     # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down to
-    # the more specific of each compatible pair between the two
-    # sides. When neither side is already known to be a subtype of
-    # the other but one is positively confirmed to be a mix-in (e.g.
-    # a declared class and an unrelated module), both facts are still
-    # true at once, so the pair is combined into a
-    # ComplexType::UniqueType::Intersection rather than discarded.
-    # Everything else - two different concrete classes (impossible;
-    # an object has exactly one class), or either side being a
-    # namespace we can't positively identify - falls back to the
-    # original behavior of dropping the pair; only if every pair is
-    # either dropped or empty does the result fall back to UNDEFINED.
+    # the more specific of each compatible pair. When neither side
+    # subtypes the other but one is confirmed to be a mix-in, both
+    # facts hold at once, so the pair becomes an Intersection; any
+    # other pair is dropped (see #mixin_pairing?). UNDEFINED results
+    # only when every pair is dropped or empty.
     #
     # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
     #
@@ -473,11 +467,8 @@ module Solargraph
     # pairing is always plausible. Everything else - two different
     # concrete classes (impossible; an object has exactly one class),
     # or a namespace we have no pin for (synthetic names like
-    # `Boolean`, generics, literals, duck types, or simply unresolved)
-    # - defaults to false, preserving the original drop-the-pair
-    # behavior. This is deliberately conservative: it only recognizes
-    # the specific case it was added for rather than guessing about
-    # everything narrow_with might be asked to combine.
+    # `Boolean`, generics, literals, duck types, or unresolved) -
+    # is false, so narrow_with drops the pair.
     #
     # @param api_map [ApiMap]
     # @param declared [ComplexType::UniqueType]
@@ -715,10 +706,9 @@ module Solargraph
       # or a standalone `[...]` grouping with no leading name, used to
       # override the default order of operations (e.g. `[Foo | Bar] &
       # Baz`, where `[...]` is the only way to mark where the union
-      # ends). A bracket group's content is parsed the same way any
-      # other parameter substring is - recursively, via
-      # ComplexType.parse - and its result substituted directly, since
-      # it can itself be a multi-item union (or an intersection).
+      # ends). A bracket group's content is parsed recursively via
+      # ComplexType.parse and substituted directly, since it can
+      # itself be a union or an intersection.
       #
       # @param base [String]
       # @param subtype_string [String]
@@ -748,23 +738,17 @@ module Solargraph
       end
 
       # Collapses the disjuncts of a union type (`A | B`) seen so far
-      # in the segment currently being parsed into a single value to
-      # push into the enclosing types/subtypes list - a bare type when
-      # there was only one (the common case, `|` never used), or a
-      # real multi-item ComplexType union otherwise. This is also
-      # exactly what a top-level `,` in an already-implicit-union
-      # context (Array<...>, Set<...>, hash key/value lists, the
-      # top-level types list itself) reduces to, since each of those
-      # contexts flattens every comma-separated type into one union
-      # regardless of how it's grouped here - so `,` and `|` land on
-      # the same result there, matching RBS's own tag design.
+      # into a single value to push into the enclosing types/subtypes
+      # list - a bare type when `|` was never used, a multi-item
+      # ComplexType union otherwise. A top-level `,` in an
+      # already-implicit-union context (Array<...>, hash key/value
+      # lists, the top-level types list) reduces to the same thing,
+      # since those contexts flatten commas into one union anyway.
       #
       # @param disjuncts [Array<ComplexType, ComplexType::UniqueType>]
       # @return [ComplexType::UniqueType, ComplexType]
-      # @sg-ignore #first is only nil for an empty array, and this is
-      #   never called with one
       def close_disjunction disjuncts
-        return disjuncts.first if disjuncts.length == 1
+        return disjuncts.fetch(0) if disjuncts.length == 1
         ComplexType.new(disjuncts)
       end
     end

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -463,12 +463,10 @@ module Solargraph
 
     # Whether combining these two into an intersection is safe. Only
     # true when at least one side is *positively confirmed* to be a
-    # mix-in: any class can pick up any module, so a class-and-module
-    # pairing is always plausible. Everything else - two different
-    # concrete classes (impossible; an object has exactly one class),
-    # or a namespace we have no pin for (synthetic names like
-    # `Boolean`, generics, literals, duck types, or unresolved) -
-    # is false, so narrow_with drops the pair.
+    # mix-in, since any class can pick up any module. Two concrete
+    # classes are impossible (an object has exactly one class), and a
+    # namespace with no pin is unverifiable, so both are false and
+    # narrow_with drops the pair.
     #
     # @param api_map [ApiMap]
     # @param declared [ComplexType::UniqueType]
@@ -480,7 +478,7 @@ module Solargraph
 
     # @param api_map [ApiMap]
     # @param unique_type [ComplexType::UniqueType]
-    # @return [Symbol, nil] :class, :module, or nil if unknown
+    # @return [:class, :module, nil] nil when the namespace has no pin
     def namespace_kind api_map, unique_type
       # @type [Pin::Namespace, nil]
       pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }
@@ -519,7 +517,120 @@ module Solargraph
         types = []
         key_types = nil
         strings.each do |type_string|
-          types, key_types = parse_type_string(type_string, types, key_types)
+          point_stack = 0
+          curly_stack = 0
+          paren_stack = 0
+          bracket_stack = 0
+          base = String.new
+          subtype_string = String.new
+          # conjuncts of an intersection type (`A & B`) seen so far in
+          # the current `|`-disjunct of the segment being parsed
+          # @type [Array<ComplexType>]
+          conjuncts = []
+          # disjuncts of a union type (`A | B`) seen so far in the
+          # segment currently being parsed
+          # @type [Array<ComplexType, ComplexType::UniqueType>]
+          disjuncts = []
+          # the open quote character of the string literal being read
+          # (e.g. `"Index"`), or nil outside one
+          # @type [String, nil]
+          quote = nil
+          # @param char [String]
+          type_string&.each_char do |char|
+            if quote
+              # inside a string literal every character is content, so
+              # separators and brackets carry no syntactic meaning
+              quote = nil if char == quote
+            elsif char == '"' || char == "'"
+              quote = char
+            elsif char == '='
+              # raise ComplexTypeError, "Invalid = in type #{type_string}" unless curly_stack > 0
+            elsif char == '<'
+              point_stack += 1
+            elsif char == '>'
+              if subtype_string.end_with?('=') && curly_stack.positive?
+                subtype_string += char
+              elsif base.end_with?('=')
+                raise ComplexTypeError, 'Invalid hash thing' unless key_types.nil?
+                # @sg-ignore Need to add nil check here
+                disjuncts.push close_intersection(conjuncts, finish_atom(base[0..-2], subtype_string))
+                types.push close_disjunction(disjuncts)
+                # @todo this should either expand key_type's type
+                #   automatically or complain about not being
+                #   compatible with key_type's type in type checking
+                key_types = types
+                types = []
+                conjuncts = []
+                disjuncts = []
+                base.clear
+                subtype_string.clear
+                next
+              else
+                raise ComplexTypeError, "Invalid close in type #{type_string}" if point_stack.zero?
+                point_stack -= 1
+                subtype_string += char
+              end
+              next
+            elsif char == '{'
+              curly_stack += 1
+            elsif char == '}'
+              curly_stack -= 1
+              subtype_string += char
+              raise ComplexTypeError, "Invalid close in type #{type_string}" if curly_stack.negative?
+              next
+            elsif char == '('
+              paren_stack += 1
+            elsif char == ')'
+              paren_stack -= 1
+              subtype_string += char
+              raise ComplexTypeError, "Invalid close in type #{type_string}" if paren_stack.negative?
+              next
+            elsif char == '[' &&
+                  (bracket_stack.positive? ||
+                   (base.strip.empty? && point_stack.zero? && curly_stack.zero? && paren_stack.zero?))
+              # Only a fresh atom (blank base, not already nested in
+              # <>/{}/()) can start a `[...]` group - matching
+              # finish_atom's own precondition. Otherwise `[` is just an
+              # ordinary character, e.g. part of a literal type like
+              # `"[]"`, which has no concept of grouping.
+              bracket_stack += 1
+            elsif char == ']' && bracket_stack.positive?
+              bracket_stack -= 1
+              subtype_string += char
+              next
+            elsif char == '&' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+              conjuncts.push ComplexType.new([finish_atom(base, subtype_string)])
+              base.clear
+              subtype_string.clear
+              next
+            elsif char == '|' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+              disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
+              conjuncts = []
+              base.clear
+              subtype_string.clear
+              next
+            elsif char == ',' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+              disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
+              types.push close_disjunction(disjuncts)
+              conjuncts = []
+              disjuncts = []
+              base.clear
+              subtype_string.clear
+              next
+            end
+            if top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
+              base.concat char
+            else
+              subtype_string.concat char
+            end
+          end
+          raise ComplexTypeError, "Unclosed string literal in #{type_string}" if quote
+          if point_stack != 0 || curly_stack != 0 || paren_stack != 0 || bracket_stack != 0
+            raise ComplexTypeError,
+                  "Unclosed subtype in #{type_string}"
+          end
+          disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
+          types.push close_disjunction(disjuncts)
         end
         unless key_types.nil?
           raise ComplexTypeError, 'Invalid use of key/value parameters' unless partial
@@ -541,156 +652,6 @@ module Solargraph
       end
 
       private
-
-      # Parses a single type string (one comma-separated slot of a
-      # types specifier list) and appends the resulting type(s) to
-      # +types+.
-      #
-      # A top-level `&` (not nested in `<>`, `{}`, or `()`) builds a
-      # ComplexType::UniqueType::Intersection instead of a plain
-      # UniqueType. This applies equally to ordinary YARD type tags
-      # and to RBS-derived tags, since both are parsed here; YARD has
-      # no official intersection syntax yet (see
-      # https://github.com/lsegal/yard/issues/1644), so this is a
-      # Solargraph extension using RBS's `&` convention.
-      #
-      # @param type_string [String, nil]
-      # @param types [Array<ComplexType::UniqueType>]
-      # @param key_types [Array<ComplexType::UniqueType>, nil]
-      # @return [Array(Array<ComplexType::UniqueType>, Array<ComplexType::UniqueType>, nil)]
-      def parse_type_string type_string, types, key_types
-        point_stack = 0
-        curly_stack = 0
-        paren_stack = 0
-        bracket_stack = 0
-        base = String.new
-        subtype_string = String.new
-        # conjuncts of an intersection type (`A & B`) seen so far in
-        # the current `|`-disjunct of the segment being parsed
-        # @type [Array<ComplexType>]
-        conjuncts = []
-        # disjuncts of a union type (`A | B`) seen so far in the
-        # segment currently being parsed
-        # @type [Array<ComplexType, ComplexType::UniqueType>]
-        disjuncts = []
-        # @param char [String]
-        type_string&.each_char do |char|
-          if char == '='
-            # raise ComplexTypeError, "Invalid = in type #{type_string}" unless curly_stack > 0
-          elsif char == '<'
-            point_stack += 1
-          elsif char == '>'
-            if subtype_string.end_with?('=') && curly_stack.positive?
-              subtype_string += char
-            elsif base.end_with?('=')
-              raise ComplexTypeError, 'Invalid hash thing' unless key_types.nil?
-              key_types = close_key_types(base, subtype_string, conjuncts, disjuncts, types)
-              types = []
-              next
-            else
-              raise ComplexTypeError, "Invalid close in type #{type_string}" if point_stack.zero?
-              point_stack -= 1
-              subtype_string += char
-            end
-            next
-          elsif char == '{'
-            curly_stack += 1
-          elsif char == '}'
-            curly_stack = close_bracket(curly_stack, subtype_string, char, type_string)
-            next
-          elsif char == '('
-            paren_stack += 1
-          elsif char == ')'
-            paren_stack = close_bracket(paren_stack, subtype_string, char, type_string)
-            next
-          elsif char == '[' &&
-                (bracket_stack.positive? ||
-                 (base.strip.empty? && point_stack.zero? && curly_stack.zero? && paren_stack.zero?))
-            # Only a fresh atom (blank base, not already nested in
-            # <>/{}/()) can start a `[...]` group - matching
-            # finish_atom's own precondition. Otherwise `[` is just an
-            # ordinary character, e.g. part of a quoted string literal
-            # type like `"[]"`, which has no concept of grouping.
-            bracket_stack += 1
-          elsif char == ']' && bracket_stack.positive?
-            bracket_stack = close_bracket(bracket_stack, subtype_string, char, type_string)
-            next
-          elsif char == '&' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
-            conjuncts.push ComplexType.new([finish_atom(base, subtype_string)])
-            base.clear
-            subtype_string.clear
-            next
-          elsif char == '|' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
-            disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
-            conjuncts = []
-            base.clear
-            subtype_string.clear
-            next
-          elsif char == ',' && top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
-            disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
-            types.push close_disjunction(disjuncts)
-            conjuncts = []
-            disjuncts = []
-            base.clear
-            subtype_string.clear
-            next
-          end
-          if top_level?(point_stack, curly_stack, paren_stack, bracket_stack)
-            base.concat char
-          else
-            subtype_string.concat char
-          end
-        end
-        if point_stack != 0 || curly_stack != 0 || paren_stack != 0 || bracket_stack != 0
-          raise ComplexTypeError,
-                "Unclosed subtype in #{type_string}"
-        end
-        disjuncts.push close_intersection(conjuncts, finish_atom(base, subtype_string))
-        types.push close_disjunction(disjuncts)
-        [types, key_types]
-      end
-
-      # Decrements the stack counter for a closing `}`/`)`/`]` and
-      # appends it to the pending subtype substring.
-      #
-      # @param stack [Integer]
-      # @param subtype_string [String]
-      # @param char [String]
-      # @param type_string [String, nil]
-      # @return [Integer] the decremented stack counter
-      def close_bracket stack, subtype_string, char, type_string
-        stack -= 1
-        subtype_string << char
-        raise ComplexTypeError, "Invalid close in type #{type_string}" if stack.negative?
-        stack
-      end
-
-      # Closes the key-list portion of a `Hash{K=>V}` split (the base
-      # ending in `=` marks the boundary) and returns the types parsed
-      # so far to be stashed as the eventual key_types, leaving
-      # conjuncts/disjuncts/base/subtype_string cleared for the value
-      # list that follows.
-      #
-      # @todo this should either expand key_type's type automatically
-      #   or complain about not being compatible with key_type's type
-      #   in type checking
-      #
-      # @param base [String]
-      # @param subtype_string [String]
-      # @param conjuncts [Array<ComplexType>]
-      # @param disjuncts [Array<ComplexType, ComplexType::UniqueType>]
-      # @param types [Array<ComplexType::UniqueType, ComplexType>]
-      # @return [Array<ComplexType::UniqueType, ComplexType>] the key_types
-      def close_key_types base, subtype_string, conjuncts, disjuncts, types
-        # @sg-ignore Need to add nil check here
-        disjuncts.push close_intersection(conjuncts, finish_atom(base[0..-2], subtype_string))
-        types.push close_disjunction(disjuncts)
-        conjuncts.clear
-        disjuncts.clear
-        base.clear
-        subtype_string.clear
-        types
-      end
 
       # @param point_stack [Integer]
       # @param curly_stack [Integer]

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -89,8 +89,13 @@ module Solargraph
         # only called when expected.is_a?(UniqueType::Intersection)
         # @type [UniqueType::Intersection]
         intersection = expected
+        # Wrap inferred in a ComplexType (rather than calling
+        # UniqueType#conforms_to? directly) so each conjunct check
+        # gets ComplexType#conforms_to?'s special-case handling (e.g.
+        # duck_type? conjuncts), not just UniqueType's.
+        wrapped_inferred = ComplexType.new([inferred])
         intersection.conjuncts.all? do |conjunct|
-          inferred.conforms_to?(api_map, ComplexType.new([conjunct]), situation, rules, variance: variance)
+          wrapped_inferred.conforms_to?(api_map, ComplexType.new([conjunct]), situation, rules, variance: variance)
         end
       end
 

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -95,7 +95,7 @@ module Solargraph
         # duck_type? conjuncts), not just UniqueType's.
         wrapped_inferred = ComplexType.new([inferred])
         intersection.conjuncts.all? do |conjunct|
-          wrapped_inferred.conforms_to?(api_map, ComplexType.new([conjunct]), situation, rules, variance: variance)
+          wrapped_inferred.conforms_to?(api_map, conjunct, situation, rules, variance: variance)
         end
       end
 

--- a/lib/solargraph/complex_type/conformance.rb
+++ b/lib/solargraph/complex_type/conformance.rb
@@ -41,6 +41,12 @@ module Solargraph
           # :nocov:
         end
 
+        # An expectation of `A & B` can only be satisfied by
+        # something that conforms to every conjunct (A & B <: A and
+        # A & B <: B, so satisfying the intersection requires
+        # satisfying both).
+        return conforms_to_intersection_expectation? if expected.is_a?(UniqueType::Intersection)
+
         return true if ignore_interface?
         return true if conforms_via_reverse_match?
 
@@ -77,6 +83,16 @@ module Solargraph
       end
 
       private
+
+      # @return [Boolean]
+      def conforms_to_intersection_expectation?
+        # only called when expected.is_a?(UniqueType::Intersection)
+        # @type [UniqueType::Intersection]
+        intersection = expected
+        intersection.conjuncts.all? do |conjunct|
+          inferred.conforms_to?(api_map, ComplexType.new([conjunct]), situation, rules, variance: variance)
+        end
+      end
 
       def only_inferred_parameters?
         !expected.parameters? && inferred.parameters?

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -212,6 +212,25 @@ module Solargraph
         @non_literal_name ||= determine_non_literal_name
       end
 
+      # Whether every one of this type's key_types is a literal type
+      # (e.g. `Hash{"Index" => Float}`'s key_types is `["Index"]`, a
+      # literal String) - a Hash-like type whose keys are specific
+      # values rather than a general key class.
+      #
+      # @return [Boolean]
+      def literal_keyed?
+        key_types.any? && key_types.all? { |kt| kt.items.all?(&:literal?) }
+      end
+
+      # Whether any of this type's key_types has the given literal tag
+      # (e.g. `'"Index"'`, `':foo'`, `'1'`).
+      #
+      # @param tag [String]
+      # @return [Boolean]
+      def key_type_tag? tag
+        key_types.any? { |kt| kt.tag == tag }
+      end
+
       # @return [self]
       def without_nil
         return UniqueType::UNDEFINED if nil_type?

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -178,7 +178,7 @@ module Solargraph
 
       # @param api_map [ApiMap]
       # @param unique_type [ComplexType::UniqueType]
-      # @return [Symbol, nil] :class, :module, or nil if unknown
+      # @return [:class, :module, nil] nil when the namespace has no pin
       def namespace_kind api_map, unique_type
         # @type [Pin::Namespace, nil]
         pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -13,6 +13,13 @@ module Solargraph
 
       attr_reader :all_params, :subtypes, :key_types
 
+      # @type [Hash{String => String}]
+      ANONYMOUS_NAME_BY_STARTING_TAG = {
+        '{' => 'Hash',
+        '(' => 'Array',
+        '<' => 'Array'
+      }.freeze
+
       # Create a UniqueType with the specified name and an optional substring.
       # The substring is the parameter section of a parametrized type, e.g.,
       # for the type `Array<String>`, the name is `Array` and the substring is
@@ -24,6 +31,11 @@ module Solargraph
       # @return [UniqueType]
       def self.parse name, substring = '', make_rooted: nil
         raise ComplexTypeError, "Illegal prefix: #{name}" if name.start_with?(':::')
+        # Anonymous shorthand - `<A>`, `(A)`, `{A=>B}` - omits the
+        # leading type name, defaulting it to Array or Hash. Resolved
+        # before the rooted/can_root_name? check below so an anonymous
+        # `<A>` behaves exactly like the equivalent `Array<A>`.
+        name = ANONYMOUS_NAME_BY_STARTING_TAG.fetch(substring[0]) if name.empty? && !substring.empty?
         if name.start_with?('::')
           name = name[2..]
           rooted = true

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -124,9 +124,15 @@ module Solargraph
       # Flow-sensitive type narrowing: given a type learned from a
       # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down
       # to the more specific of each compatible pair between the two
-      # sides. This is a set-refinement over alternatives, not a
-      # real intersection type - see
-      # ComplexType::UniqueType::Intersection for that.
+      # sides. When neither side is already known to be a subtype of
+      # the other but one is positively confirmed to be a mix-in
+      # (e.g. a declared class and an unrelated module), both facts
+      # are still true at once, so the pair is combined into an
+      # Intersection rather than discarded. Everything else - two
+      # different concrete classes (impossible; an object has exactly
+      # one class), or either side being a namespace we can't
+      # positively identify - falls back to the original behavior of
+      # dropping the pair.
       #
       # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
       #
@@ -144,12 +150,41 @@ module Solargraph
               types << ut
             elsif candidate.conforms_to?(api_map, ut, :assignment)
               types << candidate
+            elsif mixin_pairing?(api_map, ut, candidate)
+              types << Intersection.new([ComplexType.new([ut]), ComplexType.new([candidate])])
             end
           end
         end
         types = [ComplexType::UniqueType::UNDEFINED] if types.empty?
         ComplexType.new(types)
       end
+
+      # Whether combining these two into an intersection is safe. Only
+      # true when at least one side is *positively confirmed* to be a
+      # mix-in: any class can pick up any module, so a class-and-module
+      # pairing is always plausible. Everything else - two different
+      # concrete classes, or a namespace we have no pin for (synthetic
+      # names like `Boolean`, generics, literals, duck types, or
+      # simply unresolved) - defaults to false, preserving the
+      # original drop-the-pair behavior.
+      #
+      # @param api_map [ApiMap]
+      # @param declared [ComplexType::UniqueType]
+      # @param candidate [ComplexType::UniqueType]
+      # @return [Boolean]
+      def mixin_pairing? api_map, declared, candidate
+        namespace_kind(api_map, declared) == :module || namespace_kind(api_map, candidate) == :module
+      end
+
+      # @param api_map [ApiMap]
+      # @param unique_type [ComplexType::UniqueType]
+      # @return [Symbol, nil] :class, :module, or nil if unknown
+      def namespace_kind api_map, unique_type
+        # @type [Pin::Namespace, nil]
+        pin = api_map.get_path_pins(unique_type.namespace).find { |p| p.is_a?(Pin::Namespace) }
+        pin&.type
+      end
+      private :mixin_pairing?, :namespace_kind
 
       def simplifyable_literal?
         literal? && name != 'nil'

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -9,6 +9,8 @@ module Solargraph
       include TypeMethods
       include Equality
 
+      autoload :Intersection, 'solargraph/complex_type/unique_type/intersection'
+
       attr_reader :all_params, :subtypes, :key_types
 
       # Create a UniqueType with the specified name and an optional substring.
@@ -262,7 +264,9 @@ module Solargraph
         # match one of their unique types
         expected.any? do |expected_unique_type|
           # :nocov:
-          unless expected_unique_type.instance_of?(UniqueType)
+          unless expected_unique_type.is_a?(UniqueType)
+            # @sg-ignore is_a? doesn't narrow the negated branch as
+            #   precisely as instance_of? did
             raise "Expected type must be a UniqueType, got #{expected_unique_type.class} in #{expected.inspect}"
           end
           # :nocov:

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -121,22 +121,29 @@ module Solargraph
         ComplexType.new(types)
       end
 
-      # @see https://en.wikipedia.org/wiki/Intersection_type
+      # Flow-sensitive type narrowing: given a type learned from a
+      # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down
+      # to the more specific of each compatible pair between the two
+      # sides. This is a set-refinement over alternatives, not a
+      # real intersection type - see
+      # ComplexType::UniqueType::Intersection for that.
       #
-      # @param intersection_type [ComplexType, ComplexType::UniqueType, nil]
+      # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
+      #
+      # @param narrowing_type [ComplexType, ComplexType::UniqueType, nil]
       # @param api_map [ApiMap]
       # @return [self, ComplexType]
-      def intersect_with intersection_type, api_map
-        return self if intersection_type.nil?
-        return intersection_type if undefined?
+      def narrow_with narrowing_type, api_map
+        return self if narrowing_type.nil?
+        return narrowing_type if undefined?
         types = []
         # try to find common types via conformance
         items.each do |ut|
-          intersection_type.each do |int_type|
-            if ut.conforms_to?(api_map, int_type, :assignment)
+          narrowing_type.each do |candidate|
+            if ut.conforms_to?(api_map, candidate, :assignment)
               types << ut
-            elsif int_type.conforms_to?(api_map, ut, :assignment)
-              types << int_type
+            elsif candidate.conforms_to?(api_map, ut, :assignment)
+              types << candidate
             end
           end
         end

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -134,17 +134,11 @@ module Solargraph
       end
 
       # Flow-sensitive type narrowing: given a type learned from a
-      # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down
-      # to the more specific of each compatible pair between the two
-      # sides. When neither side is already known to be a subtype of
-      # the other but one is positively confirmed to be a mix-in
-      # (e.g. a declared class and an unrelated module), both facts
-      # are still true at once, so the pair is combined into an
-      # Intersection rather than discarded. Everything else - two
-      # different concrete classes (impossible; an object has exactly
-      # one class), or either side being a namespace we can't
-      # positively identify - falls back to the original behavior of
-      # dropping the pair.
+      # runtime guard (e.g. `x.is_a?(Foo)`), refines this type down to
+      # the more specific of each compatible pair. When neither side
+      # subtypes the other but one is confirmed to be a mix-in, both
+      # facts hold at once, so the pair becomes an Intersection; any
+      # other pair is dropped (see #mixin_pairing?).
       #
       # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
       #
@@ -171,15 +165,9 @@ module Solargraph
         ComplexType.new(types)
       end
 
-      # Whether combining these two into an intersection is safe. Only
-      # true when at least one side is *positively confirmed* to be a
-      # mix-in: any class can pick up any module, so a class-and-module
-      # pairing is always plausible. Everything else - two different
-      # concrete classes, or a namespace we have no pin for (synthetic
-      # names like `Boolean`, generics, literals, duck types, or
-      # simply unresolved) - defaults to false, preserving the
-      # original drop-the-pair behavior.
+      # Whether combining these two into an intersection is safe.
       #
+      # @see ComplexType#mixin_pairing?
       # @param api_map [ApiMap]
       # @param declared [ComplexType::UniqueType]
       # @param candidate [ComplexType::UniqueType]
@@ -337,11 +325,7 @@ module Solargraph
         # match one of their unique types
         expected.any? do |expected_unique_type|
           # :nocov:
-          unless expected_unique_type.is_a?(UniqueType)
-            # @sg-ignore is_a? doesn't narrow the negated branch as
-            #   precisely as instance_of? did
-            raise "Expected type must be a UniqueType, got #{expected_unique_type.class} in #{expected.inspect}"
-          end
+          raise "Expected type must be a UniqueType in #{expected.inspect}" unless expected_unique_type.is_a?(UniqueType)
           # :nocov:
           conformance = Conformance.new(api_map, self, expected_unique_type, situation,
                                         rules, variance: variance)

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -1,0 +1,129 @@
+# frozen_string_literal: true
+
+module Solargraph
+  class ComplexType
+    class UniqueType
+      # A single unique type representing the intersection of two or
+      # more conjunct types, e.g., the RBS type `A & B`.
+      #
+      # Unlike ComplexType's comma-separated items (a union, where any
+      # one member describes the value), every conjunct of an
+      # Intersection must independently describe the value. That
+      # means the subtyping rules are the mirror image of a union's:
+      #
+      #   A & B <: A
+      #   A & B <: B
+      #
+      # i.e., a value typed as the intersection can be used wherever
+      # *any* conjunct is expected, but a value can only be used
+      # where the intersection itself is expected if it satisfies
+      # *every* conjunct.
+      #
+      # `A & B` is parsed the same way from plain YARD type tags
+      # (`@param`, `@return`, `@type`, etc.) as it is from inline RBS
+      # signatures, since both funnel through ComplexType.parse. YARD
+      # itself has no official intersection type syntax yet; `&` is
+      # Solargraph's extension pending upstream guidance.
+      #
+      # @see https://en.wikipedia.org/wiki/Intersection_type
+      # @see https://github.com/ruby/rbs/blob/master/docs/syntax.md#intersection-type
+      # @see https://github.com/lsegal/yard/issues/1644
+      class Intersection < UniqueType
+        # @return [Array<UniqueType>]
+        attr_reader :conjuncts
+
+        # @param conjuncts [Array<UniqueType>]
+        def initialize conjuncts
+          @conjuncts = conjuncts
+          super(conjuncts.map(&:tag).join(' & '), rooted: true)
+        end
+
+        # @return [String]
+        def tag
+          @tag ||= conjuncts.map(&:tag).join(' & ')
+        end
+
+        # @return [String]
+        def rooted_tag
+          @rooted_tag ||= conjuncts.map(&:rooted_tag).join(' & ')
+        end
+
+        # @return [String]
+        def to_rbs
+          conjuncts.map(&:to_rbs).join(' & ')
+        end
+
+        # @return [String]
+        def namespace
+          conjuncts.fetch(0).namespace
+        end
+
+        # @return [::Symbol]
+        def scope
+          conjuncts.fetch(0).scope
+        end
+
+        def generic?
+          conjuncts.any?(&:generic?)
+        end
+
+        def rooted?
+          conjuncts.all?(&:rooted?)
+        end
+
+        def all_rooted?
+          conjuncts.all?(&:all_rooted?)
+        end
+
+        def duck_type?
+          false
+        end
+
+        def interface?
+          false
+        end
+
+        # @yieldparam [UniqueType]
+        # @return [void]
+        # @overload each_unique_type()
+        #   @return [Enumerator<UniqueType>]
+        def each_unique_type &block
+          return enum_for(__method__) unless block_given?
+          conjuncts.each { |conjunct| conjunct.each_unique_type(&block) }
+        end
+
+        # An intersection can be assigned wherever any one of its
+        # conjuncts would be accepted (A & B <: A, A & B <: B).
+        #
+        # @param api_map [ApiMap]
+        # @param expected [ComplexType, ComplexType::UniqueType]
+        # @param situation [:method_call, :assignment, :return_type]
+        # @param rules [Array<:allow_subtype_skew, :allow_empty_params, :allow_reverse_match, :allow_any_match, :allow_undefined, :allow_unresolved_generic>]
+        # @param variance [:invariant, :covariant, :contravariant]
+        # @return [Boolean]
+        def conforms_to? api_map, expected, situation, rules = [],
+                         variance: erased_variance(situation)
+          conjuncts.any? do |conjunct|
+            conjunct.conforms_to?(api_map, expected, situation, rules, variance: variance)
+          end
+        end
+
+        # Applies the transformation to each conjunct independently
+        # and rebuilds the intersection from the results.
+        #
+        # @param new_name [String, nil]
+        # @yieldparam t [UniqueType]
+        # @yieldreturn [UniqueType]
+        # @return [self]
+        def transform new_name = nil, &transform_type
+          Intersection.new(conjuncts.map { |conjunct| conjunct.transform(new_name, &transform_type) })
+        end
+
+        # @return [self]
+        def erase_parameters
+          self
+        end
+      end
+    end
+  end
+end

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -32,17 +32,17 @@ module Solargraph
         # @param conjuncts [Array<ComplexType>]
         def initialize conjuncts
           @conjuncts = conjuncts
-          super(conjuncts.map(&:tags).join(' & '), rooted: true)
+          super(intersection_tag(:tags), rooted: true)
         end
 
         # @return [String]
         def tag
-          @tag ||= conjuncts.map(&:tags).join(' & ')
+          @tag ||= intersection_tag(:tags)
         end
 
         # @return [String]
         def rooted_tag
-          @rooted_tag ||= conjuncts.map(&:rooted_tags).join(' & ')
+          @rooted_tag ||= intersection_tag(:rooted_tags)
         end
 
         # @return [String]
@@ -138,6 +138,21 @@ module Solargraph
         end
 
         private
+
+        # Renders the conjuncts as a tag, bracketing any conjunct that
+        # holds more than one type. `&` binds tighter than the `,`/`|`
+        # of a union, so without the brackets `[A | B] & C` would
+        # render as `A, B & C` and parse back as `A | (B & C)` - a
+        # different type.
+        #
+        # @param tags_method [:tags, :rooted_tags]
+        # @return [String]
+        def intersection_tag tags_method
+          conjuncts.map do |conjunct|
+            tags = conjunct.send(tags_method)
+            conjunct.items.length > 1 ? "[#{tags}]" : tags
+          end.join(' & ')
+        end
 
         # Returns expected itself when it's a bare Intersection, or
         # its one item when it's a ComplexType consisting of nothing

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -121,6 +121,29 @@ module Solargraph
           end
         end
 
+        # Every conjunct describes the same value, so each is resolved
+        # against the same context type, and a generic bound by one
+        # conjunct is visible to the rest through the shared
+        # resolved_generic_values hash. UniqueType's implementation
+        # looks for generics in #subtypes and #key_types, which an
+        # intersection does not use - its type parameters live inside
+        # the conjuncts - so `Class<generic<T>> & #new` never bound T.
+        #
+        # Conjuncts resolve left to right, so a generic that only
+        # becomes bindable through a later conjunct stays unresolved in
+        # an earlier one's output.
+        #
+        # @param generics_to_resolve [Enumerable<String>]
+        # @param context_type [ComplexType, UniqueType, nil]
+        # @param resolved_generic_values [Hash{String => ComplexType, UniqueType}]
+        # @return [Intersection]
+        def resolve_generics_from_context generics_to_resolve, context_type, resolved_generic_values: {}
+          Intersection.new(conjuncts.map do |conjunct|
+            conjunct.resolve_generics_from_context(generics_to_resolve, context_type,
+                                                   resolved_generic_values: resolved_generic_values)
+          end)
+        end
+
         # Applies the transformation to each conjunct independently
         # and rebuilds the intersection from the results.
         #

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -19,6 +19,16 @@ module Solargraph
       # where the intersection itself is expected if it satisfies
       # *every* conjunct.
       #
+      # Each conjunct is a full ComplexType, not a plain UniqueType -
+      # the same way UniqueType#subtypes and #key_types already hold
+      # ComplexTypes rather than UniqueTypes. RBS itself allows a
+      # union as one member of an intersection (`(A | B) & C`), so a
+      # conjunct needs to be able to represent more than one
+      # alternative; a single type is just the common case of a
+      # one-item ComplexType. This also means a conjunct can itself be
+      # (or contain) another Intersection, since Intersection is a
+      # UniqueType and ComplexType already holds UniqueTypes.
+      #
       # `A & B` is parsed the same way from plain YARD type tags
       # (`@param`, `@return`, `@type`, etc.) as it is from inline RBS
       # signatures, since both funnel through ComplexType.parse. YARD
@@ -29,23 +39,23 @@ module Solargraph
       # @see https://github.com/ruby/rbs/blob/master/docs/syntax.md#intersection-type
       # @see https://github.com/lsegal/yard/issues/1644
       class Intersection < UniqueType
-        # @return [Array<UniqueType>]
+        # @return [Array<ComplexType>]
         attr_reader :conjuncts
 
-        # @param conjuncts [Array<UniqueType>]
+        # @param conjuncts [Array<ComplexType>]
         def initialize conjuncts
           @conjuncts = conjuncts
-          super(conjuncts.map(&:tag).join(' & '), rooted: true)
+          super(conjuncts.map(&:tags).join(' & '), rooted: true)
         end
 
         # @return [String]
         def tag
-          @tag ||= conjuncts.map(&:tag).join(' & ')
+          @tag ||= conjuncts.map(&:tags).join(' & ')
         end
 
         # @return [String]
         def rooted_tag
-          @rooted_tag ||= conjuncts.map(&:rooted_tag).join(' & ')
+          @rooted_tag ||= conjuncts.map(&:rooted_tags).join(' & ')
         end
 
         # @return [String]
@@ -93,7 +103,10 @@ module Solargraph
         end
 
         # An intersection can be assigned wherever any one of its
-        # conjuncts would be accepted (A & B <: A, A & B <: B).
+        # conjuncts would be accepted (A & B <: A, A & B <: B). Each
+        # conjunct is checked as a full ComplexType, so a conjunct
+        # that's itself a union (from `(A | B) & C`) gets real union
+        # semantics (every member of that union must conform).
         #
         # @param api_map [ApiMap]
         # @param expected [ComplexType, ComplexType::UniqueType]

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -100,6 +100,13 @@ module Solargraph
         # *some* conjunct of this one, not necessarily the same one each
         # time - handled separately below.
         #
+        # A union on the expected side is tried one alternative at a
+        # time first, so that an intersection buried in a union is
+        # still compared as an intersection. Checking the conjuncts
+        # against the whole union instead asks a single conjunct to
+        # carry the match on its own, which `A & false` cannot do
+        # against a union that contains `A & false` itself.
+        #
         # @param api_map [ApiMap]
         # @param expected [ComplexType, ComplexType::UniqueType]
         # @param situation [:method_call, :assignment, :return_type]
@@ -108,6 +115,8 @@ module Solargraph
         # @return [Boolean]
         def conforms_to? api_map, expected, situation, rules = [],
                          variance: erased_variance(situation)
+          return true if any_union_alternative_conforms?(api_map, expected, situation, rules, variance)
+
           expected_intersection = sole_intersection(expected)
           if expected_intersection
             return expected_intersection.conjuncts.all? do |expected_conjunct|
@@ -179,12 +188,28 @@ module Solargraph
 
         # Returns expected itself when it's a bare Intersection, or
         # its one item when it's a ComplexType consisting of nothing
-        # but a single Intersection. Anything else - including a
-        # union with an intersection as just one of several
-        # alternatives - returns nil, leaving that (rarer, untested)
-        # case on the simpler existing "any conjunct" path rather
-        # than guessing at its semantics here.
+        # but a single Intersection. A union with an intersection as
+        # one of several alternatives returns nil; #conforms_to? has
+        # already tried each alternative on its own by then, so what
+        # reaches here is the fallback "any conjunct" path.
         #
+        # True when expected is a union and this intersection conforms
+        # to one of its alternatives taken on its own.
+        #
+        # @param api_map [ApiMap]
+        # @param expected [ComplexType, ComplexType::UniqueType]
+        # @param situation [:method_call, :assignment, :return_type]
+        # @param rules [Array<Symbol>]
+        # @param variance [:invariant, :covariant, :contravariant]
+        # @return [Boolean]
+        def any_union_alternative_conforms? api_map, expected, situation, rules, variance
+          return false unless expected.is_a?(ComplexType) && expected.length > 1
+
+          expected.items.any? do |item|
+            conforms_to?(api_map, ComplexType.new([item]), situation, rules, variance: variance)
+          end
+        end
+
         # @param expected [ComplexType, ComplexType::UniqueType]
         # @return [Intersection, nil]
         def sole_intersection expected

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -7,33 +7,20 @@ module Solargraph
       # more conjunct types, e.g., the RBS type `A & B`.
       #
       # Unlike ComplexType's comma-separated items (a union, where any
-      # one member describes the value), every conjunct of an
-      # Intersection must independently describe the value. That
-      # means the subtyping rules are the mirror image of a union's:
+      # one member describes the value), every conjunct must describe
+      # the value independently, so the subtyping rules are a union's
+      # mirror image: A & B <: A and A & B <: B, but a value satisfies
+      # A & B only if it satisfies every conjunct.
       #
-      #   A & B <: A
-      #   A & B <: B
+      # Each conjunct is a full ComplexType, not a plain UniqueType, as
+      # RBS allows a union as one member of an intersection
+      # (`(A | B) & C`) - and so a conjunct may itself be an
+      # Intersection.
       #
-      # i.e., a value typed as the intersection can be used wherever
-      # *any* conjunct is expected, but a value can only be used
-      # where the intersection itself is expected if it satisfies
-      # *every* conjunct.
-      #
-      # Each conjunct is a full ComplexType, not a plain UniqueType -
-      # the same way UniqueType#subtypes and #key_types already hold
-      # ComplexTypes rather than UniqueTypes. RBS itself allows a
-      # union as one member of an intersection (`(A | B) & C`), so a
-      # conjunct needs to be able to represent more than one
-      # alternative; a single type is just the common case of a
-      # one-item ComplexType. This also means a conjunct can itself be
-      # (or contain) another Intersection, since Intersection is a
-      # UniqueType and ComplexType already holds UniqueTypes.
-      #
-      # `A & B` is parsed the same way from plain YARD type tags
-      # (`@param`, `@return`, `@type`, etc.) as it is from inline RBS
-      # signatures, since both funnel through ComplexType.parse. YARD
-      # itself has no official intersection type syntax yet; `&` is
-      # Solargraph's extension pending upstream guidance.
+      # `A & B` parses the same from plain YARD type tags as from
+      # inline RBS signatures, since both funnel through
+      # ComplexType.parse. YARD has no official intersection syntax
+      # yet; `&` is Solargraph's extension pending upstream guidance.
       #
       # @see https://en.wikipedia.org/wiki/Intersection_type
       # @see https://github.com/ruby/rbs/blob/master/docs/syntax.md#intersection-type
@@ -108,16 +95,10 @@ module Solargraph
         # that's itself a union (from `(A | B) & C`) gets real union
         # semantics (every member of that union must conform).
         #
-        # When expected is *also* an intersection, that simple "any
-        # one conjunct" rule breaks down: a single one of our
-        # conjuncts, checked alone, would have to satisfy every
-        # conjunct expected of it - which fails whenever our conjuncts
-        # don't already relate to each other, even when checking an
-        # intersection against an identical copy of itself. The
-        # correct rule for A & B <: C & D is that every conjunct of
-        # the expected side must be satisfied by *some* conjunct of
-        # this one (not necessarily the same one each time), so that
-        # case is handled separately below.
+        # When expected is *also* an intersection, the rule instead is
+        # that every conjunct of the expected side must be satisfied by
+        # *some* conjunct of this one, not necessarily the same one each
+        # time - handled separately below.
         #
         # @param api_map [ApiMap]
         # @param expected [ComplexType, ComplexType::UniqueType]

--- a/lib/solargraph/complex_type/unique_type/intersection.rb
+++ b/lib/solargraph/complex_type/unique_type/intersection.rb
@@ -108,6 +108,17 @@ module Solargraph
         # that's itself a union (from `(A | B) & C`) gets real union
         # semantics (every member of that union must conform).
         #
+        # When expected is *also* an intersection, that simple "any
+        # one conjunct" rule breaks down: a single one of our
+        # conjuncts, checked alone, would have to satisfy every
+        # conjunct expected of it - which fails whenever our conjuncts
+        # don't already relate to each other, even when checking an
+        # intersection against an identical copy of itself. The
+        # correct rule for A & B <: C & D is that every conjunct of
+        # the expected side must be satisfied by *some* conjunct of
+        # this one (not necessarily the same one each time), so that
+        # case is handled separately below.
+        #
         # @param api_map [ApiMap]
         # @param expected [ComplexType, ComplexType::UniqueType]
         # @param situation [:method_call, :assignment, :return_type]
@@ -116,6 +127,14 @@ module Solargraph
         # @return [Boolean]
         def conforms_to? api_map, expected, situation, rules = [],
                          variance: erased_variance(situation)
+          expected_intersection = sole_intersection(expected)
+          if expected_intersection
+            return expected_intersection.conjuncts.all? do |expected_conjunct|
+              conjuncts.any? do |conjunct|
+                conjunct.conforms_to?(api_map, expected_conjunct, situation, rules, variance: variance)
+              end
+            end
+          end
           conjuncts.any? do |conjunct|
             conjunct.conforms_to?(api_map, expected, situation, rules, variance: variance)
           end
@@ -135,6 +154,24 @@ module Solargraph
         # @return [self]
         def erase_parameters
           self
+        end
+
+        private
+
+        # Returns expected itself when it's a bare Intersection, or
+        # its one item when it's a ComplexType consisting of nothing
+        # but a single Intersection. Anything else - including a
+        # union with an intersection as just one of several
+        # alternatives - returns nil, leaving that (rarer, untested)
+        # case on the simpler existing "any conjunct" path rather
+        # than guessing at its semantics here.
+        #
+        # @param expected [ComplexType, ComplexType::UniqueType]
+        # @return [Intersection, nil]
+        def sole_intersection expected
+          return expected if expected.is_a?(Intersection)
+          return expected.first if expected.is_a?(ComplexType) && expected.length == 1 && expected.first.is_a?(Intersection)
+          nil
         end
       end
     end

--- a/lib/solargraph/parser/flow_sensitive_typing.rb
+++ b/lib/solargraph/parser/flow_sensitive_typing.rb
@@ -206,7 +206,7 @@ module Solargraph
       # @return [void]
       def add_downcast_var pin, presence:, downcast_type:, downcast_not_type:
         new_pin = pin.downcast(exclude_return_type: downcast_not_type,
-                               intersection_return_type: downcast_type,
+                               narrowed_return_type: downcast_type,
                                source: :flow_sensitive_typing,
                                presence: presence)
         if pin.is_a?(Pin::LocalVariable)

--- a/lib/solargraph/pin/base_variable.rb
+++ b/lib/solargraph/pin/base_variable.rb
@@ -31,46 +31,48 @@ module Solargraph
       #   Example: If a return type is 'Float | Integer | nil' and the
       #   exclude_return_type is 'Integer', the resulting return
       #   type will be 'Float | nil' because Integer is excluded.
-      # @param intersection_return_type [ComplexType, nil] Ensure each unique
+      # @param narrowed_return_type [ComplexType, nil] Ensure each unique
       #   return type is compatible with at least one element of this
       #   complex type.  If a ComplexType used as a return type is an
-      #   union type - we can return any of these - these are
-      #   intersection types - everything we return needs to meet at least
-      #   one of these unique types.
+      #   union type - we can return any of these - this is a
+      #   flow-sensitive narrowing (e.g. from an `is_a?` guard), not a
+      #   real intersection type (see
+      #   ComplexType::UniqueType::Intersection for that) - everything
+      #   we return needs to meet at least one of these unique types.
       #
       #   Example: If a return type is 'Numeric | nil' and the
-      #   intersection_return_type is 'Float | nil', the resulting return
+      #   narrowed_return_type is 'Float | nil', the resulting return
       #   type will be 'Float | nil' because Float is compatible
       #   with Numeric and nil is compatible with nil.
       # @see https://www.typescriptlang.org/docs/handbook/2/everyday-types.html#union-types
-      # @see https://en.wikipedia.org/wiki/Intersection_type#TypeScript_example
+      # @see https://www.typescriptlang.org/docs/handbook/2/narrowing.html
       # @param presence [Range, nil]
       # @param [Hash{Symbol => Object}] splat
       def initialize assignment: nil, assignments: [], mass_assignment: nil,
                      presence: nil, return_type: nil,
-                     intersection_return_type: nil, exclude_return_type: nil,
+                     narrowed_return_type: nil, exclude_return_type: nil,
                      **splat
         super(**splat)
         @assignments = (assignment.nil? ? [] : [assignment]) + assignments
         # @type [nil, ::Array(Parser::AST::Node, Integer)]
         @mass_assignment = mass_assignment
         @return_type = return_type
-        @intersection_return_type = intersection_return_type
+        @narrowed_return_type = narrowed_return_type
         @exclude_return_type = exclude_return_type
         @presence = presence
       end
 
       # @param presence [Range]
       # @param exclude_return_type [ComplexType, nil]
-      # @param intersection_return_type [ComplexType, nil]
+      # @param narrowed_return_type [ComplexType, nil]
       # @param source [::Symbol]
       #
       # @return [self]
-      def downcast presence:, exclude_return_type: nil, intersection_return_type: nil,
+      def downcast presence:, exclude_return_type: nil, narrowed_return_type: nil,
                    source: self.source
         result = dup
         result.exclude_return_type = exclude_return_type
-        result.intersection_return_type = intersection_return_type
+        result.narrowed_return_type = narrowed_return_type
         result.source = source
         result.presence = presence
         result.reset_generated!
@@ -93,7 +95,7 @@ module Solargraph
                                   assignments: new_assignments,
                                   mass_assignment: combine_mass_assignment(other),
                                   return_type: combine_return_type(other),
-                                  intersection_return_type: combine_types(other, :intersection_return_type),
+                                  narrowed_return_type: combine_types(other, :narrowed_return_type),
                                   exclude_return_type: combine_types(other, :exclude_return_type),
                                   presence: combine_presence(other)
                                 })
@@ -123,7 +125,7 @@ module Solargraph
 
       def inner_desc
         super + ", presence=#{presence.inspect}, assignments=#{assignments}, " \
-                "intersection_return_type=#{intersection_return_type&.rooted_tags.inspect}, " \
+                "narrowed_return_type=#{narrowed_return_type&.rooted_tags.inspect}, " \
                 "exclude_return_type=#{exclude_return_type&.rooted_tags.inspect}"
       end
 
@@ -214,7 +216,7 @@ module Solargraph
 
       # @return [ComplexType, nil]
       def return_type
-        generate_complex_type || @return_type || intersection_return_type || ComplexType::UNDEFINED
+        generate_complex_type || @return_type || narrowed_return_type || ComplexType::UNDEFINED
       end
 
       def typify api_map
@@ -225,7 +227,7 @@ module Solargraph
 
       # @sg-ignore need boolish support for ? methods
       def presence_certain?
-        exclude_return_type || intersection_return_type
+        exclude_return_type || narrowed_return_type
       end
 
       # @param other_loc [Location]
@@ -288,7 +290,7 @@ module Solargraph
 
       protected
 
-      attr_accessor :exclude_return_type, :intersection_return_type
+      attr_accessor :exclude_return_type, :narrowed_return_type
 
       # @return [Range]
       attr_writer :presence
@@ -302,8 +304,8 @@ module Solargraph
       def adjust_type api_map, raw_return_type
         qualified_exclude = exclude_return_type&.qualify(api_map, *(closure&.gates || ['']))
         minus_exclusions = raw_return_type.exclude qualified_exclude, api_map
-        qualified_intersection = intersection_return_type&.qualify(api_map, *(closure&.gates || ['']))
-        minus_exclusions.intersect_with qualified_intersection, api_map
+        qualified_narrowing = narrowed_return_type&.qualify(api_map, *(closure&.gates || ['']))
+        minus_exclusions.narrow_with qualified_narrowing, api_map
       end
 
       # See if this variable is visible within 'viewing_closure'

--- a/lib/solargraph/pin/namespace.rb
+++ b/lib/solargraph/pin/namespace.rb
@@ -8,7 +8,7 @@ module Solargraph
       # @return [::Symbol] :public or :private
       attr_reader :visibility
 
-      # @return [::Symbol] :class or :module
+      # @return [:class, :module]
       attr_reader :type
 
       # does not assert like super, as a namespace without a closure
@@ -16,7 +16,7 @@ module Solargraph
       # qualified
       attr_reader :closure
 
-      # @param type [::Symbol] :class or :module
+      # @param type [:class, :module]
       # @param visibility [::Symbol] :public or :private
       # @param gates [::Array<String>]
       # @param name [String]

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -60,31 +60,22 @@ module Solargraph
         out
       end
 
-      # The index of the first parameter acting as a Hash-like lookup
-      # key for this class's own `K` (e.g. `Hash#fetch`'s first
-      # parameter), or nil if no parameter has that shape.
+      # The index of the first parameter typed as the receiver's own
+      # key (e.g. `Hash#fetch`'s first parameter), or nil if none is.
       #
-      # RBS's `core/hash.rbs` declares that parameter two ways, so both
-      # are recognized: `(_Key key)` from RBS 4.1.0 on (matched by the
-      # interface's literal name, so only RBS's own `Hash::_Key`), and
-      # `(K arg0)` before it, where `K` has already been resolved
-      # against the receiver - for a literal-keyed receiver that makes
-      # it the literal key type `key_tags` matches against.
+      # The parameter is declared `K`, which by this point has been
+      # resolved against the receiver - for a literal-keyed receiver
+      # that makes it the literal key type `key_tags` matches against.
+      # RBS >= 4.1 declares it as the structural interface `Hash::_Key`
+      # instead; RbsTranslator stubs that back to `K` on the way in
+      # (see RBS_INTERFACE_TO_GENERIC), so only this one shape is left
+      # to recognize here.
       #
-      # @todo Match `_Key` structurally rather than by name once
-      #   castwide/solargraph#1266 lands with ApiMap#get_own_methods -
-      #   https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
-      #
-      # @param namespace [String]
       # @param api_map [ApiMap]
       # @param key_tags [::Array<String>] the receiver's own resolved
-      #   `key_types` tags, used to recognize the pre-4.1 `K`-typed
-      #   shape. Empty disables that fallback.
+      #   `key_types` tags. Empty means there is nothing to match.
       # @return [Integer, nil]
-      def hash_key_param_index namespace, api_map, key_tags = []
-        key_tag = "#{namespace}::_Key"
-        index = parameters.find_index { |p| p.typify(api_map).tag == key_tag }
-        return index unless index.nil?
+      def hash_key_param_index api_map, key_tags
         return nil if key_tags.empty?
 
         parameters.find_index { |p| key_tags.include?(p.typify(api_map).tag) }

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -60,14 +60,24 @@ module Solargraph
         out
       end
 
-      # The index of the first parameter typed exactly
-      # `<namespace>::_Key` - the position RBS uses to mark "this
-      # parameter is a lookup key for this class's own K" (e.g.
-      # `Hash#fetch: (Hash::_Key key) -> V`) - or nil if none of this
-      # signature's parameters have that shape.
+      # The index of the first parameter acting as a lookup key for
+      # this class's own `K` (e.g. `Hash#fetch`'s first parameter), or
+      # nil if none of this signature's parameters have that shape.
       #
-      # This matches by the interface's literal name, so it only
-      # recognizes RBS's own `Hash::_Key` - a user-defined generic
+      # Two shapes are recognized, because RBS's own `core/hash.rbs`
+      # changed how it declares them in 4.1.0:
+      #
+      # - RBS >= 4.1.0 declares `def fetch: (_Key key) -> V` (also
+      #   `#[]`, `#dig`, `#delete`), so the parameter is typed exactly
+      #   `<namespace>::_Key`.
+      # - RBS < 4.1.0 declares `def fetch: (K arg0) -> V`, so the
+      #   parameter is typed as the class's own generic `K`, which by
+      #   this point has already been resolved against the receiver -
+      #   for a literal-keyed receiver that makes it the literal key
+      #   type itself, which is what `key_types` matches against.
+      #
+      # The `_Key` shape matches by the interface's literal name, so it
+      # only recognizes RBS's own `Hash::_Key` - a user-defined generic
       # class using the same "marker interface for a lookup key"
       # pattern under a different name/namespace won't be detected.
       #
@@ -76,28 +86,35 @@ module Solargraph
       # ApiMap#get_own_methods (a namespace's directly-declared
       # methods, excluding inherited ones), extracted from
       # Conformance#required_interface_methods for exactly this reuse.
-      # Replace the literal name comparison below with a structural
-      # one: a parameter is key-shaped if its type is an interface
-      # whose own declared method names equal
-      # `Hash::_Key`'s (`hash`/`eql?`), regardless of the interface's
-      # actual name -
+      # Replace the `_Key` name comparison below with a structural one:
+      # a parameter is key-shaped if its type is an interface whose own
+      # declared method names equal `Hash::_Key`'s (`hash`/`eql?`),
+      # regardless of the interface's actual name -
       # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
       #
-      #   def key_param_index namespace, api_map
-      #     key_interface_methods = api_map.get_own_methods("#{namespace}::_Key").map(&:name).to_set
-      #     parameters.find_index do |p|
-      #       type = p.typify(api_map)
-      #       next false unless type.interface?
-      #       api_map.get_own_methods(type.tag).map(&:name).to_set == key_interface_methods
-      #     end
+      #   key_interface_methods = api_map.get_own_methods("#{namespace}::_Key").map(&:name).to_set
+      #   index = parameters.find_index do |p|
+      #     type = p.typify(api_map)
+      #     next false unless type.interface?
+      #     api_map.get_own_methods(type.tag).map(&:name).to_set == key_interface_methods
       #   end
+      #
+      # That only replaces the first branch - the `key_tags` fallback is
+      # still needed for RBS < 4.1, which has no interface there at all.
       #
       # @param namespace [String]
       # @param api_map [ApiMap]
+      # @param key_tags [::Array<String>] the receiver's own resolved
+      #   `key_types` tags, used to recognize the pre-4.1 `K`-typed
+      #   shape. Empty disables that fallback.
       # @return [Integer, nil]
-      def key_param_index namespace, api_map
+      def key_param_index namespace, api_map, key_tags = []
         key_tag = "#{namespace}::_Key"
-        parameters.find_index { |p| p.typify(api_map).tag == key_tag }
+        index = parameters.find_index { |p| p.typify(api_map).tag == key_tag }
+        return index unless index.nil?
+        return nil if key_tags.empty?
+
+        parameters.find_index { |p| key_tags.include?(p.typify(api_map).tag) }
       end
     end
   end

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -66,6 +66,32 @@ module Solargraph
       # `Hash#fetch: (Hash::_Key key) -> V`) - or nil if none of this
       # signature's parameters have that shape.
       #
+      # This matches by the interface's literal name, so it only
+      # recognizes RBS's own `Hash::_Key` - a user-defined generic
+      # class using the same "marker interface for a lookup key"
+      # pattern under a different name/namespace won't be detected.
+      #
+      # TODO once castwide/solargraph#1266 (structurally verify RBS
+      # interface-typed expectations) lands - it lands with
+      # ApiMap#get_own_methods (a namespace's directly-declared
+      # methods, excluding inherited ones), extracted from
+      # Conformance#required_interface_methods for exactly this reuse.
+      # Replace the literal name comparison below with a structural
+      # one: a parameter is key-shaped if its type is an interface
+      # whose own declared method names equal
+      # `Hash::_Key`'s (`hash`/`eql?`), regardless of the interface's
+      # actual name -
+      # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
+      #
+      #   def key_param_index namespace, api_map
+      #     key_interface_methods = api_map.get_own_methods("#{namespace}::_Key").map(&:name).to_set
+      #     parameters.find_index do |p|
+      #       type = p.typify(api_map)
+      #       next false unless type.interface?
+      #       api_map.get_own_methods(type.tag).map(&:name).to_set == key_interface_methods
+      #     end
+      #   end
+      #
       # @param namespace [String]
       # @param api_map [ApiMap]
       # @return [Integer, nil]

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -59,6 +59,20 @@ module Solargraph
         logger.debug { "Signature#typify(self=#{self}) => #{out}" }
         out
       end
+
+      # The index of the first parameter typed exactly
+      # `<namespace>::_Key` - the position RBS uses to mark "this
+      # parameter is a lookup key for this class's own K" (e.g.
+      # `Hash#fetch: (Hash::_Key key) -> V`) - or nil if none of this
+      # signature's parameters have that shape.
+      #
+      # @param namespace [String]
+      # @param api_map [ApiMap]
+      # @return [Integer, nil]
+      def key_param_index namespace, api_map
+        key_tag = "#{namespace}::_Key"
+        parameters.find_index { |p| p.typify(api_map).tag == key_tag }
+      end
     end
   end
 end

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -60,47 +60,20 @@ module Solargraph
         out
       end
 
-      # The index of the first parameter acting as a lookup key for
-      # this class's own `K` (e.g. `Hash#fetch`'s first parameter), or
-      # nil if none of this signature's parameters have that shape.
+      # The index of the first parameter acting as a Hash-like lookup
+      # key for this class's own `K` (e.g. `Hash#fetch`'s first
+      # parameter), or nil if no parameter has that shape.
       #
-      # Two shapes are recognized, because RBS's own `core/hash.rbs`
-      # changed how it declares them in 4.1.0:
+      # RBS's `core/hash.rbs` declares that parameter two ways, so both
+      # are recognized: `(_Key key)` from RBS 4.1.0 on (matched by the
+      # interface's literal name, so only RBS's own `Hash::_Key`), and
+      # `(K arg0)` before it, where `K` has already been resolved
+      # against the receiver - for a literal-keyed receiver that makes
+      # it the literal key type `key_tags` matches against.
       #
-      # - RBS >= 4.1.0 declares `def fetch: (_Key key) -> V` (also
-      #   `#[]`, `#dig`, `#delete`), so the parameter is typed exactly
-      #   `<namespace>::_Key`.
-      # - RBS < 4.1.0 declares `def fetch: (K arg0) -> V`, so the
-      #   parameter is typed as the class's own generic `K`, which by
-      #   this point has already been resolved against the receiver -
-      #   for a literal-keyed receiver that makes it the literal key
-      #   type itself, which is what `key_types` matches against.
-      #
-      # The `_Key` shape matches by the interface's literal name, so it
-      # only recognizes RBS's own `Hash::_Key` - a user-defined generic
-      # class using the same "marker interface for a lookup key"
-      # pattern under a different name/namespace won't be detected.
-      #
-      # TODO once castwide/solargraph#1266 (structurally verify RBS
-      # interface-typed expectations) lands - it lands with
-      # ApiMap#get_own_methods (a namespace's directly-declared
-      # methods, excluding inherited ones), extracted from
-      # Conformance#required_interface_methods for exactly this reuse.
-      # Replace the `_Key` name comparison below with a structural one:
-      # a parameter is key-shaped if its type is an interface whose own
-      # declared method names equal `Hash::_Key`'s (`hash`/`eql?`),
-      # regardless of the interface's actual name -
-      # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
-      #
-      #   key_interface_methods = api_map.get_own_methods("#{namespace}::_Key").map(&:name).to_set
-      #   index = parameters.find_index do |p|
-      #     type = p.typify(api_map)
-      #     next false unless type.interface?
-      #     api_map.get_own_methods(type.tag).map(&:name).to_set == key_interface_methods
-      #   end
-      #
-      # That only replaces the first branch - the `key_tags` fallback is
-      # still needed for RBS < 4.1, which has no interface there at all.
+      # @todo Match `_Key` structurally rather than by name once
+      #   castwide/solargraph#1266 lands with ApiMap#get_own_methods -
+      #   https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
       #
       # @param namespace [String]
       # @param api_map [ApiMap]
@@ -108,7 +81,7 @@ module Solargraph
       #   `key_types` tags, used to recognize the pre-4.1 `K`-typed
       #   shape. Empty disables that fallback.
       # @return [Integer, nil]
-      def key_param_index namespace, api_map, key_tags = []
+      def hash_key_param_index namespace, api_map, key_tags = []
         key_tag = "#{namespace}::_Key"
         index = parameters.find_index { |p| p.typify(api_map).tag == key_tag }
         return index unless index.nil?

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -852,15 +852,6 @@ module Solargraph
         )
       end
 
-      RBS_TO_YARD_TYPE = {
-        'bool' => 'Boolean',
-        'string' => 'String',
-        'int' => 'Integer',
-        'untyped' => '',
-        'NilClass' => 'nil'
-      }
-      private_constant :RBS_TO_YARD_TYPE
-
       # Extract a ComplexType from a MethodType's return type.
       #
       # This method will convert type aliases to concrete types.
@@ -877,13 +868,7 @@ module Solargraph
       # @param type_args [Enumerable<RBS::Types::Bases::Base>]
       # @return [ComplexType::UniqueType]
       def build_type(type_name, type_args = [])
-        base = RBS_TO_YARD_TYPE[type_name.relative!.to_s] || type_name.relative!.to_s
-        params = type_args.map { |arg| RbsTranslator.to_complex_type(arg).force_rooted }
-        if base == 'Hash' && params.length == 2
-          ComplexType::UniqueType.new(base, [params.first], [params.last], rooted: true, parameters_type: :hash)
-        else
-          ComplexType::UniqueType.new(base, [], params.reject(&:undefined?), rooted: true, parameters_type: :list)
-        end
+        RbsTranslator.build_unique_type(type_name, type_args)
       end
 
       # @param decl [RBS::AST::Declarations::Class, RBS::AST::Declarations::Module]

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -12,16 +12,30 @@ module Solargraph
       'NilClass' => 'nil'
     }
 
+    # From 4.1.0, RBS types Hash's own key lookups (`#[]`, `#fetch`,
+    # `#dig`, `#delete`) as the structural interface `Hash::_Key` -
+    # anything answering `hash`/`eql?` - rather than the class's own
+    # `K`, which is how it declared them before. Solargraph resolves
+    # interfaces by name rather than structurally, so the well-known
+    # name is stubbed to the type parameter it stands in for, the same
+    # way `bool`/`string`/`int` are stubbed above.
+    #
+    # This is a stand-in, not a translation: it reads as `K`, which is
+    # narrower than the `hash`/`eql?` that RBS actually accepts.
+    #
+    # @type [Hash{String => String}]
+    RBS_INTERFACE_TO_GENERIC = {
+      'Hash::_Key' => 'K'
+    }.freeze
+
     # Translates an RBS type into a ComplexType.
     #
     # Every RBS node that can *contain* another type - intersections,
     # unions, optionals, tuples, and generic type arguments - is built
     # directly as a ComplexType/UniqueType object graph by recursing
-    # through this method, rather than by rendering a tag string and
-    # re-parsing it. A joined string can't represent grouping that
-    # Solargraph's own tag grammar has no syntax for (e.g. a union
-    # nested inside an intersection, `(A | B) & C`), so round-tripping
-    # through one silently produces the wrong structure. Only leaf
+    # through this method, continuing the move away from tag strings
+    # begun in castwide/solargraph#870 so that `rooted?` is carried
+    # through unchanged rather than re-derived by a parse. Only leaf
     # types that can't contain a nested type (literals, `bool`, `nil`,
     # `void`, generic type variables, `self`/`instance`, `Proc`, etc.)
     # go through the tag-string fallback in type_to_tag.
@@ -130,14 +144,20 @@ module Solargraph
       Pin::Signature.new(generics: generics, parameters: parameters, return_type: return_type, block: block, source: :rbs, type_location: closure.location, closure: closure)
     end
 
+    # Builds a named type (with its generic arguments, if any) directly
+    # as an object rather than via a tag string, so `rooted?` survives -
+    # see castwide/solargraph#870.
+    #
     # @param type_name [RBS::TypeName]
     # @param type_args [Enumerable<RBS::Types::Bases::Base>]
     # @return [ComplexType::UniqueType]
     def self.build_unique_type(type_name, type_args = [])
-      base = RBS_TO_YARD_TYPE[type_name.relative!.to_s] || type_name.relative!.to_s
-      params = type_args.map do |a|
-        RbsTranslator.to_complex_type(a)
-      end
+      name = type_name.relative!.to_s
+      generic = RBS_INTERFACE_TO_GENERIC[name]
+      return ComplexType.parse("#{ComplexType::GENERIC_TAG_NAME}<#{generic}>").first if generic
+
+      base = RBS_TO_YARD_TYPE[name] || name
+      params = type_args.map { |arg| RbsTranslator.to_complex_type(arg).force_rooted }
       if base == 'Hash' && params.length == 2
         ComplexType::UniqueType.new(base, [params.first], [params.last], rooted: true, parameters_type: :hash)
       else

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -15,6 +15,7 @@ module Solargraph
     # @param type [RBS::Types::Bases::Base]
     # @return [ComplexType]
     def self.to_complex_type(type)
+      return intersection_complex_type(type) if type.is_a?(RBS::Types::Intersection)
       tag = type_to_tag(type)
       ComplexType.try_parse(tag).force_rooted
     end
@@ -122,6 +123,22 @@ module Solargraph
 
     class << self
       private
+
+      # Builds an Intersection directly from each member's own
+      # translated ComplexType, rather than flattening through
+      # type_to_tag's string-based join. RBS allows a union as one
+      # member of an intersection (e.g. `(A | B) & C`); going through
+      # a joined string would lose that structure (`type_to_tag`
+      # would render the union member as a plain comma list, which
+      # ComplexType.parse would then read back as a top-level union
+      # of the whole expression rather than a nested one).
+      #
+      # @param type [RBS::Types::Intersection]
+      # @return [ComplexType]
+      def intersection_complex_type type
+        conjuncts = type.types.map { |member| RbsTranslator.to_complex_type(member) }
+        ComplexType.new([ComplexType::UniqueType::Intersection.new(conjuncts)]).force_rooted
+      end
 
       # @param type [RBS::Types::Bases::Base]
       # @return [String]

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -152,7 +152,7 @@ module Solargraph
           # `Top` is the most super superclass
           'BasicObject'
         when RBS::Types::Intersection
-          type.types.map { |member| type_to_tag(member) }.join(', ')
+          type.types.map { |member| type_to_tag(member) }.join(' & ')
         when RBS::Types::Proc
           'Proc'
         when RBS::Types::ClassInstance, RBS::Types::Alias, RBS::Types::Interface

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -12,12 +12,47 @@ module Solargraph
       'NilClass' => 'nil'
     }
 
+    # Translates an RBS type into a ComplexType.
+    #
+    # Every RBS node that can *contain* another type - intersections,
+    # unions, optionals, tuples, and generic type arguments - is built
+    # directly as a ComplexType/UniqueType object graph by recursing
+    # through this method, rather than by rendering a tag string and
+    # re-parsing it. A joined string can't represent grouping that
+    # Solargraph's own tag grammar has no syntax for (e.g. a union
+    # nested inside an intersection, `(A | B) & C`), so round-tripping
+    # through one silently produces the wrong structure. Only leaf
+    # types that can't contain a nested type (literals, `bool`, `nil`,
+    # `void`, generic type variables, `self`/`instance`, `Proc`, etc.)
+    # go through the tag-string fallback in type_to_tag.
+    #
     # @param type [RBS::Types::Bases::Base]
     # @return [ComplexType]
     def self.to_complex_type(type)
-      return intersection_complex_type(type) if type.is_a?(RBS::Types::Intersection)
-      tag = type_to_tag(type)
-      ComplexType.try_parse(tag).force_rooted
+      case type
+      when RBS::Types::Intersection
+        intersection_complex_type(type)
+      when RBS::Types::Optional
+        optional_complex_type(type)
+      when RBS::Types::Union
+        union_complex_type(type)
+      when RBS::Types::Tuple
+        tuple_complex_type(type)
+      when RBS::Types::ClassInstance, RBS::Types::Alias, RBS::Types::Interface
+        # `Alias` is a top-level type alias, e.g., 'bool' in "type bool = true | false"
+        # @todo ensure these get resolved after processing all aliases
+        # @todo handle recursive aliases
+        #
+        # `Interface` represents a mix-in module which can be considered a
+        # subtype of a consumer of it
+        ComplexType.new([build_unique_type(type.name, type.args)]).force_rooted
+      when RBS::Types::ClassSingleton
+        # e.g., singleton(String)
+        ComplexType.new([build_unique_type(type.name)]).force_rooted
+      else
+        tag = type_to_tag(type)
+        ComplexType.try_parse(tag).force_rooted
+      end
     end
 
     # @param param_type [RBS::Types::Function::Param]
@@ -124,15 +159,6 @@ module Solargraph
     class << self
       private
 
-      # Builds an Intersection directly from each member's own
-      # translated ComplexType, rather than flattening through
-      # type_to_tag's string-based join. RBS allows a union as one
-      # member of an intersection (e.g. `(A | B) & C`); going through
-      # a joined string would lose that structure (`type_to_tag`
-      # would render the union member as a plain comma list, which
-      # ComplexType.parse would then read back as a top-level union
-      # of the whole expression rather than a nested one).
-      #
       # @param type [RBS::Types::Intersection]
       # @return [ComplexType]
       def intersection_complex_type type
@@ -140,20 +166,38 @@ module Solargraph
         ComplexType.new([ComplexType::UniqueType::Intersection.new(conjuncts)]).force_rooted
       end
 
+      # @param type [RBS::Types::Optional]
+      # @return [ComplexType]
+      def optional_complex_type type
+        inner = RbsTranslator.to_complex_type(type.type)
+        ComplexType.new(inner.items + [ComplexType::UniqueType::NIL]).force_rooted
+      end
+
+      # @param type [RBS::Types::Union]
+      # @return [ComplexType]
+      def union_complex_type type
+        ComplexType.new(type.types.flat_map { |t| RbsTranslator.to_complex_type(t).items }).force_rooted
+      end
+
+      # @param type [RBS::Types::Tuple]
+      # @return [ComplexType]
+      def tuple_complex_type type
+        subtypes = type.types.map { |t| RbsTranslator.to_complex_type(t) }
+        ComplexType.new([ComplexType::UniqueType.new('Array', [], subtypes, rooted: true, parameters_type: :fixed)]).force_rooted
+      end
+
+      # Renders a leaf RBS type (one that can't contain another type)
+      # as a tag string. Composite/recursive types are handled
+      # directly in to_complex_type instead - see its comment.
+      #
       # @param type [RBS::Types::Bases::Base]
       # @return [String]
       def type_to_tag type
         case type
-        when RBS::Types::Optional
-          "#{type_to_tag(type.type)}, nil"
         when RBS::Types::Bases::Bool
           'Boolean'
-        when RBS::Types::Tuple
-          "Array(#{type.types.map { |t| type_to_tag(t) }.join(', ')})"
         when RBS::Types::Literal
           type.literal.inspect
-        when RBS::Types::Union
-          type.types.map { |t| type_to_tag(t) }.join(', ')
         when RBS::Types::Record
           # @todo Better record support
           'Hash'
@@ -168,22 +212,8 @@ module Solargraph
         when RBS::Types::Bases::Top
           # `Top` is the most super superclass
           'BasicObject'
-        when RBS::Types::Intersection
-          type.types.map { |member| type_to_tag(member) }.join(' & ')
         when RBS::Types::Proc
           'Proc'
-        when RBS::Types::ClassInstance, RBS::Types::Alias, RBS::Types::Interface
-          # `Alias` is a top-level type alias, e.g., 'bool' in "type bool = true | false"
-          # @todo ensure these get resolved after processing all aliases
-          # @todo handle recursive aliases
-          #
-          # `Interface represents a mix-in module which can be considered a
-          # subtype of a consumer of it
-          #
-          type_tag(type.name, type.args)
-        when RBS::Types::ClassSingleton
-          # e.g., singleton(String)
-          type_tag(type.name)
         when RBS::Types::Bases::Any, RBS::Types::Bases::Bottom
           # `Bottom`` is used in contexts where nothing will ever return
           # - e.g., it could be the return type of 'exit()' or 'raise'
@@ -194,28 +224,6 @@ module Solargraph
         else
           Solargraph.logger.warn "Unrecognized RBS type: #{type.class} at #{type.location}"
           'undefined'
-        end
-      end
-
-      # @param type_name [RBS::TypeName]
-      # @param type_args [Enumerable<RBS::Types::Bases::Base>]
-      # @return [String]
-      def type_tag(type_name, type_args = [])
-        build_type(type_name, type_args).tags
-      end
-
-      # @param type_name [RBS::TypeName]
-      # @param type_args [Enumerable<RBS::Types::Bases::Base>]
-      # @return [ComplexType::UniqueType]
-      def build_type(type_name, type_args = [])
-        base = RBS_TO_YARD_TYPE[type_name.relative!.to_s] || type_name.relative!.to_s
-        params = type_args.map { |a| type_to_tag(a) }.map do |t|
-          ComplexType.try_parse(t)
-        end
-        if base == 'Hash' && params.length == 2
-          ComplexType::UniqueType.new(base, [params.first], [params.last], rooted: true, parameters_type: :hash)
-        else
-          ComplexType::UniqueType.new(base, [], params.reject(&:undefined?), rooted: true, parameters_type: :list)
         end
       end
     end

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -100,7 +100,7 @@ module Solargraph
         # @return [::Array<Pin::Base>, nil] nil when unresolved
         def method_stack_pins unique_type, api_map
           if unique_type.is_a?(ComplexType::UniqueType::Intersection)
-            resolved = unique_type.conjuncts.filter_map do |conjunct|
+            resolved = key_verified_conjuncts(unique_type.conjuncts, api_map).filter_map do |conjunct|
               pins = method_pins_for_binder(conjunct, api_map)
               pins.empty? ? nil : pins
             end
@@ -112,6 +112,99 @@ module Solargraph
             stack = api_map.get_method_stack(ns_tag, word, scope: unique_type.scope)
             return nil if stack.first.nil?
             [stack.first]
+          end
+        end
+
+        # Narrows a same-class-generic intersection's conjuncts to
+        # whichever ones we can positively verify match this call's own
+        # literal argument against a `_Key`-shaped parameter (e.g.
+        # `Hash#fetch: (Hash::_Key key) -> V`, `Hash#[]`), e.g. resolving
+        # `(Hash{"Index" => Float} & Hash{"Triggers" => Array<...>})#fetch("Index")`
+        # to just the "Index" conjunct instead of a union of both.
+        #
+        # RBS's own `_Key`-shaped signatures can't do this narrowing
+        # themselves - `_Key` is a structural hash/eql? interface, not
+        # literally `K`, so the key argument's type is never connected to
+        # the return type by ordinary overload resolution. This has to be
+        # done here, ahead of generic resolution, by matching the call's
+        # own literal argument directly against each conjunct's own
+        # `key_types` - which generalizes to any `_Key`-shaped method
+        # (`#fetch`, `#[]`, `#dig`, `#delete`, ...) without naming them.
+        #
+        # Conservative by construction: a conjunct is only ever narrowed
+        # away when *every* conjunct produced a positive verdict (matched
+        # or didn't). If we can't determine a verdict for even one
+        # conjunct - its method isn't `_Key`-shaped there, the argument
+        # isn't a literal, or it has no literal `key_types` to compare
+        # against - we don't have enough evidence to safely exclude
+        # anything, so every conjunct passes through unfiltered, same as
+        # before this method existed.
+        #
+        # @param conjuncts [::Array<ComplexType>]
+        # @param api_map [ApiMap]
+        # @return [::Array<ComplexType>]
+        def key_verified_conjuncts conjuncts, api_map
+          return conjuncts if arguments.empty?
+
+          verdicts = conjuncts.map { |c| conjunct_key_verdict(c, api_map) }
+          return conjuncts if verdicts.any?(&:nil?)
+
+          matching = conjuncts.zip(verdicts).select { |(_c, matched)| matched }.map(&:first)
+          matching.empty? ? conjuncts : matching
+        end
+
+        # Whether this conjunct's own literal `key_types` positively match
+        # the call's own literal argument at the `_Key`-typed parameter's
+        # position, or nil if that can't be determined (no `_Key`-shaped
+        # parameter here, non-literal argument, or no literal `key_types`
+        # to compare against).
+        #
+        # @param conjunct [ComplexType]
+        # @param api_map [ApiMap]
+        # @return [Boolean, nil]
+        def conjunct_key_verdict conjunct, api_map
+          verdicts = conjunct.items.map { |unique_type| unique_type_key_verdict(unique_type, api_map) }
+          return nil if verdicts.any?(&:nil?)
+
+          verdicts.all?
+        end
+
+        # @param unique_type [ComplexType::UniqueType]
+        # @param api_map [ApiMap]
+        # @return [Boolean, nil]
+        def unique_type_key_verdict unique_type, api_map
+          return nil unless unique_type.literal_keyed?
+
+          ns_tag = unique_type.namespace == '' ? '' : unique_type.namespace_type.tag
+          pin = api_map.get_method_stack(ns_tag, word, scope: unique_type.scope).first
+          return nil if pin.nil?
+
+          index = pin.signatures.filter_map { |s| s.key_param_index(unique_type.namespace, api_map) }.first
+          return nil if index.nil? || index >= arguments.length
+
+          key_tag = literal_node_tag(arguments[index]&.node)
+          return nil if key_tag.nil?
+
+          unique_type.key_type_tag?(key_tag)
+        end
+
+        # The literal tag (e.g. `"Index"`, `:index`, `1`) a `UniqueType`
+        # built from this argument node's literal value would have, or nil
+        # if the node isn't a literal Hash-key-shaped value.
+        #
+        # @param node [Parser::AST::Node, Object]
+        # @return [String, nil]
+        def literal_node_tag node
+          return nil unless Parser.is_ast_node?(node)
+
+          # @sg-ignore Translate to something flow sensitive typing understands
+          case node.type
+          # @sg-ignore Translate to something flow sensitive typing understands
+          when :str then node.children.first.inspect
+          # @sg-ignore Translate to something flow sensitive typing understands
+          when :sym then ":#{node.children.first}"
+          # @sg-ignore Translate to something flow sensitive typing understands
+          when :int then node.children.first.to_s
           end
         end
 

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -57,19 +57,55 @@ module Solargraph
 
           # @sg-ignore Need to handle duck-typed method calls on union types
           binder = binder.without_nil if nullable?
-          # @sg-ignore Need to handle duck-typed method calls on union types
-          pin_groups = binder.each_unique_type.map do |context|
-            ns_tag = context.namespace == '' ? '' : context.namespace_type.tag
-            stack = api_map.get_method_stack(ns_tag, word, scope: context.scope)
-            [stack.first].compact
-          end
-          pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:empty?)
-          pins = pin_groups.flatten.uniq(&:path)
+          pins = method_pins_for_binder(binder, api_map)
           return [] if pins.empty?
           inferred_pins(pins, api_map, name_pin, locals)
         end
 
         private
+
+        # Resolves the pins for calling `word` on every top-level
+        # alternative of a (possibly union) binder type. Each
+        # alternative must define the method unless
+        # api_map.loose_unions allows duck-typed leniency.
+        #
+        # @param binder_type [ComplexType, ComplexType::UniqueType]
+        # @param api_map [ApiMap]
+        # @return [::Array<Pin::Base>]
+        def method_pins_for_binder binder_type, api_map
+          top_level_types = binder_type.is_a?(ComplexType) ? binder_type.to_a : [binder_type]
+          pin_groups = top_level_types.map { |unique_type| method_stack_pins(unique_type, api_map) }
+          pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:nil?)
+          pin_groups.compact.flatten.uniq(&:path)
+        end
+
+        # Resolves the method stack's first pin for a single
+        # top-level unique type. An Intersection conjunct only needs
+        # *one* of its conjuncts to define the method (A & B <: A,
+        # A & B <: B) - the opposite of a union, where every
+        # alternative needs it - so it recurses through
+        # #method_pins_for_binder per conjunct (a conjunct is a full
+        # ComplexType, since RBS allows e.g. `(A | B) & C`) and
+        # accepts whichever conjuncts resolve.
+        #
+        # @param unique_type [ComplexType::UniqueType]
+        # @param api_map [ApiMap]
+        # @return [::Array<Pin::Base>, nil] nil when unresolved
+        def method_stack_pins unique_type, api_map
+          if unique_type.is_a?(ComplexType::UniqueType::Intersection)
+            resolved = unique_type.conjuncts.filter_map do |conjunct|
+              pins = method_pins_for_binder(conjunct, api_map)
+              pins.empty? ? nil : pins
+            end
+            return nil if resolved.empty?
+            resolved.flatten.uniq(&:path)
+          else
+            ns_tag = unique_type.namespace == '' ? '' : unique_type.namespace_type.tag
+            stack = api_map.get_method_stack(ns_tag, word, scope: unique_type.scope)
+            return nil if stack.first.nil?
+            [stack.first]
+          end
+        end
 
         # @param pins [::Enumerable<Pin::Base>]
         # @param api_map [ApiMap]

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -164,7 +164,7 @@ module Solargraph
           return nil if pin.nil?
 
           key_tags = unique_type.key_types.map(&:tag)
-          index = pin.signatures.filter_map { |s| s.hash_key_param_index(unique_type.namespace, api_map, key_tags) }.first
+          index = pin.signatures.filter_map { |s| s.hash_key_param_index(api_map, key_tags) }.first
           return nil if index.nil? || index >= arguments.length
 
           key_tag = literal_node_tag(arguments[index]&.node)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -76,7 +76,14 @@ module Solargraph
           top_level_types = binder_type.is_a?(ComplexType) ? binder_type.to_a : [binder_type]
           pin_groups = top_level_types.map { |unique_type| method_stack_pins(unique_type, api_map) }
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:nil?)
-          pin_groups.compact.flatten.uniq(&:path)
+          # Different alternatives can resolve to pins that share a
+          # path (e.g. the same generic method looked up against
+          # `Box<Integer>` and `Box<String>`) but that have already
+          # been resolved to different return types for their
+          # respective context - dedup on both so a real union
+          # doesn't silently lose every alternative but the first.
+          # @param p [Pin::Base]
+          pin_groups.compact.flatten.uniq { |p| [p.path, p.return_type.tag] }
         end
 
         # Resolves the method stack's first pin for a single
@@ -98,7 +105,8 @@ module Solargraph
               pins.empty? ? nil : pins
             end
             return nil if resolved.empty?
-            resolved.flatten.uniq(&:path)
+            # @param p [Pin::Base]
+            resolved.flatten.uniq { |p| [p.path, p.return_type.tag] }
           else
             ns_tag = unique_type.namespace == '' ? '' : unique_type.namespace_type.tag
             stack = api_map.get_method_stack(ns_tag, word, scope: unique_type.scope)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -116,9 +116,9 @@ module Solargraph
         # key parameter, so
         # `(Hash{"Index" => Float} & Hash{"Triggers" => Array<...>})#fetch("Index")`
         # resolves to the "Index" conjunct rather than a union of both.
-        # RBS can't do this itself - `Hash#fetch: (_Key key) -> V` types
-        # the key as a structural hash/eql? interface, not `K`, so
-        # overload resolution never connects it to the return type.
+        # Overload resolution can't do this on its own: it runs per
+        # conjunct, and both conjuncts produce a pin with the same path,
+        # so nothing downstream knows which one the argument selected.
         #
         # A conjunct is only narrowed away when *every* conjunct yields a
         # positive verdict (matched or didn't); if even one is

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -76,24 +76,20 @@ module Solargraph
           top_level_types = binder_type.is_a?(ComplexType) ? binder_type.to_a : [binder_type]
           pin_groups = top_level_types.map { |unique_type| method_stack_pins(unique_type, api_map) }
           pin_groups = [] if !api_map.loose_unions && pin_groups.any?(&:nil?)
-          # Different alternatives can resolve to pins that share a
-          # path (e.g. the same generic method looked up against
-          # `Box<Integer>` and `Box<String>`) but that have already
-          # been resolved to different return types for their
-          # respective context - dedup on both so a real union
-          # doesn't silently lose every alternative but the first.
+          # Alternatives can share a pin path (e.g. the same generic
+          # method against `Box<Integer>` and `Box<String>`) while
+          # already resolving to different return types, so dedup on
+          # both rather than losing every alternative but the first.
           # @param p [Pin::Base]
           pin_groups.compact.flatten.uniq { |p| [p.path, p.return_type.tag] }
         end
 
-        # Resolves the method stack's first pin for a single
-        # top-level unique type. An Intersection conjunct only needs
-        # *one* of its conjuncts to define the method (A & B <: A,
-        # A & B <: B) - the opposite of a union, where every
-        # alternative needs it - so it recurses through
-        # #method_pins_for_binder per conjunct (a conjunct is a full
-        # ComplexType, since RBS allows e.g. `(A | B) & C`) and
-        # accepts whichever conjuncts resolve.
+        # Resolves the method stack's first pin for a single top-level
+        # unique type. An Intersection needs only *one* of its conjuncts
+        # to define the method (A & B <: A, A & B <: B) - the opposite of
+        # a union - so it recurses per conjunct and accepts whichever
+        # ones resolve. A conjunct is a full ComplexType, since RBS
+        # allows e.g. `(A | B) & C`.
         #
         # @param unique_type [ComplexType::UniqueType]
         # @param api_map [ApiMap]
@@ -115,30 +111,18 @@ module Solargraph
           end
         end
 
-        # Narrows a same-class-generic intersection's conjuncts to
-        # whichever ones we can positively verify match this call's own
-        # literal argument against a `_Key`-shaped parameter (e.g.
-        # `Hash#fetch: (Hash::_Key key) -> V`, `Hash#[]`), e.g. resolving
+        # Narrows an intersection's conjuncts to the ones whose own
+        # `key_types` match this call's literal argument at a Hash-like
+        # key parameter, so
         # `(Hash{"Index" => Float} & Hash{"Triggers" => Array<...>})#fetch("Index")`
-        # to just the "Index" conjunct instead of a union of both.
+        # resolves to the "Index" conjunct rather than a union of both.
+        # RBS can't do this itself - `Hash#fetch: (_Key key) -> V` types
+        # the key as a structural hash/eql? interface, not `K`, so
+        # overload resolution never connects it to the return type.
         #
-        # RBS's own `_Key`-shaped signatures can't do this narrowing
-        # themselves - `_Key` is a structural hash/eql? interface, not
-        # literally `K`, so the key argument's type is never connected to
-        # the return type by ordinary overload resolution. This has to be
-        # done here, ahead of generic resolution, by matching the call's
-        # own literal argument directly against each conjunct's own
-        # `key_types` - which generalizes to any `_Key`-shaped method
-        # (`#fetch`, `#[]`, `#dig`, `#delete`, ...) without naming them.
-        #
-        # Conservative by construction: a conjunct is only ever narrowed
-        # away when *every* conjunct produced a positive verdict (matched
-        # or didn't). If we can't determine a verdict for even one
-        # conjunct - its method isn't `_Key`-shaped there, the argument
-        # isn't a literal, or it has no literal `key_types` to compare
-        # against - we don't have enough evidence to safely exclude
-        # anything, so every conjunct passes through unfiltered, same as
-        # before this method existed.
+        # A conjunct is only narrowed away when *every* conjunct yields a
+        # positive verdict (matched or didn't); if even one is
+        # undeterminable, every conjunct passes through unfiltered.
         #
         # @param conjuncts [::Array<ComplexType>]
         # @param api_map [ApiMap]
@@ -155,7 +139,7 @@ module Solargraph
 
         # Whether this conjunct's own literal `key_types` positively match
         # the call's own literal argument at the key parameter's position
-        # (see Pin::Signature#key_param_index), or nil if that can't be
+        # (see Pin::Signature#hash_key_param_index), or nil if that can't be
         # determined (no key-shaped parameter here, non-literal argument,
         # or no literal `key_types` to compare against).
         #
@@ -180,7 +164,7 @@ module Solargraph
           return nil if pin.nil?
 
           key_tags = unique_type.key_types.map(&:tag)
-          index = pin.signatures.filter_map { |s| s.key_param_index(unique_type.namespace, api_map, key_tags) }.first
+          index = pin.signatures.filter_map { |s| s.hash_key_param_index(unique_type.namespace, api_map, key_tags) }.first
           return nil if index.nil? || index >= arguments.length
 
           key_tag = literal_node_tag(arguments[index]&.node)

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -154,10 +154,10 @@ module Solargraph
         end
 
         # Whether this conjunct's own literal `key_types` positively match
-        # the call's own literal argument at the `_Key`-typed parameter's
-        # position, or nil if that can't be determined (no `_Key`-shaped
-        # parameter here, non-literal argument, or no literal `key_types`
-        # to compare against).
+        # the call's own literal argument at the key parameter's position
+        # (see Pin::Signature#key_param_index), or nil if that can't be
+        # determined (no key-shaped parameter here, non-literal argument,
+        # or no literal `key_types` to compare against).
         #
         # @param conjunct [ComplexType]
         # @param api_map [ApiMap]
@@ -179,7 +179,8 @@ module Solargraph
           pin = api_map.get_method_stack(ns_tag, word, scope: unique_type.scope).first
           return nil if pin.nil?
 
-          index = pin.signatures.filter_map { |s| s.key_param_index(unique_type.namespace, api_map) }.first
+          key_tags = unique_type.key_types.map(&:tag)
+          index = pin.signatures.filter_map { |s| s.key_param_index(unique_type.namespace, api_map, key_tags) }.first
           return nil if index.nil? || index >= arguments.length
 
           key_tag = literal_node_tag(arguments[index]&.node)

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -223,6 +223,12 @@ describe Solargraph::ApiMap do
     expect(pins.map(&:path)).to eq(['Bar#meth', 'Foo#meth', 'Mixin#meth'])
   end
 
+  it 'returns no methods for an unparseable tag instead of raising' do
+    pins = nil
+    expect { pins = @api_map.get_method_stack('Hash{"a" => Float}{"b" => Float}', 'keys') }.not_to raise_error
+    expect(pins).to eq([])
+  end
+
   it 'finds symbols' do
     map = Solargraph::SourceMap.load_string('sym = :sym')
     @api_map.index map.pins

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -315,6 +315,23 @@ describe Solargraph::ComplexType do
         exp = described_class.parse('Sub & Unrelated')
         expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
       end
+
+      it 'conforms to a union that offers the same intersection as one alternative' do
+        inf = described_class.parse('Sub & Unrelated')
+        exp = described_class.parse('Sub & Integer', 'Sub & Unrelated', 'nil')
+        expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+      end
+
+      it 'conforms to itself when it is a union of intersections' do
+        type = described_class.parse('Sub & Unrelated', 'Sub & Integer', 'nil')
+        expect(type.conforms_to?(api_map, type, :assignment)).to be(true)
+      end
+
+      it 'still rejects a union whose alternatives no conjunct combination covers' do
+        inf = described_class.parse('Sub & Unrelated')
+        exp = described_class.parse('Sub & Integer', 'Float')
+        expect(inf.conforms_to?(api_map, exp, :method_call)).to be(false)
+      end
     end
 
     it 'combines a class and a mix-in as conjuncts' do

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -240,7 +240,6 @@ describe Solargraph::ComplexType do
     end
   end
 
-  # https://github.com/castwide/solargraph/issues/1229
   context 'with intersection types' do
     let(:source) do
       Solargraph::Source.load_string(%(

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -283,6 +283,40 @@ describe Solargraph::ComplexType do
       expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
     end
 
+    context 'when both the inferred and expected types are intersections' do
+      # A & B <: C & D iff every conjunct of the expected side is
+      # satisfied by *some* conjunct of the inferred side - not "one
+      # single inferred conjunct satisfies the whole expected type."
+      # Checking a single already-chosen conjunct against the full
+      # expected intersection (rather than letting different inferred
+      # conjuncts cover different expected conjuncts) makes an
+      # intersection fail to conform to an identical copy of itself
+      # whenever its conjuncts don't already relate to each other.
+      it 'conforms to an identical intersection with unrelated conjuncts' do
+        inf = described_class.parse('Sub & Unrelated')
+        exp = described_class.parse('Sub & Unrelated')
+        expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+      end
+
+      it 'conforms to an identical intersection regardless of conjunct order' do
+        inf = described_class.parse('Sub & Unrelated')
+        exp = described_class.parse('Unrelated & Sub')
+        expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+      end
+
+      it 'still requires every expected conjunct to be covered by some inferred conjunct' do
+        inf = described_class.parse('Sub & Unrelated')
+        exp = described_class.parse('Sub & Integer')
+        expect(inf.conforms_to?(api_map, exp, :method_call)).to be(false)
+      end
+
+      it 'lets a wider inferred intersection satisfy a narrower expected one' do
+        inf = described_class.parse('Sub & Unrelated & Integer')
+        exp = described_class.parse('Sub & Unrelated')
+        expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+      end
+    end
+
     it 'combines a class and a mix-in as conjuncts' do
       inf = described_class.parse('String & Comparable')
       expect(inf.conforms_to?(api_map, described_class.parse('Comparable'), :method_call)).to be(true)

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -240,6 +240,51 @@ describe Solargraph::ComplexType do
     end
   end
 
+  # https://github.com/castwide/solargraph/issues/1229
+  context 'with intersection types' do
+    let(:source) do
+      Solargraph::Source.load_string(%(
+        class Sup; end
+        class Sub < Sup; end
+        class Unrelated; end
+      ))
+    end
+
+    before do
+      api_map.map source
+    end
+
+    it 'lets an intersection satisfy an expectation of any one conjunct (A & B <: A)' do
+      inf = described_class.parse('Sub & Unrelated')
+      exp = described_class.parse('Sub')
+      expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+    end
+
+    it 'lets an intersection satisfy an expectation of any one conjunct (A & B <: B)' do
+      inf = described_class.parse('Sub & Unrelated')
+      exp = described_class.parse('Unrelated')
+      expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+    end
+
+    it 'does not let an intersection satisfy an expectation none of its conjuncts meet' do
+      inf = described_class.parse('Sub & Unrelated')
+      exp = described_class.parse('Integer')
+      expect(inf.conforms_to?(api_map, exp, :method_call)).to be(false)
+    end
+
+    it 'requires every conjunct to be satisfied to conform to an intersection expectation' do
+      inf = described_class.parse('Sub')
+      exp = described_class.parse('Sup & Unrelated')
+      expect(inf.conforms_to?(api_map, exp, :method_call)).to be(false)
+    end
+
+    it 'conforms to an intersection expectation when every conjunct is satisfied' do
+      inf = described_class.parse('Sub')
+      exp = described_class.parse('Sup & Sub')
+      expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
+    end
+  end
+
   context 'with inheritance relationship in allow_reverse_match mode' do
     let(:api_map) { Solargraph::ApiMap.new }
     let(:sup) { described_class.parse('String') }

--- a/spec/complex_type/conforms_to_spec.rb
+++ b/spec/complex_type/conforms_to_spec.rb
@@ -283,6 +283,44 @@ describe Solargraph::ComplexType do
       exp = described_class.parse('Sup & Sub')
       expect(inf.conforms_to?(api_map, exp, :method_call)).to be(true)
     end
+
+    it 'combines a class and a mix-in as conjuncts' do
+      inf = described_class.parse('String & Comparable')
+      expect(inf.conforms_to?(api_map, described_class.parse('Comparable'), :method_call)).to be(true)
+      expect(inf.conforms_to?(api_map, described_class.parse('Enumerable'), :method_call)).to be(false)
+    end
+
+    it 'lets a value satisfy a class-and-mix-in intersection expectation' do
+      exp = described_class.parse('Comparable & String')
+      expect(described_class.parse('String').conforms_to?(api_map, exp, :method_call)).to be(true)
+      expect(described_class.parse('Integer').conforms_to?(api_map, exp, :method_call)).to be(false)
+    end
+
+    context 'with a duck-typed conjunct in the expectation' do
+      let(:source) do
+        Solargraph::Source.load_string(%(
+          class Sup; end
+          class Sub < Sup; end
+          class Unrelated; end
+
+          class Quacker
+            def to_str
+              ''
+            end
+          end
+        ))
+      end
+
+      it 'structurally verifies a duck-typed conjunct alongside a nominal one' do
+        exp = described_class.parse('Object & #to_str')
+        expect(described_class.parse('Quacker').conforms_to?(api_map, exp, :method_call)).to be(true)
+      end
+
+      it 'still requires the nominal conjunct even if the duck-typed one matches' do
+        exp = described_class.parse('Comparable & #to_str')
+        expect(described_class.parse('Quacker').conforms_to?(api_map, exp, :method_call)).to be(false)
+      end
+    end
   end
 
   context 'with inheritance relationship in allow_reverse_match mode' do

--- a/spec/complex_type/exclude_spec.rb
+++ b/spec/complex_type/exclude_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+# ComplexType#exclude already accepts an api_map parameter, but its
+# current implementation ignores it and does plain exact-match array
+# subtraction. This documents the api_map-aware behavior it would
+# ideally have (a third example of api-map-driven type simplification,
+# alongside narrow_with's subtype/mix-in reduction and qualify's name
+# resolution): excluding a type should also exclude any union member
+# already known to be one of its subtypes, since a value that fails
+# `is_a?(Sup)` can't be a `Sub` either.
+#
+# Not implemented - out of scope for the PR that added this file.
+# These specs exist so the gap is tracked rather than silently unknown.
+describe Solargraph::ComplexType do
+  let(:api_map) { Solargraph::ApiMap.new }
+
+  let(:source) do
+    Solargraph::Source.load_string(%(
+      class Sup; end
+      class Sub < Sup; end
+      class Unrelated; end
+    ))
+  end
+
+  before { api_map.map source }
+
+  it 'excludes known subtypes of an excluded type, not just exact matches' do
+    pending 'exclude ignores its api_map parameter and only removes exact matches'
+    type = described_class.parse('Sub, Sup, Unrelated')
+    result = type.exclude(described_class.parse('Sup'), api_map)
+    expect(result.tags).to eq('Unrelated')
+  end
+
+  it 'falls back to UNDEFINED when every member is excluded transitively' do
+    pending 'exclude ignores its api_map parameter and only removes exact matches'
+    type = described_class.parse('Sub, Sup')
+    result = type.exclude(described_class.parse('Sup'), api_map)
+    expect(result.undefined?).to be(true)
+  end
+end

--- a/spec/complex_type/narrow_with_spec.rb
+++ b/spec/complex_type/narrow_with_spec.rb
@@ -1,0 +1,57 @@
+# frozen_string_literal: true
+
+# ComplexType#narrow_with is flow-sensitive type narrowing (e.g.
+# refining a declared type using a type learned from an `is_a?`
+# guard) - see spec/parser/flow_sensitive_typing_spec.rb for
+# end-to-end coverage through real source. These specs exercise the
+# narrowing logic directly.
+describe Solargraph::ComplexType do
+  let(:api_map) { Solargraph::ApiMap.new }
+
+  context 'when narrowing a class with an unrelated mix-in' do
+    let(:source) do
+      Solargraph::Source.load_string(%(
+        module M; end
+        class T; end
+      ))
+    end
+
+    before { api_map.map source }
+
+    it 'builds an intersection rather than discarding both facts' do
+      declared = described_class.parse('T')
+      learned = described_class.parse('M')
+      narrowed = declared.narrow_with(learned, api_map)
+      expect(narrowed.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+      expect(narrowed.tag).to eq('T & M')
+    end
+
+    it 'lets the narrowed intersection satisfy either original fact' do
+      declared = described_class.parse('T')
+      learned = described_class.parse('M')
+      narrowed = declared.narrow_with(learned, api_map)
+      expect(narrowed.conforms_to?(api_map, described_class.parse('T'), :method_call)).to be(true)
+      expect(narrowed.conforms_to?(api_map, described_class.parse('M'), :method_call)).to be(true)
+    end
+  end
+
+  context 'when the mix-in is already known to be included' do
+    let(:source) do
+      Solargraph::Source.load_string(%(
+        module M; end
+        class T
+          include M
+        end
+      ))
+    end
+
+    before { api_map.map source }
+
+    it 'simplifies to the already-more-specific type instead of building a redundant intersection' do
+      declared = described_class.parse('T')
+      learned = described_class.parse('M')
+      narrowed = declared.narrow_with(learned, api_map)
+      expect(narrowed.tag).to eq('T')
+    end
+  end
+end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -341,6 +341,36 @@ describe 'YARD type specifier list parsing' do
     xit 'understands reference tags'
   end
 
+  # https://github.com/ruby/rbs/blob/master/docs/syntax.md#intersection-type
+  context 'when parsing RBS intersection types' do
+    it 'parses two conjuncts as a single unique type' do
+      types = Solargraph::ComplexType.parse('String & Comparable')
+      expect(types.length).to eq(1)
+      expect(types.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+      expect(types.first.tag).to eq('String & Comparable')
+      expect(types.to_rbs).to eq('String & Comparable')
+    end
+
+    it 'parses more than two conjuncts' do
+      types = Solargraph::ComplexType.parse('String & Comparable & Enumerable')
+      expect(types.length).to eq(1)
+      expect(types.first.conjuncts.map(&:tag)).to eq(%w[String Comparable Enumerable])
+    end
+
+    it 'distinguishes intersections from unions in the same list' do
+      types = Solargraph::ComplexType.parse('String & Comparable, Integer')
+      expect(types.length).to eq(2)
+      expect(types[0].tag).to eq('String & Comparable')
+      expect(types[1].tag).to eq('Integer')
+    end
+
+    it 'parses intersections nested in subtypes' do
+      types = Solargraph::ComplexType.parse('Array<String & Comparable>')
+      expect(types.first.tag).to eq('Array<String & Comparable>')
+      expect(types.to_rbs).to eq('Array[String & Comparable]')
+    end
+  end
+
   context 'when given non-sensical types by machine users' do
     it 'raises ComplexTypeError for unmatched brackets' do
       expect do

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -802,7 +802,11 @@ describe 'YARD type specifier list parsing' do
         ['generic<A>', 'Array<String>', { 'A' => 'String' }, 'String', { 'A' => 'String' }],
         ['generic<A>', 'Array<generic<B>>', { 'B' => 'Integer' }, 'Array<Integer>',
          { 'B' => 'Integer', 'A' => 'Array<Integer>' }],
-        ['Array<generic<A>>', 'Array<String>', {}, 'Array<String>', { 'A' => 'String' }]
+        ['Array<generic<A>>', 'Array<String>', {}, 'Array<String>', { 'A' => 'String' }],
+        ['Class<generic<A>> & #new', 'Class<String>', {}, 'Class<String> & #new', { 'A' => 'String' }],
+        ['#each & Array<generic<A>>', 'Array<String>', {}, '#each & Array<String>', { 'A' => 'String' }],
+        ['Class<generic<A>> & #new', 'Class<String>', { 'A' => 'Integer' }, 'Class<Integer> & #new',
+         { 'A' => 'Integer' }]
       ].freeze
 
       UNIQUE_METHOD_GENERIC_TESTS.each do |tag, context_type_tag, unfrozen_input_map, expected_tag, expected_output_map|

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -420,23 +420,127 @@ describe 'YARD type specifier list parsing' do
         expect(intersection.conjuncts.map(&:tags)).to eq(['Array(A, B)', 'C'])
       end
 
-      it 'has no standalone grouping syntax, so a bare union in parens reads as an anonymous tuple' do
-        # Unlike `Array(A, B)`, a bare `(A, B)` isn't preceded by a
-        # type name - Solargraph's tag grammar interprets it as an
-        # anonymous tuple (the same way `(A, B)` reads standalone
-        # elsewhere), not as "the union of A and B, grouped". There is
-        # currently no way to write a grouped union as a YARD/RBS tag
-        # *string* - `(A | B) & C` can only be built by translating
-        # real RBS (see RbsTranslator specs) or constructing
-        # ComplexType::UniqueType::Intersection directly.
+      it 'reads a bare comma-separated parenthesized group as an anonymous fixed tuple, not a grouped union' do
+        # `(A, B)` (parentheses, not brackets) is the anonymous form of
+        # the fixed-tuple-parameter syntax (see "anonymous shorthand"
+        # specs below) - its name defaults to Array, and its comma
+        # keeps positional/fixed-arity meaning rather than becoming a
+        # grouped union. `[...]` (below) is the actual grouping
+        # syntax; `(...)` never is, with or without a leading name.
         types = Solargraph::ComplexType.parse('(A, B) & C')
         expect(types.length).to eq(1)
         intersection = types.first
         expect(intersection.conjuncts.length).to eq(2)
         tuple_conjunct = intersection.conjuncts.first.first
-        expect(tuple_conjunct.name).to eq('')
+        expect(tuple_conjunct.name).to eq('Array')
         expect(tuple_conjunct.fixed_parameters?).to be(true)
         expect(tuple_conjunct.subtypes.map(&:tags)).to eq(%w[A B])
+      end
+    end
+
+    # https://github.com/lsegal/yard/pull/1700
+    context 'with the | union operator' do
+      it 'parses a top-level union the same as a comma-separated one' do
+        types = Solargraph::ComplexType.parse('String | Integer')
+        expect(types.length).to eq(2)
+        expect(types.tags).to eq('String, Integer')
+      end
+
+      it 'binds looser than &' do
+        types = Solargraph::ComplexType.parse('A & B | C')
+        expect(types.length).to eq(2)
+        expect(types[0].tag).to eq('A & B')
+        expect(types[1].tag).to eq('C')
+      end
+
+      it 'binds looser than & on either side' do
+        types = Solargraph::ComplexType.parse('A | B & C')
+        expect(types.length).to eq(2)
+        expect(types[0].tag).to eq('A')
+        expect(types[1].tag).to eq('B & C')
+      end
+
+      it 'groups multiple types into a single positional slot of a fixed tuple' do
+        ut = Solargraph::ComplexType.parse('Array(Foo | Bar, Baz)').first
+        expect(ut.fixed_parameters?).to be(true)
+        expect(ut.subtypes.length).to eq(2)
+        expect(ut.subtypes[0].tags).to eq('Foo, Bar')
+        expect(ut.to_rbs).to eq('[(Foo | Bar), Baz]')
+        expect(ut.subtypes[1].tags).to eq('Baz')
+      end
+
+      it 'groups multiple types into a single positional slot of a generic type parameter list' do
+        ut = Solargraph::ComplexType.parse('Result<Success | Failure, Other>').first
+        expect(ut.subtypes.length).to eq(2)
+        expect(ut.subtypes[0].tags).to eq('Success, Failure')
+        expect(ut.to_rbs).to eq('Result[(Success | Failure), Other]')
+      end
+
+      it 'lands on the same result as a comma inside an implicit-union context (Array<...>)' do
+        # Both mean "an Array of Foo-or-Bar". They differ in how many
+        # subtype slots hold the union (one 2-item slot for `|`, two
+        # 1-item slots for `,`) - implicit_union? treats both the same
+        # way, so #tags (which doesn't group-render a slot) matches;
+        # #to_rbs parenthesizes a multi-item slot wherever it appears,
+        # so it doesn't happen to here, same as any other multi-item
+        # subtype slot (see the fixed-tuple specs above).
+        piped = Solargraph::ComplexType.parse('Array<Foo | Bar>').first
+        commaed = Solargraph::ComplexType.parse('Array<Foo, Bar>').first
+        expect(piped.tag).to eq(commaed.tag)
+      end
+    end
+
+    # https://github.com/lsegal/yard/pull/1700
+    context 'with [...] grouping brackets' do
+      it 'groups a union so it can be one conjunct of an intersection' do
+        types = Solargraph::ComplexType.parse('[Foo | Bar] & Baz')
+        expect(types.length).to eq(1)
+        intersection = types.first
+        expect(intersection).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+        expect(intersection.conjuncts.map(&:tags)).to eq(['Foo, Bar', 'Baz'])
+        expect(intersection.to_rbs).to eq('(Foo | Bar) & Baz')
+      end
+
+      it 'groups a union as the second conjunct of an intersection' do
+        types = Solargraph::ComplexType.parse('Foo & [Bar | Baz]')
+        intersection = types.first
+        expect(intersection.conjuncts.map(&:tags)).to eq(['Foo', 'Bar, Baz'])
+        expect(intersection.to_rbs).to eq('Foo & (Bar | Baz)')
+      end
+
+      it 'raises on an unclosed bracket' do
+        expect { Solargraph::ComplexType.parse('[Foo | Bar & Baz') }.to raise_error(Solargraph::ComplexTypeError)
+      end
+    end
+
+    # https://github.com/lsegal/yard/pull/1700
+    context 'with anonymous shorthand forms' do
+      it 'defaults <A> to Array<A>' do
+        ut = Solargraph::ComplexType.parse('<String>').first
+        expect(ut.name).to eq('Array')
+        expect(ut.list_parameters?).to be(true)
+        expect(ut.tag).to eq('Array<String>')
+      end
+
+      it 'defaults (A) to Array(A)' do
+        ut = Solargraph::ComplexType.parse('(String)').first
+        expect(ut.name).to eq('Array')
+        expect(ut.fixed_parameters?).to be(true)
+        expect(ut.tag).to eq('Array(String)')
+      end
+
+      it 'defaults {A=>B} to Hash{A=>B}' do
+        ut = Solargraph::ComplexType.parse('{String=>Integer}').first
+        expect(ut.name).to eq('Hash')
+        expect(ut.hash_parameters?).to be(true)
+        expect(ut.tag).to eq('Hash{String => Integer}')
+        expect(ut.to_rbs).to eq('Hash[String, Integer]')
+      end
+
+      it 'roots an anonymous shorthand the same way its named equivalent would be' do
+        anonymous = Solargraph::ComplexType.parse('<String>').first
+        named = Solargraph::ComplexType.parse('Array<String>').first
+        expect(anonymous.rooted?).to eq(named.rooted?)
       end
     end
   end
@@ -828,7 +932,10 @@ describe 'YARD type specifier list parsing' do
     it 'resolves self keywords in ordered array types' do
       selfy = Solargraph::ComplexType.parse('Array<(String, Symbol, self)>')
       type = selfy.self_to_type(Solargraph::ComplexType.parse('Foo'))
-      expect(type.tag).to eq('Array<(String, Symbol, Foo)>')
+      # the anonymous `(...)` tuple defaults its name to Array (see
+      # "anonymous shorthand" specs below), so it renders with that
+      # name now instead of bare parentheses
+      expect(type.tag).to eq('Array<Array(String, Symbol, Foo)>')
       expect(type.to_rbs).to eq('Array[[String, Symbol, Foo]]')
     end
 

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -285,6 +285,27 @@ describe 'YARD type specifier list parsing' do
       expect(type.to_s).to eq('String')
     end
 
+    # A string literal is opaque: the characters that separate or
+    # group types everywhere else are just content inside one.
+    ['"a,b"', '"a|b"', '"a&b"', '"a<b>"', '"[]"', "'a,b'"].each do |tag|
+      it "treats #{tag} as one literal, not a separator" do
+        type = Solargraph::ComplexType.parse(tag)
+        expect(type.length).to eq(1)
+        expect(type.tag).to eq(tag)
+        expect(type.first.name).to eq(tag)
+      end
+    end
+
+    it 'keeps a string literal whole inside a hash key' do
+      type = Solargraph::ComplexType.parse('Hash{"a,b" => Float}')
+      expect(type.tag).to eq('Hash{"a,b" => Float}')
+      expect(type.to_rbs).to eq('Hash["a,b", Float]')
+    end
+
+    it 'raises on an unclosed string literal' do
+      expect { Solargraph::ComplexType.parse('"abc') }.to raise_error(Solargraph::ComplexTypeError)
+    end
+
     it 'understands literal symbols' do
       type = Solargraph::ComplexType.parse(':foo')
       expect(type.tag).to eq(':foo')
@@ -510,6 +531,35 @@ describe 'YARD type specifier list parsing' do
 
       it 'raises on an unclosed bracket' do
         expect { Solargraph::ComplexType.parse('[Foo | Bar & Baz') }.to raise_error(Solargraph::ComplexTypeError)
+      end
+
+      # `&` binds tighter than the `,`/`|` of a union, so a grouped
+      # conjunct has to keep its brackets when rendered back to a tag -
+      # otherwise `[Foo | Bar] & Baz` renders as `Foo, Bar & Baz` and
+      # parses back as `Foo | (Bar & Baz)`.
+      [
+        '[Foo | Bar] & Baz',
+        'Foo & [Bar | Baz]',
+        'Hash{[Foo | Bar] & Baz => Qux}',
+        '[Foo | Bar] & [Baz | Qux]'
+      ].each do |tag|
+        it "round-trips #{tag} through its tag" do
+          original = Solargraph::ComplexType.parse(tag)
+          reparsed = Solargraph::ComplexType.parse(original.tag)
+          expect(reparsed.tag).to eq(original.tag)
+          expect(reparsed.to_rbs).to eq(original.to_rbs)
+        end
+      end
+
+      it 'brackets a grouped conjunct when generating a tag' do
+        types = Solargraph::ComplexType.parse('[Foo | Bar] & Baz')
+        expect(types.tag).to eq('[Foo, Bar] & Baz')
+        expect(types.to_rbs).to eq('(Foo | Bar) & Baz')
+      end
+
+      it 'leaves a single-type conjunct unbracketed' do
+        types = Solargraph::ComplexType.parse('Foo & Baz')
+        expect(types.tag).to eq('Foo & Baz')
       end
     end
 

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -933,8 +933,7 @@ describe 'YARD type specifier list parsing' do
       selfy = Solargraph::ComplexType.parse('Array<(String, Symbol, self)>')
       type = selfy.self_to_type(Solargraph::ComplexType.parse('Foo'))
       # the anonymous `(...)` tuple defaults its name to Array (see
-      # "anonymous shorthand" specs below), so it renders with that
-      # name now instead of bare parentheses
+      # "anonymous shorthand" specs below)
       expect(type.tag).to eq('Array<Array(String, Symbol, Foo)>')
       expect(type.to_rbs).to eq('Array[[String, Symbol, Foo]]')
     end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -369,6 +369,76 @@ describe 'YARD type specifier list parsing' do
       expect(types.first.tag).to eq('Array<String & Comparable>')
       expect(types.to_rbs).to eq('Array[String & Comparable]')
     end
+
+    # `&` binds tighter than the top-level `,` (union), matching RBS's
+    # documented precedence: "A & B | C is (A & B) | C". Our
+    # single-pass parser doesn't implement precedence via grouping -
+    # it greedily gathers `&`-separated conjuncts until the next `,`
+    # or end of string - but that happens to produce the same result
+    # as real operator precedence for every case reachable through
+    # this tag-string grammar, since there is no way to write a
+    # standalone grouped union in it (see below).
+    context 'with & and , precedence' do
+      it 'binds & tighter than , when & comes first' do
+        types = Solargraph::ComplexType.parse('A & B, C')
+        expect(types.length).to eq(2)
+        expect(types[0].tag).to eq('A & B')
+        expect(types[1].tag).to eq('C')
+      end
+
+      it 'binds & tighter than , when , comes first' do
+        types = Solargraph::ComplexType.parse('A, B & C')
+        expect(types.length).to eq(2)
+        expect(types[0].tag).to eq('A')
+        expect(types[1].tag).to eq('B & C')
+      end
+
+      it 'handles multiple intersections in the same union' do
+        types = Solargraph::ComplexType.parse('A & B, C & D')
+        expect(types.length).to eq(2)
+        expect(types[0].tag).to eq('A & B')
+        expect(types[1].tag).to eq('C & D')
+      end
+
+      it 'handles intersections of different sizes in the same union' do
+        types = Solargraph::ComplexType.parse('A & B & C, D & E')
+        expect(types.length).to eq(2)
+        expect(types[0].conjuncts.map(&:tags)).to eq(%w[A B C])
+        expect(types[1].conjuncts.map(&:tags)).to eq(%w[D E])
+      end
+    end
+
+    context 'with parentheses' do
+      it 'does not confuse a fixed-tuple-parameter name with a grouped union' do
+        # `Array(A, B)` is Solargraph's existing fixed-tuple-parameter
+        # syntax (a tuple `[A, B]`), unrelated to grouping. `&` after
+        # it still means "intersected with", not "and one more tuple
+        # element".
+        types = Solargraph::ComplexType.parse('Array(A, B) & C')
+        expect(types.length).to eq(1)
+        intersection = types.first
+        expect(intersection.conjuncts.map(&:tags)).to eq(['Array(A, B)', 'C'])
+      end
+
+      it 'has no standalone grouping syntax, so a bare union in parens reads as an anonymous tuple' do
+        # Unlike `Array(A, B)`, a bare `(A, B)` isn't preceded by a
+        # type name - Solargraph's tag grammar interprets it as an
+        # anonymous tuple (the same way `(A, B)` reads standalone
+        # elsewhere), not as "the union of A and B, grouped". There is
+        # currently no way to write a grouped union as a YARD/RBS tag
+        # *string* - `(A | B) & C` can only be built by translating
+        # real RBS (see RbsTranslator specs) or constructing
+        # ComplexType::UniqueType::Intersection directly.
+        types = Solargraph::ComplexType.parse('(A, B) & C')
+        expect(types.length).to eq(1)
+        intersection = types.first
+        expect(intersection.conjuncts.length).to eq(2)
+        tuple_conjunct = intersection.conjuncts.first.first
+        expect(tuple_conjunct.name).to eq('')
+        expect(tuple_conjunct.fixed_parameters?).to be(true)
+        expect(tuple_conjunct.subtypes.map(&:tags)).to eq(%w[A B])
+      end
+    end
   end
 
   context 'when given non-sensical types by machine users' do

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -441,6 +441,45 @@ describe 'YARD type specifier list parsing' do
     end
   end
 
+  # Redundant-member simplification for plain unions, based on a
+  # specific api_map's class hierarchy - a second example of
+  # api-map-driven type simplification, alongside narrow_with's
+  # subtype/mix-in reduction and (differently) qualify's name
+  # resolution. `Superclass, Subclass` is logically the same set as
+  # `Superclass` alone, since every Subclass instance already is a
+  # Superclass instance - but ComplexType.parse has no api_map to
+  # check that with, and no such simplification happens anywhere else
+  # either (verified: nothing in the codebase does this today).
+  #
+  # Not implemented - out of scope for the PR that added this file.
+  # `simplify_redundant_members` below is a proposed/illustrative
+  # interface, not a settled design; these specs exist so the gap is
+  # tracked rather than silently unknown.
+  context 'when simplifying unions of a known superclass and subclass' do
+    let(:api_map) { Solargraph::ApiMap.new }
+
+    let(:source) do
+      Solargraph::Source.load_string(%(
+        class Sup; end
+        class Sub < Sup; end
+      ))
+    end
+
+    before { api_map.map source }
+
+    it 'drops a redundant subclass when the superclass is already listed' do
+      pending 'no api_map-aware union simplification exists yet'
+      type = described_class.parse('Sup, Sub')
+      expect(type.simplify_redundant_members(api_map).tags).to eq('Sup')
+    end
+
+    it 'drops the redundant subclass regardless of listed order' do
+      pending 'no api_map-aware union simplification exists yet'
+      type = described_class.parse('Sub, Sup')
+      expect(type.simplify_redundant_members(api_map).tags).to eq('Sup')
+    end
+  end
+
   context 'when given non-sensical types by machine users' do
     it 'raises ComplexTypeError for unmatched brackets' do
       expect do

--- a/spec/convention/activesupport_concern_spec.rb
+++ b/spec/convention/activesupport_concern_spec.rb
@@ -187,17 +187,13 @@ describe Solargraph::Convention::ActiveSupportConcern do
       end
 
       it 'finds superclass method pin parameter type' do
-        # RBS core's Hash#[] started taking its key as the _Key duck-type
-        # interface instead of the generic K as of RBS 4.1.0, so instantiating
-        # Hash{Symbol => untyped} no longer substitutes the param type on
-        # newer RBS - see ruby/rbs core/hash.rbs.
-        expected = if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
-                     ['::Hash::_Key']
-                   else
-                     ['Symbol']
-                   end
+        # RBS core's Hash#[] takes its key as the _Key duck-type interface
+        # rather than the generic K as of RBS 4.1.0. RbsTranslator stubs
+        # that back to K (see RBS_INTERFACE_TO_GENERIC), so instantiating
+        # Hash{Symbol => untyped} substitutes the param type on every RBS
+        # version rather than leaving the interface unresolved.
         expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
-                 .uniq).to eq(expected)
+                 .uniq).to eq(['Symbol'])
       end
     end
   end

--- a/spec/parser/flow_sensitive_typing_spec.rb
+++ b/spec/parser/flow_sensitive_typing_spec.rb
@@ -24,6 +24,50 @@ describe Solargraph::Parser::FlowSensitiveTyping do
     expect(clip.infer.to_s).to eq('ReproBase')
   end
 
+  it 'narrows to an intersection when is_a? checks an unrelated mix-in' do
+    source = Solargraph::Source.load_string(%(
+      module M; end
+      class T; end
+      # @param t [T]
+      def verify(t)
+        if t.is_a?(M)
+          t
+        else
+          t
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [6, 10])
+    expect(clip.infer.to_s).to eq('T & M')
+
+    clip = api_map.clip_at('test.rb', [8, 10])
+    expect(clip.infer.to_s).to eq('T')
+  end
+
+  it 'does not build a redundant intersection when the mix-in is already included' do
+    source = Solargraph::Source.load_string(%(
+      module M; end
+      class T
+        include M
+      end
+      # @param t [T]
+      def verify(t)
+        if t.is_a?(M)
+          t
+        else
+          t
+        end
+      end
+  ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [7, 10])
+    expect(clip.infer.to_s).to eq('T')
+
+    clip = api_map.clip_at('test.rb', [9, 10])
+    expect(clip.infer.to_s).to eq('T')
+  end
+
   it 'uses is_a? in a simple if() with a union to refine types' do
     source = Solargraph::Source.load_string(%(
       class ReproBase; end

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -635,6 +635,19 @@ describe Solargraph::Pin::Method do
       expect(pin.return_type.to_s).to eq('Boolean')
     end
 
+    it 'sets intersection return types' do
+      # https://github.com/castwide/solargraph/issues/1229
+      source = Solargraph::Source.load_string(%(
+        #: () -> (String & Comparable)
+        def foo; end
+      ))
+      api_map = Solargraph::ApiMap.new
+      api_map.map source
+      pin = api_map.get_path_pins('#foo').first
+      expect(pin.return_type.to_s).to eq('String & Comparable')
+      expect(pin.return_type.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+    end
+
     it 'sets required positional parameters' do
       source = Solargraph::Source.load_string(%(
         #: (String) -> bool

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -694,15 +694,7 @@ describe Solargraph::Pin::Method do
         expect(intersection.to_rbs).to eq('::String & ::Comparable & ::Enumerable')
       end
 
-      it 'is not round-trippable through the tag string, unlike to_rbs' do
-        # The object model built directly by RbsTranslator is
-        # correct (verified above), but there is no way to express a
-        # grouped union as a plain tag *string* (see
-        # complex_type_spec.rb). Re-parsing the informal `tag`/`to_s`
-        # output therefore does not reproduce the same structure -
-        # this is a known, documented limitation, not a silent
-        # inconsistency. `to_rbs` uses real RBS grouping syntax and
-        # does round-trip correctly.
+      it 'round-trips through both the tag string and to_rbs' do
         source = Solargraph::Source.load_string(%(
           #: () -> ((String | Integer) & Comparable)
           def foo; end
@@ -711,17 +703,20 @@ describe Solargraph::Pin::Method do
         api_map.map source
         pin = api_map.get_path_pins('#foo').first
         original = pin.return_type
-        expect(original.tag).to eq('String, Integer & Comparable')
 
+        # `&` binds tighter than a union's `,`, so the grouped conjunct
+        # keeps its brackets and re-parses to the same structure.
+        expect(original.tag).to eq('[String, Integer] & Comparable')
         reparsed = Solargraph::ComplexType.parse(original.tag)
-        expect(reparsed.length).to eq(2)
-        expect(reparsed[0].tag).to eq('String')
-        expect(reparsed[1].tag).to eq('Integer & Comparable')
+        expect(reparsed.length).to eq(1)
+        expect(reparsed.first.conjuncts.map(&:tags)).to eq(['String, Integer', 'Comparable'])
 
-        # to_rbs, by contrast, produces real RBS syntax and round-trips
-        # correctly through RBS's own parser (not Solargraph's tag parser,
-        # which speaks a different dialect and doesn't understand `|` or
-        # bare grouping parens).
+        # rooted_tag keeps the `::` prefixes that tag drops, so it is
+        # the form that round-trips to an identical RBS rendering.
+        expect(Solargraph::ComplexType.parse(original.rooted_tag).to_rbs).to eq(original.to_rbs)
+
+        # to_rbs uses RBS's own grouping syntax and round-trips through
+        # RBS's parser rather than Solargraph's tag parser.
         rbs_type = RBS::Parser.parse_type(original.to_rbs)
         reparsed_via_rbs = Solargraph::RbsTranslator.to_complex_type(rbs_type)
         expect(reparsed_via_rbs.length).to eq(1)

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -636,7 +636,6 @@ describe Solargraph::Pin::Method do
     end
 
     it 'sets intersection return types' do
-      # https://github.com/castwide/solargraph/issues/1229
       source = Solargraph::Source.load_string(%(
         #: () -> (String & Comparable)
         def foo; end
@@ -646,6 +645,88 @@ describe Solargraph::Pin::Method do
       pin = api_map.get_path_pins('#foo').first
       expect(pin.return_type.to_s).to eq('String & Comparable')
       expect(pin.return_type.first).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+    end
+
+    # RBS allows a union as one member of an intersection - `&` and
+    # `|` nest freely in either direction, unlike the YARD/tag-string
+    # grammar (see complex_type_spec.rb "with parentheses"), so these
+    # go through RbsTranslator directly instead of round-tripping
+    # through a tag string.
+    context 'with a union nested inside an intersection' do
+      it 'preserves a union as the first conjunct' do
+        source = Solargraph::Source.load_string(%(
+          #: () -> ((String | Integer) & Comparable)
+          def foo; end
+        ))
+        api_map = Solargraph::ApiMap.new
+        api_map.map source
+        pin = api_map.get_path_pins('#foo').first
+        intersection = pin.return_type.first
+        expect(intersection).to be_a(Solargraph::ComplexType::UniqueType::Intersection)
+        expect(intersection.conjuncts.length).to eq(2)
+        expect(intersection.conjuncts.first.length).to eq(2)
+        expect(intersection.conjuncts.first.tags).to eq('String, Integer')
+        expect(intersection.to_rbs).to eq('(::String | ::Integer) & ::Comparable')
+      end
+
+      it 'preserves a union as the second conjunct' do
+        source = Solargraph::Source.load_string(%(
+          #: () -> (Comparable & (String | Integer))
+          def foo; end
+        ))
+        api_map = Solargraph::ApiMap.new
+        api_map.map source
+        pin = api_map.get_path_pins('#foo').first
+        intersection = pin.return_type.first
+        expect(intersection.conjuncts.last.length).to eq(2)
+        expect(intersection.to_rbs).to eq('::Comparable & (::String | ::Integer)')
+      end
+
+      it 'flattens a nested intersection into the same conjunct list' do
+        source = Solargraph::Source.load_string(%(
+          #: () -> (String & (Comparable & Enumerable))
+          def foo; end
+        ))
+        api_map = Solargraph::ApiMap.new
+        api_map.map source
+        pin = api_map.get_path_pins('#foo').first
+        intersection = pin.return_type.first
+        expect(intersection.to_rbs).to eq('::String & ::Comparable & ::Enumerable')
+      end
+
+      it 'is not round-trippable through the tag string, unlike to_rbs' do
+        # The object model built directly by RbsTranslator is
+        # correct (verified above), but there is no way to express a
+        # grouped union as a plain tag *string* (see
+        # complex_type_spec.rb). Re-parsing the informal `tag`/`to_s`
+        # output therefore does not reproduce the same structure -
+        # this is a known, documented limitation, not a silent
+        # inconsistency. `to_rbs` uses real RBS grouping syntax and
+        # does round-trip correctly.
+        source = Solargraph::Source.load_string(%(
+          #: () -> ((String | Integer) & Comparable)
+          def foo; end
+        ))
+        api_map = Solargraph::ApiMap.new
+        api_map.map source
+        pin = api_map.get_path_pins('#foo').first
+        original = pin.return_type
+        expect(original.tag).to eq('String, Integer & Comparable')
+
+        reparsed = Solargraph::ComplexType.parse(original.tag)
+        expect(reparsed.length).to eq(2)
+        expect(reparsed[0].tag).to eq('String')
+        expect(reparsed[1].tag).to eq('Integer & Comparable')
+
+        # to_rbs, by contrast, produces real RBS syntax and round-trips
+        # correctly through RBS's own parser (not Solargraph's tag parser,
+        # which speaks a different dialect and doesn't understand `|` or
+        # bare grouping parens).
+        rbs_type = RBS::Parser.parse_type(original.to_rbs)
+        reparsed_via_rbs = Solargraph::RbsTranslator.to_complex_type(rbs_type)
+        expect(reparsed_via_rbs.length).to eq(1)
+        expect(reparsed_via_rbs.first.conjuncts.map(&:tags)).to eq(['String, Integer', 'Comparable'])
+      end
     end
 
     it 'sets required positional parameters' do

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -142,17 +142,13 @@ describe Solargraph::RbsMap::Conversions do
       end
 
       it 'finds superclass method pin parameter type' do
-        # RBS core's Hash#[] started taking its key as the _Key duck-type
-        # interface instead of the generic K as of RBS 4.1.0, so instantiating
-        # Hash{Symbol => untyped} no longer substitutes the param type on
-        # newer RBS - see ruby/rbs core/hash.rbs.
-        expected = if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
-                     ['::Hash::_Key']
-                   else
-                     ['Symbol']
-                   end
+        # RBS core's Hash#[] takes its key as the _Key duck-type interface
+        # rather than the generic K as of RBS 4.1.0. RbsTranslator stubs
+        # that back to K (see RBS_INTERFACE_TO_GENERIC), so instantiating
+        # Hash{Symbol => untyped} substitutes the param type on every RBS
+        # version rather than leaving the interface unresolved.
         expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
-                 .uniq).to eq(expected)
+                 .uniq).to eq(['Symbol'])
       end
     end
   end

--- a/spec/rbs_translator_spec.rb
+++ b/spec/rbs_translator_spec.rb
@@ -26,6 +26,22 @@ describe Solargraph::RbsTranslator do
     described_class.to_complex_type(RBS::Parser.parse_type(rbs_string))
   end
 
+  context 'with RBS 4.1+ structural key interfaces' do
+    it 'stubs Hash::_Key in as the class\'s own K' do
+      expect(translate('Hash::_Key').tag).to eq('generic<K>')
+    end
+
+    it 'leaves an unqualified _Key alone' do
+      # the stub is keyed on the well-known qualified name, so an
+      # unrelated interface that happens to be called _Key is untouched
+      expect(translate('_Key').tag).to eq('_Key')
+    end
+
+    it 'leaves other interfaces alone' do
+      expect(translate('Enumerable::_Each').tag).to eq('Enumerable::_Each')
+    end
+  end
+
   context 'when translating at the top level (already correct)' do
     it 'builds a real intersection from a union conjunct' do
       type = translate('(Integer | String) & Comparable')

--- a/spec/rbs_translator_spec.rb
+++ b/spec/rbs_translator_spec.rb
@@ -1,0 +1,90 @@
+# frozen_string_literal: true
+
+require 'rbs'
+
+# RbsTranslator.to_complex_type builds ComplexType::UniqueType::Intersection
+# directly from the RBS AST for a *top-level* RBS::Types::Intersection,
+# rather than flattening it through a joined tag string - see
+# spec/pin/method_spec.rb "with a union nested inside an intersection".
+# That fix only covers the entry point used for method return types and
+# parameter types. Every other place a type gets recursively translated
+# - RBS::Types::Optional, RBS::Types::Union members, RBS::Types::Tuple
+# elements, and generic type arguments (Array[...], Hash[...], and any
+# other name with type args, via build_type/type_tag) - still goes
+# through the same flattening `type_to_tag` string join that caused the
+# original bug, whenever the nested type is an intersection with a union
+# conjunct. A plain (non-union-conjunct) intersection nested anywhere is
+# fine; only the combination of "intersection containing a union" nested
+# below the top level is affected.
+#
+# This spec covers that whole class of position, not just the one
+# reported.
+describe Solargraph::RbsTranslator do
+  # @param rbs_string [String]
+  # @return [Solargraph::ComplexType]
+  def translate rbs_string
+    described_class.to_complex_type(RBS::Parser.parse_type(rbs_string))
+  end
+
+  context 'when translating at the top level (already correct)' do
+    it 'builds a real intersection from a union conjunct' do
+      type = translate('(Integer | String) & Comparable')
+      expect(type.length).to eq(1)
+      expect(type.to_rbs).to eq('(::Integer | ::String) & ::Comparable')
+    end
+  end
+
+  context 'with a plain intersection (no union conjunct) nested anywhere' do
+    it 'translates correctly inside a generic argument' do
+      type = translate('Array[Integer & Comparable]')
+      expect(type.to_rbs).to eq('::Array[::Integer & ::Comparable]')
+    end
+  end
+
+  context 'with a union-in-intersection nested below the top level' do
+    it 'preserves grouping inside a generic argument (Array)' do
+      type = translate('Array[(Integer | String) & Comparable]')
+      expect(type.to_rbs).to eq('::Array[(::Integer | ::String) & ::Comparable]')
+    end
+
+    it 'preserves grouping inside a Hash value' do
+      type = translate('Hash[Symbol, (Integer | String) & Comparable]')
+      expect(type.to_rbs).to eq('::Hash[::Symbol, (::Integer | ::String) & ::Comparable]')
+    end
+
+    it 'preserves grouping inside a Hash key' do
+      type = translate('Hash[(Integer | String) & Comparable, Symbol]')
+      expect(type.to_rbs).to eq('::Hash[(::Integer | ::String) & ::Comparable, ::Symbol]')
+    end
+
+    it 'preserves grouping when doubly nested (Array of Hash values)' do
+      type = translate('Array[Hash[Symbol, (Integer | String) & Comparable]]')
+      expect(type.to_rbs).to eq('::Array[::Hash[::Symbol, (::Integer | ::String) & ::Comparable]]')
+    end
+
+    it 'preserves grouping under an optional (nilable) wrapper' do
+      type = translate('((Integer | String) & Comparable)?')
+      # T? is T | nil - a 2-item union of [the intersection, nil], not a
+      # 3-item union that leaks the intersection's own first conjunct
+      # out to the top level.
+      expect(type.length).to eq(2)
+      expect(type.to_rbs).to eq('((::Integer | ::String) & ::Comparable | nil)')
+    end
+
+    it 'preserves grouping as one member of an outer union' do
+      # NilClass renders as the literal `nil` tag everywhere in this
+      # codebase (see RBS_TO_YARD_TYPE), independent of this fix.
+      type = translate('((Integer | String) & Comparable) | NilClass')
+      expect(type.length).to eq(2)
+      expect(type.to_rbs).to eq('((::Integer | ::String) & ::Comparable | nil)')
+    end
+
+    it 'preserves grouping as a tuple element' do
+      type = translate('[(Integer | String) & Comparable, Integer]')
+      # a 2-element tuple - the intersection, then Integer - not a
+      # 3-element tuple that leaks the intersection's first conjunct out
+      # as its own element.
+      expect(type.to_rbs).to eq('[(::Integer | ::String) & ::Comparable, ::Integer]')
+    end
+  end
+end

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -389,6 +389,37 @@ describe Solargraph::Source::Chain::Call do
     expect(type.tag).to eq('undefined')
   end
 
+  it 'denies calls on a two-class union when loose union mode is off and only one class defines the method' do
+    # The nilable spec above exercises this same "every union member must
+    # define the method, unless loose_unions" rule, but only via
+    # nullable?/without_nil stripping nil out first - it never actually
+    # tests the general two-real-class case. Found while checking whether
+    # the Call#resolve fix for intersections (A & B <: A, A & B <: B)
+    # regressed real union semantics (A, B calls require both) - it
+    # doesn't (this reproduces identically on unmodified HEAD, before that
+    # fix), but this specific shape was never covered.
+    pending 'strict union mode does not deny a call when only one of two plain classes defines it'
+    source = Solargraph::Source.load_string(%(
+      class A
+        # @return [void]
+        def foo; end
+      end
+
+      class B
+      end
+
+      # @type [A, B]
+      x = make
+      x.foo
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new(loose_unions: false)
+    api_map.map source
+
+    chain = Solargraph::Source::SourceChainer.chain(source, Solargraph::Position.new(10, 8))
+    type = chain.infer(api_map, Solargraph::Pin::ROOT_PIN, api_map.source_map('test.rb').locals)
+    expect(type.tag).to eq('undefined')
+  end
+
   it 'preserves unions in value position in Hash' do
     source = Solargraph::Source.load_string(%(
       # @param params [Hash{String => Array<undefined>, Hash{String => undefined}, String, Integer}]

--- a/spec/source/chain/call_spec.rb
+++ b/spec/source/chain/call_spec.rb
@@ -390,14 +390,11 @@ describe Solargraph::Source::Chain::Call do
   end
 
   it 'denies calls on a two-class union when loose union mode is off and only one class defines the method' do
-    # The nilable spec above exercises this same "every union member must
+    # The nilable spec above covers the same "every union member must
     # define the method, unless loose_unions" rule, but only via
-    # nullable?/without_nil stripping nil out first - it never actually
-    # tests the general two-real-class case. Found while checking whether
-    # the Call#resolve fix for intersections (A & B <: A, A & B <: B)
-    # regressed real union semantics (A, B calls require both) - it
-    # doesn't (this reproduces identically on unmodified HEAD, before that
-    # fix), but this specific shape was never covered.
+    # nullable?/without_nil stripping nil out first, not the general
+    # two-real-class case. This is a pre-existing gap, unrelated to
+    # intersections: it reproduces identically on unmodified master.
     pending 'strict union mode does not deny a call when only one of two plain classes defines it'
     source = Solargraph::Source.load_string(%(
       class A

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -3121,6 +3121,24 @@ describe Solargraph::SourceMap::Clip do
     api_map = Solargraph::ApiMap.new
     api_map.map source
     clip = api_map.clip_at('test.rb', [7, 8])
-    expect(clip.infer.tag).to eq('String')
+
+    make_pin = api_map.get_methods('Object').find { |p| p.name == 'make' }
+    warn "DEBUG RUBY_VERSION=#{RUBY_VERSION} RUBY_PLATFORM=#{RUBY_PLATFORM} RUBY_ENGINE=#{RUBY_ENGINE}"
+    warn "DEBUG make_pin=#{make_pin.inspect}"
+    warn "DEBUG make_pin.generics=#{make_pin&.generics.inspect}" if make_pin.respond_to?(:generics)
+    warn "DEBUG make_pin.parameters=#{make_pin&.parameters&.map { |p| [p.name, p.decl, p.asgn_code].inspect }.inspect}" if make_pin
+    warn "DEBUG make_pin.return_type=#{make_pin&.return_type.inspect}" if make_pin
+    warn "DEBUG cursor.chain=#{clip.send(:cursor).chain.inspect}"
+    warn "DEBUG cursor.chain.links=#{clip.send(:cursor).chain.links.map(&:class).inspect}"
+    define_result = clip.send(:cursor).chain.define(api_map, clip.send(:closure), clip.locals)
+    warn "DEBUG chain.define=#{define_result.inspect}"
+    infer_result = clip.infer
+    warn "DEBUG clip.infer=#{infer_result.inspect}"
+    warn "DEBUG clip.infer.tag=#{infer_result.tag.inspect}"
+    warn "DEBUG clip.infer.class=#{infer_result.class}"
+
+    expect(clip.infer.tag).to eq('String'),
+                              "DEBUG: make_pin=#{make_pin.inspect}, chain.define=#{define_result.inspect}, " \
+                              "clip.infer=#{infer_result.inspect}"
   end
 end

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -3107,4 +3107,20 @@ describe Solargraph::SourceMap::Clip do
     expect(paths).to include('String#upcase')
     expect(paths).to include('Integer#abs')
   end
+
+  it 'binds a generic through an intersection param at the call site' do
+    source = Solargraph::Source.load_string(%(
+      # @generic T
+      # @param clazz [Class<generic<T>> & #new]
+      # @return [generic<T>]
+      def make(clazz)
+        raise
+      end
+      make(String)
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    clip = api_map.clip_at('test.rb', [7, 8])
+    expect(clip.infer.tag).to eq('String')
+  end
 end

--- a/spec/type_checker/levels/strict_spec.rb
+++ b/spec/type_checker/levels/strict_spec.rb
@@ -268,26 +268,6 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.first.message).to include('Wrong argument type')
     end
 
-    it 'accepts a duck-typed argument declared with the exact same duck type as expected' do
-      # duck_types_match? used to check the expected duck type against
-      # inferred.namespace/#scope, which are only meaningful for a
-      # nominal type - a duck-typed *inferred* type has no namespace
-      # of its own, so this failed to typecheck even when the two
-      # duck types were textually identical.
-      checker = type_checker(%(
-        # @param callback [#quack]
-        # @return [void]
-        def notify(callback); end
-
-        # @param x [#quack]
-        # @return [void]
-        def relay(x)
-          notify(x)
-        end
-      ))
-      expect(checker.problems).to be_empty
-    end
-
     it 'reports mismatched kwrestargs' do
       checker = type_checker(%(
         class Foo

--- a/spec/type_checker/levels/strict_spec.rb
+++ b/spec/type_checker/levels/strict_spec.rb
@@ -268,6 +268,26 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.first.message).to include('Wrong argument type')
     end
 
+    it 'accepts a duck-typed argument declared with the exact same duck type as expected' do
+      # duck_types_match? used to check the expected duck type against
+      # inferred.namespace/#scope, which are only meaningful for a
+      # nominal type - a duck-typed *inferred* type has no namespace
+      # of its own, so this failed to typecheck even when the two
+      # duck types were textually identical.
+      checker = type_checker(%(
+        # @param callback [#quack]
+        # @return [void]
+        def notify(callback); end
+
+        # @param x [#quack]
+        # @return [void]
+        def relay(x)
+          notify(x)
+        end
+      ))
+      expect(checker.problems).to be_empty
+    end
+
     it 'reports mismatched kwrestargs' do
       checker = type_checker(%(
         class Foo

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1018,6 +1018,47 @@ describe Solargraph::TypeChecker do
           .to include('Wrong argument type for Consumer#project_to_h: project_obj expected Asana::Resources::Project, received Mocha::Mock')
       end
 
+      it 'accepts an intersection-typed argument where the duck-typed conjunct is expected (#1231)' do
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5280196737 -
+        # ComplexType#duck_types_match? used to check the duck-typed
+        # expectation against ComplexType#namespace/#scope, which for an
+        # Intersection just delegates to its *first* conjunct
+        # (Intersection#namespace/#scope). That rejected an intersection
+        # whenever the duck-typed conjunct wasn't the first one, even
+        # though duck-typed subtyping only needs *some* conjunct to
+        # satisfy it - the same "any one conjunct" rule
+        # Intersection#conforms_to? already applies elsewhere. Fixed by
+        # checking each conjunct instead of just the first.
+        checker = type_checker(%(
+          # @param callback [#quack]
+          # @return [void]
+          def notify(callback); end
+
+          # @param x [String & #quack]
+          # @return [void]
+          def relay(x)
+            notify(x)
+          end
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'still rejects an intersection-typed argument when no conjunct satisfies the duck-typed expectation' do
+        checker = type_checker(%(
+          # @param callback [#quack]
+          # @return [void]
+          def notify(callback); end
+
+          # @param x [String & Integer]
+          # @return [void]
+          def relay(x)
+            notify(x)
+          end
+      ))
+        expect(checker.problems.map(&:message))
+          .to include('Wrong argument type for #notify: callback expected #quack, received String & Integer')
+      end
+
       it 'dispatches generic methods per-conjunct when intersecting two instantiations of the same generic class (#1231)' do
         # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
         # #fetch on Hash{K1=>V1} & Hash{K2=>V2} used to always resolve through

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1239,6 +1239,50 @@ describe Solargraph::TypeChecker do
       ))
         expect(checker.problems.map(&:message)).to be_empty
       end
+
+      # Passes with and without the conjunct resolution: an unbound
+      # generic return is accepted leniently, so this is a
+      # no-regression check. The mismatch spec below is the
+      # discriminating one.
+      it 'binds a generic declared only inside an intersection @param' do
+        checker = type_checker(%(
+          class Factory
+            # @generic T
+            # @param clazz [Class<generic<T>> & #new]
+            # @return [Class<generic<T>>]
+            def echo(clazz)
+              clazz
+            end
+
+            # @return [Class<String>]
+            def use
+              echo(String)
+            end
+          end
+        ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'reports a mismatch against the generic bound through the intersection' do
+        checker = type_checker(%(
+          class Factory
+            # @generic T
+            # @param clazz [Class<generic<T>> & #new]
+            # @return [Class<generic<T>>]
+            def echo(clazz)
+              clazz
+            end
+
+            # @return [Class<Integer>]
+            def use
+              echo(String)
+            end
+          end
+        ))
+        expect(checker.problems.map(&:message))
+          .to eq(['Declared return type ::Class<::Integer> does not match inferred type ::Class<::String> ' \
+                  'for Factory#use'])
+      end
     end
   end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -922,6 +922,48 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to be_empty
     end
 
+    it 'always dispatches a same-class generic method through the first union member, not #1231-specific' do
+      # Not an intersection-types bug at all: a *union* of two Hash
+      # instantiations shows the identical "always the first one, regardless
+      # of order or argument" dispatch bug that the same-class intersection
+      # specs below track. Confirmed on unmodified castwide/solargraph
+      # master (8fda63384, no & or | involved) with a minimal @generic
+      # class (no Hash, no literal keys, no #1266 dependency):
+      #
+      #   # @generic T
+      #   class Box
+      #     # @return [generic<T>]
+      #     def get; end
+      #   end
+      #
+      #   # @param b [Box<Integer>, Box<String>]
+      #   b.get  # infers Integer
+      #   # @param b [Box<String>, Box<Integer>]
+      #   b.get  # infers String - order picked the type, not the call
+      #
+      # Root cause: Call#inferred_pins resolves the class's generic
+      # parameter against `self_type = name_pin.binder` - the *whole*
+      # union/intersection type - rather than per-member, so it binds
+      # against whichever member it structurally matches first.
+      #
+      # Filing this as its own issue/PR against master, independent of
+      # #1231 and #1266, so the Hash intersection specs below inherit the
+      # fix whichever order the PRs land in rather than stacking one PR on
+      # top of another.
+      pending 'Call#inferred_pins binds a generic against the first union/intersection member only'
+      checker = type_checker(%(
+        class Repro
+          # @param period [Hash{"Index" => Float}, Hash{"Triggers" => Array<Hash{"Name" => String}>}]
+          # @return [void]
+          def process(period)
+            # @type [Float]
+            index = period.fetch("Index")
+          end
+        end
+    ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     context 'with intersection types' do
       it 'accepts an intersection-typed argument where any one conjunct is expected' do
         checker = type_checker(%(

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -899,7 +899,16 @@ describe Solargraph::TypeChecker do
       # reproduces identically for a single, non-intersected generic Hash - the
       # intersection is not the trigger, so the fix for #1231 should not be expected
       # to resolve this on its own.
-      pending 'pre-existing Hash#fetch generic-parameter leak, unrelated to intersection types'
+      #
+      # Root cause: Pin::Parameter#compatible_arg? rejects Hash#fetch's exact-arity
+      # `(key: Hash::_Key) -> V` overload because Hash::_Key (an ad-hoc RBS
+      # interface) is checked nominally, not structurally, against the String
+      # argument - so it falls through to the pin's raw combined signature type,
+      # which still carries the unresolved generic X from the other overloads.
+      # Blocked on https://github.com/castwide/solargraph/pull/1266 (structurally
+      # verify RBS interface-typed expectations), which already fixes this on a
+      # different branch but isn't on master or this branch yet.
+      pending 'blocked on #1266 (structural RBS interface-typed expectation checks)'
       checker = type_checker(%(
         class Repro
           # @param period [Hash{"Index" => Float}]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -893,6 +893,26 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
 
+    it 'leaks an unresolved generic<X> from Hash#fetch even with no intersection involved' do
+      # Not #1231-specific: https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
+      # reported this against an intersection of two Hash instantiations, but it
+      # reproduces identically for a single, non-intersected generic Hash - the
+      # intersection is not the trigger, so the fix for #1231 should not be expected
+      # to resolve this on its own.
+      pending 'pre-existing Hash#fetch generic-parameter leak, unrelated to intersection types'
+      checker = type_checker(%(
+        class Repro
+          # @param period [Hash{"Index" => Float}]
+          # @return [void]
+          def process(period)
+            # @type [Float]
+            index = period.fetch("Index")
+          end
+        end
+    ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     context 'with intersection types' do
       it 'accepts an intersection-typed argument where any one conjunct is expected' do
         checker = type_checker(%(
@@ -956,6 +976,40 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
+      it 'ignores which conjunct is fetched from and always resolves via the first conjunct (#1231)' do
+        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 - ' \
+                'swapping the conjunct order flips which (still wrong) type both fetches ' \
+                'report, showing dispatch always uses the first conjunct rather than the key'
+        checker = type_checker(%(
+          class Repro
+            # @param period [Hash{"Triggers" => Array<Hash{"Name" => String}>} & Hash{"Index" => Float}]
+            # @return [void]
+            def process(period)
+              # @type [Array<Hash{"Name" => String}>]
+              triggers = period.fetch("Triggers")
+
+              # @type [Float]
+              index = period.fetch("Index")
+            end
+          end
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'resolves a non-generic method shared by both conjuncts of a same-class intersection' do
+        checker = type_checker(%(
+          class Repro
+            # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
+            # @return [void]
+            def process(period)
+              # @type [Integer]
+              n = period.size
+            end
+          end
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
       it 'resolves a call to a method defined on just one conjunct of an intersection-typed receiver (#1231)' do
         pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
                 'method-call resolution does not walk the conjuncts of an intersection-typed receiver'
@@ -980,6 +1034,91 @@ describe Solargraph::TypeChecker do
 
           Factory.new.make.foo
           Factory.new.make.bar
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'resolves a call to a method inherited from a common ancestor of both conjuncts' do
+        checker = type_checker(%(
+          class A
+            # @return [void]
+            def foo; end
+          end
+
+          class B
+            # @return [void]
+            def bar; end
+          end
+
+          class Factory
+            # @sg-ignore A.new duck-types as A & B for this repro
+            # @return [A & B]
+            def make
+              A.new
+            end
+          end
+
+          # @type [String]
+          s = Factory.new.make.to_s
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'fails to resolve a conjunct method on an intersection-typed local variable, not just a call chain (#1231)' do
+        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
+                'the gap is in resolving methods on any intersection-typed value, not specific ' \
+                'to method-return-value call chains'
+        checker = type_checker(%(
+          class A
+            # @return [void]
+            def foo; end
+          end
+
+          class B
+            # @return [void]
+            def bar; end
+          end
+
+          # @sg-ignore A.new duck-types as A & B for this repro
+          # @type [A & B]
+          value = A.new
+
+          value.foo
+          value.bar
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'fails to resolve conjunct methods on a three-way intersection' do
+        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
+                'method-call resolution does not walk conjuncts, regardless of how many there are'
+        checker = type_checker(%(
+          class A
+            # @return [void]
+            def foo; end
+          end
+
+          class B
+            # @return [void]
+            def bar; end
+          end
+
+          class C
+            # @return [void]
+            def baz; end
+          end
+
+          class Factory
+            # @sg-ignore A.new duck-types as A & B & C for this repro
+            # @return [A & B & C]
+            def make
+              A.new
+            end
+          end
+
+          Factory.new.make.foo
+          Factory.new.make.bar
+          Factory.new.make.baz
       ))
         expect(checker.problems.map(&:message)).to be_empty
       end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1019,16 +1019,10 @@ describe Solargraph::TypeChecker do
       end
 
       it 'accepts an intersection-typed argument where the duck-typed conjunct is expected (#1231)' do
-        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5280196737 -
-        # ComplexType#duck_types_match? used to check the duck-typed
-        # expectation against ComplexType#namespace/#scope, which for an
-        # Intersection just delegates to its *first* conjunct
-        # (Intersection#namespace/#scope). That rejected an intersection
-        # whenever the duck-typed conjunct wasn't the first one, even
-        # though duck-typed subtyping only needs *some* conjunct to
-        # satisfy it - the same "any one conjunct" rule
-        # Intersection#conforms_to? already applies elsewhere. Fixed by
-        # checking each conjunct instead of just the first.
+        # Duck-typed subtyping needs *some* conjunct to satisfy it, not
+        # specifically the first one that Intersection#namespace/#scope
+        # delegate to -
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5280196737
         checker = type_checker(%(
           # @param callback [#quack]
           # @return [void]
@@ -1060,45 +1054,19 @@ describe Solargraph::TypeChecker do
       end
 
       it 'dispatches generic methods per-conjunct when intersecting two instantiations of the same generic class (#1231)' do
-        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
-        # #fetch on Hash{K1=>V1} & Hash{K2=>V2} used to always resolve through
-        # the *first* conjunct's #fetch signature regardless of which key was
-        # passed. Root cause (shared with castwide/solargraph#1272): both
-        # conjuncts resolve to a pin with the same path (Hash#fetch) but
-        # different, already-correctly-resolved return types, and dedup was
-        # keying on path alone - fixed here the same way
-        # castwide/solargraph#1273 fixed it for real unions, applied to
-        # Call#method_stack_pins's Intersection branch too.
+        # Both conjuncts resolve to a pin with the same path (Hash#fetch)
+        # but different, already-resolved return types, so dispatch keys on
+        # path *and* return type, then narrows to the conjunct whose key
+        # matches the call's literal argument. RBS's own
+        # `Hash#fetch: (_Key key) -> V` can't narrow that itself - `_Key` is
+        # a structural hash/eql? interface, not literally `K`, so the key
+        # argument is never connected to the return type by ordinary
+        # overload resolution -
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
         #
-        # That made dispatch order-independent and sound (both conjuncts'
-        # possible return types show up), but not yet *precise*: it returned
-        # a union of every conjunct's result rather than narrowing to the one
-        # whose key actually matches. RBS's own `Hash#fetch: (_Key key) -> V`
-        # can't do this itself - `_Key` is a structural hash/eql? interface,
-        # not literally `K`, so the key argument is never connected to the
-        # return type by ordinary overload resolution. Call#method_stack_pins
-        # now detects any `_Key`-shaped parameter on a conjunct's method
-        # (generalizing past #fetch/#[] to #dig, #delete, etc. for free) and,
-        # when every conjunct yields a positive verdict for or against the
-        # call's own literal argument, keeps only the matching conjunct(s) -
-        # conservatively falling back to today's full union whenever even one
-        # conjunct can't be verified one way or the other.
-        #
-        # Key-parameter detection has to handle two shapes, because RBS's
-        # own core/hash.rbs changed in 4.1.0: `(_Key key)` from 4.1.0 on,
-        # `(K arg0)` before it. Pin::Signature#key_param_index recognizes
-        # both - see its comment. Without the pre-4.1 shape this spec
-        # passes on RBS >= 4.1 and fails on 3.10.x/4.0.x, which is what
-        # apiology/solargraph#49 CI was reporting before that was fixed.
-        #
-        # Still pending on this branch alone: castwide/solargraph#1223
-        # (restores literal type inference). Without it the literal
-        # "Index"/"Triggers" key_types get widened to plain String before
-        # the narrowing above ever sees them - verified directly, with just
-        # this branch's own commits the union already loses the literal keys
-        # (`Hash{String => String}`), independent of anything else. #1223 is
-        # an independent, already-scoped PR that just happens to be a
-        # prerequisite for this spec to observe the fix above working.
+        # castwide/solargraph#1223 is a prerequisite: without it the literal
+        # "Index"/"Triggers" key_types widen to plain String before the
+        # narrowing can see them.
         pending 'needs castwide/solargraph#1223'
         checker = type_checker(%(
           class Repro
@@ -1117,14 +1085,9 @@ describe Solargraph::TypeChecker do
       end
 
       it 'dispatches generic methods per-conjunct regardless of conjunct order (#1231)' do
-        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
-        # this used to demonstrate order-*dependence*: swapping the conjunct
-        # order flipped which (wrong) type both fetches reported. The
-        # dedup-key fix described in the sibling spec above makes this
-        # order-independent now - same per-key-narrowed result either way,
-        # dispatched via the same literal-key matching described there.
-        # Pending on this branch alone for the same independent,
-        # already-scoped prerequisite as that spec: castwide/solargraph#1223.
+        # The conjunct order of the sibling spec above, reversed: the same
+        # per-key narrowing applies either way, with the same
+        # castwide/solargraph#1223 prerequisite.
         pending 'needs castwide/solargraph#1223'
         checker = type_checker(%(
           class Repro
@@ -1143,18 +1106,12 @@ describe Solargraph::TypeChecker do
       end
 
       it 'dispatches generic methods per-conjunct for symbol keys (#1231)' do
-        # Symbol keys take a different path to the same bug than the string
-        # keys above: symbols already infer as literal types, so per-overload
-        # matching correctly rejects the non-matching conjunct - but a pin
-        # whose overloads all fail to match is not dropped, it just falls
-        # through to its declared return type, so the union survives anyway.
-        # Only key_verified_conjuncts can actually remove a conjunct. Before
-        # Pin::Signature#key_param_index learned RBS < 4.1's `(K arg0)`
-        # shape, this reported the union plus an unresolved generic<X> plus
-        # three spurious "Wrong argument type for Hash#fetch: arg0 expected
-        # :Index, received :Triggers" errors on RBS 3.10.x/4.0.x - the arg
-        # check was resolving against the conjunct that narrowing should
-        # have dropped.
+        # Symbol keys reach the same union by a different route than the
+        # string keys above: symbols already infer as literal types, so
+        # per-overload matching rejects the non-matching conjunct - but a
+        # pin whose overloads all fail to match falls through to its
+        # declared return type rather than being dropped, so only
+        # Call#key_verified_conjuncts can actually remove a conjunct.
         pending 'needs castwide/solargraph#1223'
         checker = type_checker(%(
           class Repro
@@ -1187,11 +1144,10 @@ describe Solargraph::TypeChecker do
       end
 
       it 'resolves a call to a method defined on just one conjunct of an intersection-typed receiver (#1231)' do
-        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 -
-        # method-call resolution used to only try the first conjunct's method
-        # stack, per unique type, and required every one of them to define the
-        # method the way a real union would. Fixed in Call#method_stack_pins by
-        # giving Intersection conjuncts "any one is enough" semantics instead.
+        # Method lookup gives an intersection's conjuncts "any one is
+        # enough" semantics (A & B <: A, A & B <: B), unlike a union, where
+        # every alternative has to define the method -
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119
         checker = type_checker(%(
           class A
             # @return [void]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -893,7 +893,6 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
 
-    # https://github.com/castwide/solargraph/issues/1229
     context 'with intersection types' do
       it 'accepts an intersection-typed argument where any one conjunct is expected' do
         checker = type_checker(%(

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -892,5 +892,50 @@ describe Solargraph::TypeChecker do
       # an error when trying to declare sub as Subclass
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
+
+    # https://github.com/castwide/solargraph/issues/1229
+    context 'with intersection types' do
+      it 'accepts an intersection-typed argument where any one conjunct is expected' do
+        checker = type_checker(%(
+          class Asana; class Resources; class Project; end; end; end
+          class Mocha; class Mock; end; end
+
+          class Consumer
+            # @param project_obj [Asana::Resources::Project]
+            # @return [void]
+            def project_to_h(project_obj); end
+          end
+
+          class MockFactory
+            # @sg-ignore Mocha::Mock configured with responds_like_instance_of
+            #   duck-types as Asana::Resources::Project at every call site.
+            # @return [Mocha::Mock & Asana::Resources::Project]
+            def make_mock
+              Mocha::Mock.new
+            end
+          end
+
+          Consumer.new.project_to_h(MockFactory.new.make_mock)
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'still rejects a plain conjunct type that does not satisfy the expected type' do
+        checker = type_checker(%(
+          class Asana; class Resources; class Project; end; end; end
+          class Mocha; class Mock; end; end
+
+          class Consumer
+            # @param project_obj [Asana::Resources::Project]
+            # @return [void]
+            def project_to_h(project_obj); end
+          end
+
+          Consumer.new.project_to_h(Mocha::Mock.new)
+      ))
+        expect(checker.problems.map(&:message))
+          .to include('Wrong argument type for Consumer#project_to_h: project_obj expected Asana::Resources::Project, received Mocha::Mock')
+      end
+    end
   end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1018,25 +1018,40 @@ describe Solargraph::TypeChecker do
         # castwide/solargraph#1273 fixed it for real unions, applied to
         # Call#method_stack_pins's Intersection branch too.
         #
-        # That makes dispatch order-independent and sound (both conjuncts'
-        # possible return types show up), but not yet *precise*: it's a union
-        # of every conjunct's result rather than narrowing to the one whose
-        # key actually matches. True per-key narrowing needs the literal key
-        # ("Index" vs "Triggers") to survive Pin::Parameter#typify, but
-        # UniqueType#qualify widens every literal type to its base class
-        # (String) via UniqueType#non_literal_name - tried gating that behind
-        # a corrected #literal? check (the existing check is unconditionally
-        # disabled by #1201, for an unrelated array/tuple-inference reason),
-        # but qualify's widening turns out to be load-bearing for other
-        # cases (RBS's `NilClass#to_s: () -> ''`, true/false -> Boolean
-        # consolidation) that use the exact same code path - see reverted
-        # attempt in this branch's history. A real fix needs qualify/transform
-        # to distinguish a Hash's key_types from a general return-type
-        # position, which they can't currently do.
+        # That made dispatch order-independent and sound (both conjuncts'
+        # possible return types show up), but not yet *precise*: it returned
+        # a union of every conjunct's result rather than narrowing to the one
+        # whose key actually matches. RBS's own `Hash#fetch: (_Key key) -> V`
+        # can't do this itself - `_Key` is a structural hash/eql? interface,
+        # not literally `K`, so the key argument is never connected to the
+        # return type by ordinary overload resolution. Call#method_stack_pins
+        # now detects any `_Key`-shaped parameter on a conjunct's method
+        # (generalizing past #fetch/#[] to #dig, #delete, etc. for free) and,
+        # when every conjunct yields a positive verdict for or against the
+        # call's own literal argument, keeps only the matching conjunct(s) -
+        # conservatively falling back to today's full union whenever even one
+        # conjunct can't be verified one way or the other.
         #
-        # Still blocked on #1266 too: the generic<X> leak is layered on top
-        # of the union.
-        pending 'blocked on #1266, plus qualify erasing literal Hash keys needed for precise per-key dispatch'
+        # Still pending on two independent prerequisites neither present on
+        # this branch:
+        #
+        # - castwide/solargraph#1223 (restores literal type inference) -
+        #   without it, the literal "Index"/"Triggers" key_types get widened
+        #   to plain String before the narrowing above ever sees them.
+        #   Verified directly: with just this branch's own commits, the
+        #   union already loses the literal keys (`Hash{String => String}`),
+        #   independent of anything else.
+        # - castwide/solargraph#1266 (structurally verifies RBS
+        #   interface-typed expectations) - needed only on RBS >= 4.1.x,
+        #   where `Hash#fetch`'s exact-arity overload gets nominally (not
+        #   structurally) rejected against `Hash::_Key` and falls through to
+        #   an unresolved `generic<X>`. Confirmed this branch alone is clean
+        #   on RBS 3.10.x but leaks `generic<X>` on RBS 4.1.x without #1266.
+        #
+        # Neither is specific to intersections or to this fix - both are
+        # independent, already-scoped PRs that just happen to be
+        # prerequisites for this spec to observe the fix above working.
+        pending 'needs castwide/solargraph#1223 and, on RBS >= 4.1.x, castwide/solargraph#1266'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
@@ -1053,16 +1068,17 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
-      it 'resolves the same (still imprecise) union regardless of conjunct order (#1231)' do
+      it 'dispatches generic methods per-conjunct regardless of conjunct order (#1231)' do
         # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
         # this used to demonstrate order-*dependence*: swapping the conjunct
         # order flipped which (wrong) type both fetches reported. The
         # dedup-key fix described in the sibling spec above makes this
-        # order-independent now - same union of both conjuncts' return types
-        # either way. Still pending for the same two reasons as that spec:
-        # the #1266-blocked generic<X> leak, and imprecise
-        # union-instead-of-narrowed-to-one-conjunct dispatch.
-        pending 'blocked on #1266, plus qualify erasing literal Hash keys needed for precise per-key dispatch'
+        # order-independent now - same per-key-narrowed result either way,
+        # dispatched via the same literal-key matching described there.
+        # Pending for the same two independent, already-scoped prerequisites
+        # as that spec: castwide/solargraph#1223 and, on RBS >= 4.1.x,
+        # castwide/solargraph#1266.
+        pending 'needs castwide/solargraph#1223 and, on RBS >= 4.1.x, castwide/solargraph#1266'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Triggers" => Array<Hash{"Name" => String}>} & Hash{"Index" => Float}]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -893,33 +893,18 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
 
-    it 'leaks an unresolved generic<X> from Hash#fetch even with no intersection involved' do
+    it 'resolves Hash#fetch on a literal-keyed Hash with no intersection involved' do
       # Not #1231-specific: https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
       # reported this against an intersection of two Hash instantiations, but it
-      # reproduces identically for a single, non-intersected generic Hash - the
-      # intersection is not the trigger, so the fix for #1231 should not be expected
-      # to resolve this on its own.
+      # reproduced identically for a single, non-intersected generic Hash.
       #
-      # Root cause: Pin::Parameter#compatible_arg? rejects Hash#fetch's exact-arity
-      # `(key: Hash::_Key) -> V` overload because Hash::_Key (an ad-hoc RBS
-      # interface) is checked nominally, not structurally, against the String
-      # argument - so it falls through to the pin's raw combined signature type,
-      # which still carries the unresolved generic X from the other overloads.
-      #
-      # https://github.com/castwide/solargraph/pull/1266 (structurally verify
-      # RBS interface-typed expectations) fixes this, but isn't merged into
-      # this branch. CI's full matrix showed this only actually leaks on
-      # RBS >= 4.1.0 - `rspec (3.1, 3.10.0)` unexpectedly passed here (an
-      # RSpec "pending example fixed" failure, since a bare `pending` assumed
-      # it leaked on every RBS version). Matches the same RBS 4.1.0 cutover
-      # already tracked in spec/rbs_map/conversions_spec.rb,
-      # spec/convention/activesupport_concern_spec.rb, and the mirror image
-      # of this same version-aware pattern applied on branch 2026-08-04
-      # (which does have #1266) in commit ac4eb27c5.
-      require 'rbs'
-      if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
-        pending 'blocked on #1266 (structural RBS interface-typed expectation checks), not yet merged into this branch'
-      end
+      # On RBS >= 4.1.0, Pin::Parameter#compatible_arg? rejected Hash#fetch's
+      # exact-arity `(key: Hash::_Key) -> V` overload, because Hash::_Key is
+      # checked nominally rather than structurally against the String argument,
+      # and fell through to the pin's raw combined signature type, which still
+      # carries an unresolved generic X from the other overloads. RbsTranslator
+      # now stubs Hash::_Key back to K (see RBS_INTERFACE_TO_GENERIC), so the
+      # nominal check succeeds and no interface is left to resolve structurally.
       checker = type_checker(%(
         class Repro
           # @param period [Hash{"Index" => Float}]
@@ -1057,11 +1042,9 @@ describe Solargraph::TypeChecker do
         # Both conjuncts resolve to a pin with the same path (Hash#fetch)
         # but different, already-resolved return types, so dispatch keys on
         # path *and* return type, then narrows to the conjunct whose key
-        # matches the call's literal argument. RBS's own
-        # `Hash#fetch: (_Key key) -> V` can't narrow that itself - `_Key` is
-        # a structural hash/eql? interface, not literally `K`, so the key
-        # argument is never connected to the return type by ordinary
-        # overload resolution -
+        # matches the call's literal argument. Overload resolution can't
+        # do that on its own, since it runs per conjunct and both
+        # conjuncts yield a pin with the same path -
         # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909
         #
         # castwide/solargraph#1223 is a prerequisite: without it the literal

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -966,9 +966,18 @@ describe Solargraph::TypeChecker do
       end
 
       it 'dispatches generic methods per-conjunct when intersecting two instantiations of the same generic class (#1231)' do
-        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 - ' \
-                '#fetch on Hash{K1=>V1} & Hash{K2=>V2} leaks an unresolved generic<X> ' \
-                'and returns the same wrong type regardless of which key is passed'
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
+        # #fetch on Hash{K1=>V1} & Hash{K2=>V2} leaks an unresolved generic<X> and
+        # returns the same wrong type regardless of which key is passed.
+        #
+        # Confirmed (by running this same repro against a branch with #1266
+        # merged) that this is two separate bugs layered together: #1266 fixes
+        # the generic<X> leak, but the call still resolves through the *first*
+        # conjunct's #fetch signature regardless of which key was passed - see
+        # the sibling 'ignores which conjunct is fetched from' spec below, which
+        # isolates that second bug. So landing #1266 alone will not flip this
+        # spec to passing; it needs its own per-conjunct dispatch fix too.
+        pending 'blocked on #1266, plus a separate first-conjunct-only dispatch bug'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
@@ -986,9 +995,14 @@ describe Solargraph::TypeChecker do
       end
 
       it 'ignores which conjunct is fetched from and always resolves via the first conjunct (#1231)' do
-        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 - ' \
-                'swapping the conjunct order flips which (still wrong) type both fetches ' \
-                'report, showing dispatch always uses the first conjunct rather than the key'
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
+        # swapping the conjunct order flips which (still wrong) type both fetches
+        # report, showing dispatch always uses the first conjunct rather than the
+        # key. This bug survives #1266 (confirmed by running this repro against a
+        # branch with #1266 merged: the generic<X> leak is gone, but the
+        # first-conjunct-only behavior is unchanged) - it needs its own
+        # per-conjunct dispatch fix, independent of #1266.
+        pending 'first-conjunct-only dispatch, independent of #1266'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Triggers" => Array<Hash{"Name" => String}>} & Hash{"Index" => Float}]
@@ -1020,8 +1034,16 @@ describe Solargraph::TypeChecker do
       end
 
       it 'resolves a call to a method defined on just one conjunct of an intersection-typed receiver (#1231)' do
-        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
-                'method-call resolution does not walk the conjuncts of an intersection-typed receiver'
+        # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 -
+        # method-call resolution does not walk the conjuncts of an
+        # intersection-typed receiver. Confirmed independent of #1266: running
+        # this repro against a branch with #1266 merged reproduces identically -
+        # #1266's interface-conformance fix doesn't touch Chain::Call#resolve's
+        # method-stack lookup (lib/solargraph/source/chain/call.rb:61-64), which
+        # only takes the first unique type's method stack and never walks the
+        # other conjuncts of an Intersection. Needs its own fix regardless of
+        # #1266's fate.
+        pending 'method-call resolution does not walk intersection conjuncts (unrelated to #1266)'
         checker = type_checker(%(
           class A
             # @return [void]
@@ -1074,9 +1096,10 @@ describe Solargraph::TypeChecker do
       end
 
       it 'fails to resolve a conjunct method on an intersection-typed local variable, not just a call chain (#1231)' do
-        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
-                'the gap is in resolving methods on any intersection-typed value, not specific ' \
-                'to method-return-value call chains'
+        # Same root cause and #1266-independence as the sibling spec above; the
+        # gap is in resolving methods on any intersection-typed value, not
+        # specific to method-return-value call chains.
+        pending 'method-call resolution does not walk intersection conjuncts (unrelated to #1266)'
         checker = type_checker(%(
           class A
             # @return [void]
@@ -1099,8 +1122,10 @@ describe Solargraph::TypeChecker do
       end
 
       it 'fails to resolve conjunct methods on a three-way intersection' do
-        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
-                'method-call resolution does not walk conjuncts, regardless of how many there are'
+        # Same root cause and #1266-independence as the sibling specs above;
+        # method-call resolution does not walk conjuncts, regardless of how
+        # many there are.
+        pending 'method-call resolution does not walk intersection conjuncts (unrelated to #1266)'
         checker = type_checker(%(
           class A
             # @return [void]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -935,6 +935,54 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message))
           .to include('Wrong argument type for Consumer#project_to_h: project_obj expected Asana::Resources::Project, received Mocha::Mock')
       end
+
+      it 'dispatches generic methods per-conjunct when intersecting two instantiations of the same generic class (#1231)' do
+        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 - ' \
+                '#fetch on Hash{K1=>V1} & Hash{K2=>V2} leaks an unresolved generic<X> ' \
+                'and returns the same wrong type regardless of which key is passed'
+        checker = type_checker(%(
+          class Repro
+            # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
+            # @return [void]
+            def process(period)
+              # @type [Float]
+              index = period.fetch("Index")
+
+              # @type [Array<Hash{"Name" => String}>]
+              triggers = period.fetch("Triggers")
+            end
+          end
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'resolves a call to a method defined on just one conjunct of an intersection-typed receiver (#1231)' do
+        pending 'https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 - ' \
+                'method-call resolution does not walk the conjuncts of an intersection-typed receiver'
+        checker = type_checker(%(
+          class A
+            # @return [void]
+            def foo; end
+          end
+
+          class B
+            # @return [void]
+            def bar; end
+          end
+
+          class Factory
+            # @sg-ignore A.new duck-types as A & B for this repro
+            # @return [A & B]
+            def make
+              A.new
+            end
+          end
+
+          Factory.new.make.foo
+          Factory.new.make.bar
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
     end
   end
 end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1035,15 +1035,10 @@ describe Solargraph::TypeChecker do
 
       it 'resolves a call to a method defined on just one conjunct of an intersection-typed receiver (#1231)' do
         # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207595119 -
-        # method-call resolution does not walk the conjuncts of an
-        # intersection-typed receiver. Confirmed independent of #1266: running
-        # this repro against a branch with #1266 merged reproduces identically -
-        # #1266's interface-conformance fix doesn't touch Chain::Call#resolve's
-        # method-stack lookup (lib/solargraph/source/chain/call.rb:61-64), which
-        # only takes the first unique type's method stack and never walks the
-        # other conjuncts of an Intersection. Needs its own fix regardless of
-        # #1266's fate.
-        pending 'method-call resolution does not walk intersection conjuncts (unrelated to #1266)'
+        # method-call resolution used to only try the first conjunct's method
+        # stack, per unique type, and required every one of them to define the
+        # method the way a real union would. Fixed in Call#method_stack_pins by
+        # giving Intersection conjuncts "any one is enough" semantics instead.
         checker = type_checker(%(
           class A
             # @return [void]
@@ -1095,11 +1090,9 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
-      it 'fails to resolve a conjunct method on an intersection-typed local variable, not just a call chain (#1231)' do
-        # Same root cause and #1266-independence as the sibling spec above; the
-        # gap is in resolving methods on any intersection-typed value, not
-        # specific to method-return-value call chains.
-        pending 'method-call resolution does not walk intersection conjuncts (unrelated to #1266)'
+      it 'resolves a conjunct method on an intersection-typed local variable, not just a call chain (#1231)' do
+        # Same fix as the sibling spec above applies to any intersection-typed
+        # value, not just method-return-value call chains.
         checker = type_checker(%(
           class A
             # @return [void]
@@ -1121,11 +1114,9 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
-      it 'fails to resolve conjunct methods on a three-way intersection' do
-        # Same root cause and #1266-independence as the sibling specs above;
-        # method-call resolution does not walk conjuncts, regardless of how
-        # many there are.
-        pending 'method-call resolution does not walk intersection conjuncts (unrelated to #1266)'
+      it 'resolves conjunct methods on a three-way intersection' do
+        # Same fix as the sibling specs above; each conjunct is checked
+        # independently regardless of how many there are.
         checker = type_checker(%(
           class A
             # @return [void]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -905,10 +905,21 @@ describe Solargraph::TypeChecker do
       # interface) is checked nominally, not structurally, against the String
       # argument - so it falls through to the pin's raw combined signature type,
       # which still carries the unresolved generic X from the other overloads.
-      # Blocked on https://github.com/castwide/solargraph/pull/1266 (structurally
-      # verify RBS interface-typed expectations), which already fixes this on a
-      # different branch but isn't on master or this branch yet.
-      pending 'blocked on #1266 (structural RBS interface-typed expectation checks)'
+      #
+      # https://github.com/castwide/solargraph/pull/1266 (structurally verify
+      # RBS interface-typed expectations) fixes this, but isn't merged into
+      # this branch. CI's full matrix showed this only actually leaks on
+      # RBS >= 4.1.0 - `rspec (3.1, 3.10.0)` unexpectedly passed here (an
+      # RSpec "pending example fixed" failure, since a bare `pending` assumed
+      # it leaked on every RBS version). Matches the same RBS 4.1.0 cutover
+      # already tracked in spec/rbs_map/conversions_spec.rb,
+      # spec/convention/activesupport_concern_spec.rb, and the mirror image
+      # of this same version-aware pattern applied on branch 2026-08-04
+      # (which does have #1266) in commit ac4eb27c5.
+      require 'rbs'
+      if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
+        pending 'blocked on #1266 (structural RBS interface-typed expectation checks), not yet merged into this branch'
+      end
       checker = type_checker(%(
         class Repro
           # @param period [Hash{"Index" => Float}]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1084,26 +1084,22 @@ describe Solargraph::TypeChecker do
         # conservatively falling back to today's full union whenever even one
         # conjunct can't be verified one way or the other.
         #
-        # Still pending on two independent prerequisites neither present on
-        # this branch:
+        # Key-parameter detection has to handle two shapes, because RBS's
+        # own core/hash.rbs changed in 4.1.0: `(_Key key)` from 4.1.0 on,
+        # `(K arg0)` before it. Pin::Signature#key_param_index recognizes
+        # both - see its comment. Without the pre-4.1 shape this spec
+        # passes on RBS >= 4.1 and fails on 3.10.x/4.0.x, which is what
+        # apiology/solargraph#49 CI was reporting before that was fixed.
         #
-        # - castwide/solargraph#1223 (restores literal type inference) -
-        #   without it, the literal "Index"/"Triggers" key_types get widened
-        #   to plain String before the narrowing above ever sees them.
-        #   Verified directly: with just this branch's own commits, the
-        #   union already loses the literal keys (`Hash{String => String}`),
-        #   independent of anything else.
-        # - castwide/solargraph#1266 (structurally verifies RBS
-        #   interface-typed expectations) - needed only on RBS >= 4.1.x,
-        #   where `Hash#fetch`'s exact-arity overload gets nominally (not
-        #   structurally) rejected against `Hash::_Key` and falls through to
-        #   an unresolved `generic<X>`. Confirmed this branch alone is clean
-        #   on RBS 3.10.x but leaks `generic<X>` on RBS 4.1.x without #1266.
-        #
-        # Neither is specific to intersections or to this fix - both are
-        # independent, already-scoped PRs that just happen to be
-        # prerequisites for this spec to observe the fix above working.
-        pending 'needs castwide/solargraph#1223 and, on RBS >= 4.1.x, castwide/solargraph#1266'
+        # Still pending on this branch alone: castwide/solargraph#1223
+        # (restores literal type inference). Without it the literal
+        # "Index"/"Triggers" key_types get widened to plain String before
+        # the narrowing above ever sees them - verified directly, with just
+        # this branch's own commits the union already loses the literal keys
+        # (`Hash{String => String}`), independent of anything else. #1223 is
+        # an independent, already-scoped PR that just happens to be a
+        # prerequisite for this spec to observe the fix above working.
+        pending 'needs castwide/solargraph#1223'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
@@ -1127,10 +1123,9 @@ describe Solargraph::TypeChecker do
         # dedup-key fix described in the sibling spec above makes this
         # order-independent now - same per-key-narrowed result either way,
         # dispatched via the same literal-key matching described there.
-        # Pending for the same two independent, already-scoped prerequisites
-        # as that spec: castwide/solargraph#1223 and, on RBS >= 4.1.x,
-        # castwide/solargraph#1266.
-        pending 'needs castwide/solargraph#1223 and, on RBS >= 4.1.x, castwide/solargraph#1266'
+        # Pending on this branch alone for the same independent,
+        # already-scoped prerequisite as that spec: castwide/solargraph#1223.
+        pending 'needs castwide/solargraph#1223'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Triggers" => Array<Hash{"Name" => String}>} & Hash{"Index" => Float}]
@@ -1141,6 +1136,36 @@ describe Solargraph::TypeChecker do
 
               # @type [Float]
               index = period.fetch("Index")
+            end
+          end
+      ))
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+
+      it 'dispatches generic methods per-conjunct for symbol keys (#1231)' do
+        # Symbol keys take a different path to the same bug than the string
+        # keys above: symbols already infer as literal types, so per-overload
+        # matching correctly rejects the non-matching conjunct - but a pin
+        # whose overloads all fail to match is not dropped, it just falls
+        # through to its declared return type, so the union survives anyway.
+        # Only key_verified_conjuncts can actually remove a conjunct. Before
+        # Pin::Signature#key_param_index learned RBS < 4.1's `(K arg0)`
+        # shape, this reported the union plus an unresolved generic<X> plus
+        # three spurious "Wrong argument type for Hash#fetch: arg0 expected
+        # :Index, received :Triggers" errors on RBS 3.10.x/4.0.x - the arg
+        # check was resolving against the conjunct that narrowing should
+        # have dropped.
+        pending 'needs castwide/solargraph#1223'
+        checker = type_checker(%(
+          class Repro
+            # @param period [Hash{:Index => Float} & Hash{:Triggers => Array<Hash{:Name => String}>}]
+            # @return [void]
+            def process(period)
+              # @type [Float]
+              index = period.fetch(:Index)
+
+              # @type [Array<Hash{:Name => String}>]
+              triggers = period.fetch(:Triggers)
             end
           end
       ))

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1009,17 +1009,34 @@ describe Solargraph::TypeChecker do
 
       it 'dispatches generic methods per-conjunct when intersecting two instantiations of the same generic class (#1231)' do
         # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
-        # #fetch on Hash{K1=>V1} & Hash{K2=>V2} leaks an unresolved generic<X> and
-        # returns the same wrong type regardless of which key is passed.
+        # #fetch on Hash{K1=>V1} & Hash{K2=>V2} used to always resolve through
+        # the *first* conjunct's #fetch signature regardless of which key was
+        # passed. Root cause (shared with castwide/solargraph#1272): both
+        # conjuncts resolve to a pin with the same path (Hash#fetch) but
+        # different, already-correctly-resolved return types, and dedup was
+        # keying on path alone - fixed here the same way
+        # castwide/solargraph#1273 fixed it for real unions, applied to
+        # Call#method_stack_pins's Intersection branch too.
         #
-        # Confirmed (by running this same repro against a branch with #1266
-        # merged) that this is two separate bugs layered together: #1266 fixes
-        # the generic<X> leak, but the call still resolves through the *first*
-        # conjunct's #fetch signature regardless of which key was passed - see
-        # the sibling 'ignores which conjunct is fetched from' spec below, which
-        # isolates that second bug. So landing #1266 alone will not flip this
-        # spec to passing; it needs its own per-conjunct dispatch fix too.
-        pending 'blocked on #1266, plus a separate first-conjunct-only dispatch bug'
+        # That makes dispatch order-independent and sound (both conjuncts'
+        # possible return types show up), but not yet *precise*: it's a union
+        # of every conjunct's result rather than narrowing to the one whose
+        # key actually matches. True per-key narrowing needs the literal key
+        # ("Index" vs "Triggers") to survive Pin::Parameter#typify, but
+        # UniqueType#qualify widens every literal type to its base class
+        # (String) via UniqueType#non_literal_name - tried gating that behind
+        # a corrected #literal? check (the existing check is unconditionally
+        # disabled by #1201, for an unrelated array/tuple-inference reason),
+        # but qualify's widening turns out to be load-bearing for other
+        # cases (RBS's `NilClass#to_s: () -> ''`, true/false -> Boolean
+        # consolidation) that use the exact same code path - see reverted
+        # attempt in this branch's history. A real fix needs qualify/transform
+        # to distinguish a Hash's key_types from a general return-type
+        # position, which they can't currently do.
+        #
+        # Still blocked on #1266 too: the generic<X> leak is layered on top
+        # of the union.
+        pending 'blocked on #1266, plus qualify erasing literal Hash keys needed for precise per-key dispatch'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Index" => Float} & Hash{"Triggers" => Array<Hash{"Name" => String}>}]
@@ -1036,15 +1053,16 @@ describe Solargraph::TypeChecker do
         expect(checker.problems.map(&:message)).to be_empty
       end
 
-      it 'ignores which conjunct is fetched from and always resolves via the first conjunct (#1231)' do
+      it 'resolves the same (still imprecise) union regardless of conjunct order (#1231)' do
         # https://github.com/castwide/solargraph/pull/1231#issuecomment-5207523909 -
-        # swapping the conjunct order flips which (still wrong) type both fetches
-        # report, showing dispatch always uses the first conjunct rather than the
-        # key. This bug survives #1266 (confirmed by running this repro against a
-        # branch with #1266 merged: the generic<X> leak is gone, but the
-        # first-conjunct-only behavior is unchanged) - it needs its own
-        # per-conjunct dispatch fix, independent of #1266.
-        pending 'first-conjunct-only dispatch, independent of #1266'
+        # this used to demonstrate order-*dependence*: swapping the conjunct
+        # order flipped which (wrong) type both fetches reported. The
+        # dedup-key fix described in the sibling spec above makes this
+        # order-independent now - same union of both conjuncts' return types
+        # either way. Still pending for the same two reasons as that spec:
+        # the #1266-blocked generic<X> leak, and imprecise
+        # union-instead-of-narrowed-to-one-conjunct dispatch.
+        pending 'blocked on #1266, plus qualify erasing literal Hash keys needed for precise per-key dispatch'
         checker = type_checker(%(
           class Repro
             # @param period [Hash{"Triggers" => Array<Hash{"Name" => String}>} & Hash{"Index" => Float}]


### PR DESCRIPTION
**Claude:**

Throwaway diagnostic branch, not for merging. Adds temporary `warn` instrumentation to `spec/source_map/clip_spec.rb:3111` ("binds a generic through an intersection param at the call site") to compare intermediate resolution state between Ruby 3.2.6 (passes locally) and Ruby 4.0.6 (fails in #1231's `regression` CI job).

Will be closed and the branch deleted once the debug output is captured. See #1231.
