### PR TITLE
Fix generic arguments lost through inherited methods

### DIFF
--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -463,14 +463,8 @@ module Solargraph
             elsif idx.zero? && !context_type.all_params.empty?
               ComplexType.new(context_type.all_params)
             else
-              # No concrete value was supplied for this type param (e.g.
-              # a bare reference to a generic class/superclass with no
-              # type arguments) and it has no default. Leave it as an
-              # unbound generic placeholder rather than erasing it to
-              # untyped -- the same type param queried directly on its
-              # declaring class (with no reference/superclass involved)
-              # is never substituted at all and stays unbound the same
-              # way.
+              # No concrete value was supplied; leave unbound rather than untyped,
+              # matching a direct (non-substituted) lookup on the declaring class.
               t
             end
           else

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -463,7 +463,15 @@ module Solargraph
             elsif idx.zero? && !context_type.all_params.empty?
               ComplexType.new(context_type.all_params)
             else
-              ComplexType::UNDEFINED
+              # No concrete value was supplied for this type param (e.g.
+              # a bare reference to a generic class/superclass with no
+              # type arguments) and it has no default. Leave it as an
+              # unbound generic placeholder rather than erasing it to
+              # untyped -- the same type param queried directly on its
+              # declaring class (with no reference/superclass involved)
+              # is never substituted at all and stays unbound the same
+              # way.
+              t
             end
           else
             t

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -501,6 +501,14 @@ describe 'YARD type specifier list parsing' do
         expect(type.tag).to eq('Array<String>')
       end
 
+      it 'leaves a trailing generic param unresolved instead of undefined when referenced with no type args' do
+        generic_class = Solargraph::Pin::Namespace.new(name: 'Box', comments: "@generic K\n@generic V")
+        context_type = Solargraph::ComplexType.parse('Box')
+        type = Solargraph::ComplexType.parse('generic<V>').first
+        resolved = type.resolve_generics(generic_class, context_type)
+        expect(resolved.tag).to eq('generic<V>')
+      end
+
       UNIQUE_METHOD_GENERIC_TESTS = [
         # tag, context_type_tag, unfrozen_input_map, expected_tag, expected_output_map
         ['String', 'String', {}, 'String', {}],

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1904,10 +1904,7 @@ describe Solargraph::SourceMap::Clip do
   end
 
   it 'propagates a concrete generic argument through an inherited method' do
-    # NoMethodError<T> < NameError<T>, and NameError#receiver
-    # returns T - given a concrete argument on the subclass
-    # reference, the inherited method should resolve it rather
-    # than erasing it to untyped/undefined.
+    # NoMethodError<T> < NameError<T>; NameError#receiver returns T.
     source = Solargraph::Source.load_string(%(
       # @type [NoMethodError<String>]
       e = NoMethodError.new

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1903,6 +1903,22 @@ describe Solargraph::SourceMap::Clip do
     expect(type.to_s).to eq('undefined')
   end
 
+  it 'propagates a concrete generic argument through an inherited method' do
+    # NoMethodError<T> < NameError<T>, and NameError#receiver
+    # returns T - given a concrete argument on the subclass
+    # reference, the inherited method should resolve it rather
+    # than erasing it to untyped/undefined.
+    source = Solargraph::Source.load_string(%(
+      # @type [NoMethodError<String>]
+      e = NoMethodError.new
+      e.receiver
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [3, 12])
+    type = clip.infer
+    expect(type.tag).to eq('String')
+  end
+
   it 'erases unresolvable method generics' do
     source = Solargraph::Source.load_string(%(
       # @generic T


### PR DESCRIPTION
**Claude:**

A class reference with a concrete generic argument doesn't propagate that argument through a method inherited from its superclass:

```
$ bundle exec solargraph pin 'NoMethodError<String>#receiver' --rbs
untyped
```

`NoMethodError<T> < NameError<T>`, and `NameError#receiver` is declared to return `T`. Given `NoMethodError<String>`, `#receiver` should resolve to `String` (or `String | nil`) — instead it erases to `untyped`.

Root cause: `UniqueType#resolve_generics` erased a class's own generic type parameter to `ComplexType::UNDEFINED` whenever the querying context supplied no concrete value and no default existed, rather than leaving it as an unbound placeholder. `resolve_generics` is called twice on this path (`ApiMap#inner_get_methods_from_reference`) — once resolving the superclass reference itself, once resolving the returned method pins — and the fallback nuked the intermediate value before the second call could use it.

After the fix:

```
$ bundle exec solargraph pin 'NoMethodError<String>#receiver' --rbs
(::String | nil)
```

A bare, unrooted query (`NoMethodError#receiver`, no type args) still shows `untyped` via the CLI `pin` command — that comes from `ApiMap#erase_generics`, a separate, deliberate policy (see `spec/source_map/clip_spec.rb`'s "erases unresolvable class generics" example), and is unaffected by this change.

Full spec suite: 1624 examples, 0 failures. Rubocop: 2 pre-existing offenses, both outside this diff (`Lint/UnreachableCode` at lines 151 and 379, unrelated to the change at line ~466).

This PR was written by Claude Code on behalf of @apiology.
