### PR TITLE
Fix @!override with @overload not dispatching per call site

### DIFF
--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -195,14 +195,14 @@ module Solargraph
             end
             # pin.reset_generated! always runs (matches prior behavior) so
             # non-overload tags (e.g. @param) still re-typify against the
-            # updated docstring. The @signatures/@overloads ivars are only
-            # cleared in addition when the override carries @overload tags
-            # -- see #reset_overridden_signatures.
+            # updated docstring. #invalidate_signatures! is only called in
+            # addition when the override carries @overload tags -- see its
+            # doc comment on Pin::Method for why that's conditional.
             pin.reset_generated!
             new_pin&.reset_generated!
             if ovr.tags.any? { |tag| tag.tag_name == 'overload' }
-              reset_overridden_signatures pin
-              reset_overridden_signatures new_pin
+              pin.invalidate_signatures!
+              new_pin&.invalidate_signatures!
             end
             ovr.tags.each do |tag|
               redefine_return_type pin, tag
@@ -210,29 +210,6 @@ module Solargraph
             end
           end
         end
-      end
-
-      # Clear any signatures/overloads Pin::Method may already have
-      # memoized for +pin+, so the next read rebuilds them from the
-      # docstring as it now stands (after `map_overrides` finished mutating
-      # it). Clears the ivars directly rather than via
-      # Pin::Method#reset_generated!, which also clobbers signatures
-      # assigned explicitly elsewhere (e.g. #transform_types,
-      # #combine_with) that have nothing to do with override application.
-      #
-      # Only called when the override carries @overload tags: rebuilding
-      # #signatures from scratch also rebuilds it from the pin's bare
-      # #parameters (Pin::Method#signatures_from_yard), which is empty or
-      # stale for many RBS/combined pins and would silently drop argument
-      # checking for overrides that only touch a single return type.
-      #
-      # @param pin [Pin::Method, nil]
-      # @return [void]
-      def reset_overridden_signatures pin
-        return unless pin
-
-        pin.instance_variable_set(:@signatures, nil)
-        pin.instance_variable_set(:@overloads, nil)
       end
 
       # @param pin [Pin::Method, nil]

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -183,17 +183,12 @@ module Solargraph
               pin.docstring.delete_tags tag
               new_pin&.docstring&.delete_tags tag
             end
-            # Add all tags before invalidating: #signatures rebuilds every
-            # @overload tag at once, so invalidating mid-loop would freeze
-            # it against a half-applied docstring and drop the rest.
+            # Add all tags first, or invalidating mid-loop drops later ones.
             ovr.tags.each do |tag|
               pin.docstring.add_tag(tag)
               new_pin&.docstring&.add_tag(tag)
             end
-            # reset_generated! always runs, so non-overload tags (e.g.
-            # @param) still re-typify; invalidate_signatures! only runs in
-            # addition when the override has @overload tags -- see its doc
-            # comment on Pin::Method for why.
+            # invalidate_signatures! only runs for @overload tags; see its doc comment.
             pin.reset_generated!
             new_pin&.reset_generated!
             if ovr.tags.any? { |tag| tag.tag_name == 'overload' }

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -183,22 +183,45 @@ module Solargraph
               pin.docstring.delete_tags tag
               new_pin&.docstring&.delete_tags tag
             end
+            # Add every tag from this override to the docstring before
+            # invalidating cached signatures below. Pin::Method#signatures
+            # rebuilds all @overload tags on the docstring at once, so
+            # invalidating mid-loop (after only some tags were added) would
+            # freeze the signature set against a partially-applied
+            # docstring and silently drop the remaining @overload tags.
             ovr.tags.each do |tag|
               pin.docstring.add_tag(tag)
+              new_pin&.docstring&.add_tag(tag)
+            end
+            reset_overridden_signatures pin
+            reset_overridden_signatures new_pin
+            ovr.tags.each do |tag|
               redefine_return_type pin, tag
-              pin.reset_generated!
-
-              next unless new_pin
-
-              new_pin.docstring.add_tag(tag)
               redefine_return_type new_pin, tag
-              new_pin.reset_generated!
             end
           end
         end
       end
 
-      # @param pin [Pin::Method]
+      # Invalidate any signatures/overloads Pin::Method may already have
+      # memoized for +pin+, so the next read rebuilds them from the
+      # docstring as it now stands (after `map_overrides` finished mutating
+      # it). Clears the ivars directly rather than via
+      # Pin::Method#reset_generated!, which also clobbers signatures
+      # assigned explicitly elsewhere (e.g. #transform_types,
+      # #combine_with) that have nothing to do with override application.
+      #
+      # @param pin [Pin::Method, nil]
+      # @return [void]
+      def reset_overridden_signatures pin
+        return unless pin
+
+        pin.reset_generated!
+        pin.instance_variable_set(:@signatures, nil)
+        pin.instance_variable_set(:@overloads, nil)
+      end
+
+      # @param pin [Pin::Method, nil]
       # @param tag [YARD::Tags::Tag]
       # @return [void]
       def redefine_return_type pin, tag

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -183,21 +183,17 @@ module Solargraph
               pin.docstring.delete_tags tag
               new_pin&.docstring&.delete_tags tag
             end
-            # Add every tag from this override to the docstring before
-            # invalidating cached signatures below. Pin::Method#signatures
-            # rebuilds all @overload tags on the docstring at once, so
-            # invalidating mid-loop (after only some tags were added) would
-            # freeze the signature set against a partially-applied
-            # docstring and silently drop the remaining @overload tags.
+            # Add all tags before invalidating: #signatures rebuilds every
+            # @overload tag at once, so invalidating mid-loop would freeze
+            # it against a half-applied docstring and drop the rest.
             ovr.tags.each do |tag|
               pin.docstring.add_tag(tag)
               new_pin&.docstring&.add_tag(tag)
             end
-            # pin.reset_generated! always runs (matches prior behavior) so
-            # non-overload tags (e.g. @param) still re-typify against the
-            # updated docstring. #invalidate_signatures! is only called in
-            # addition when the override carries @overload tags -- see its
-            # doc comment on Pin::Method for why that's conditional.
+            # reset_generated! always runs, so non-overload tags (e.g.
+            # @param) still re-typify; invalidate_signatures! only runs in
+            # addition when the override has @overload tags -- see its doc
+            # comment on Pin::Method for why.
             pin.reset_generated!
             new_pin&.reset_generated!
             if ovr.tags.any? { |tag| tag.tag_name == 'overload' }

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -193,8 +193,17 @@ module Solargraph
               pin.docstring.add_tag(tag)
               new_pin&.docstring&.add_tag(tag)
             end
-            reset_overridden_signatures pin
-            reset_overridden_signatures new_pin
+            # pin.reset_generated! always runs (matches prior behavior) so
+            # non-overload tags (e.g. @param) still re-typify against the
+            # updated docstring. The @signatures/@overloads ivars are only
+            # cleared in addition when the override carries @overload tags
+            # -- see #reset_overridden_signatures.
+            pin.reset_generated!
+            new_pin&.reset_generated!
+            if ovr.tags.any? { |tag| tag.tag_name == 'overload' }
+              reset_overridden_signatures pin
+              reset_overridden_signatures new_pin
+            end
             ovr.tags.each do |tag|
               redefine_return_type pin, tag
               redefine_return_type new_pin, tag
@@ -203,7 +212,7 @@ module Solargraph
         end
       end
 
-      # Invalidate any signatures/overloads Pin::Method may already have
+      # Clear any signatures/overloads Pin::Method may already have
       # memoized for +pin+, so the next read rebuilds them from the
       # docstring as it now stands (after `map_overrides` finished mutating
       # it). Clears the ivars directly rather than via
@@ -211,12 +220,17 @@ module Solargraph
       # assigned explicitly elsewhere (e.g. #transform_types,
       # #combine_with) that have nothing to do with override application.
       #
+      # Only called when the override carries @overload tags: rebuilding
+      # #signatures from scratch also rebuilds it from the pin's bare
+      # #parameters (Pin::Method#signatures_from_yard), which is empty or
+      # stale for many RBS/combined pins and would silently drop argument
+      # checking for overrides that only touch a single return type.
+      #
       # @param pin [Pin::Method, nil]
       # @return [void]
       def reset_overridden_signatures pin
         return unless pin
 
-        pin.reset_generated!
         pin.instance_variable_set(:@signatures, nil)
         pin.instance_variable_set(:@overloads, nil)
       end

--- a/lib/solargraph/api_map/index.rb
+++ b/lib/solargraph/api_map/index.rb
@@ -183,18 +183,15 @@ module Solargraph
               pin.docstring.delete_tags tag
               new_pin&.docstring&.delete_tags tag
             end
-            # Add all tags first, or invalidating mid-loop drops later ones.
+            # Add all tags first, or applying mid-loop drops later ones.
             ovr.tags.each do |tag|
               pin.docstring.add_tag(tag)
               new_pin&.docstring&.add_tag(tag)
             end
-            # invalidate_signatures! only runs for @overload tags; see its doc comment.
+            pin.apply_override_overloads!
+            new_pin&.apply_override_overloads!
             pin.reset_generated!
             new_pin&.reset_generated!
-            if ovr.tags.any? { |tag| tag.tag_name == 'overload' }
-              pin.invalidate_signatures!
-              new_pin&.invalidate_signatures!
-            end
             ovr.tags.each do |tag|
               redefine_return_type pin, tag
               redefine_return_type new_pin, tag

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -436,7 +436,6 @@ module Solargraph
             source: :overloads
           )
         end
-        @overloads
       end
 
       def anon_splat?

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -101,19 +101,14 @@ module Solargraph
         nil
       end
 
-      # Discard any memoized #signatures and #overloads so the next read
-      # rebuilds them from the docstring.
+      # Discards memoized #signatures/#overloads so the next read rebuilds
+      # from the docstring -- needed when a caller mutates the docstring
+      # directly (e.g. applying `@!override`'s `@overload` tags to an
+      # already-cached pin) and needs the new tags to take effect.
       #
-      # Unlike #reset_generated!, which only resets state already computed
-      # for the current signatures, this drops the memoized array itself --
-      # needed when a caller mutates the docstring directly (e.g. applying
-      # a `@!override`'s `@overload` tags to an already-cached pin) and
-      # needs the new tags to actually take effect.
-      #
-      # With no `@overload` tag present, #signatures instead regenerates
-      # from this pin's own #parameters, which is empty or stale for many
-      # RBS/combined pins -- callers should only invalidate when the
-      # docstring actually gained or lost `@overload` tags.
+      # Only call this when `@overload` tags were added or removed: with
+      # none present, #signatures regenerates from this pin's own
+      # #parameters, which is empty or stale for many RBS/combined pins.
       #
       # @return [void]
       def invalidate_signatures!

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -101,6 +101,26 @@ module Solargraph
         nil
       end
 
+      # Discard any memoized #signatures and #overloads so the next read
+      # rebuilds them from the docstring.
+      #
+      # Unlike #reset_generated!, which only resets state already computed
+      # for the current signatures, this drops the memoized array itself --
+      # needed when a caller mutates the docstring directly (e.g. applying
+      # a `@!override`'s `@overload` tags to an already-cached pin) and
+      # needs the new tags to actually take effect.
+      #
+      # With no `@overload` tag present, #signatures instead regenerates
+      # from this pin's own #parameters, which is empty or stale for many
+      # RBS/combined pins -- callers should only invalidate when the
+      # docstring actually gained or lost `@overload` tags.
+      #
+      # @return [void]
+      def invalidate_signatures!
+        @signatures = nil
+        @overloads = nil
+      end
+
       def all_rooted?
         super && parameters.all?(&:all_rooted?) && (!block || block&.all_rooted?) && signatures.all?(&:all_rooted?)
       end

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -101,14 +101,9 @@ module Solargraph
         nil
       end
 
-      # Discards memoized #signatures/#overloads so the next read rebuilds
-      # from the docstring -- needed when a caller mutates the docstring
-      # directly (e.g. applying `@!override`'s `@overload` tags to an
-      # already-cached pin) and needs the new tags to take effect.
-      #
-      # Only call this when `@overload` tags were added or removed: with
-      # none present, #signatures regenerates from this pin's own
-      # #parameters, which is empty or stale for many RBS/combined pins.
+      # Discards memoized #signatures/#overloads so a docstring mutation
+      # (e.g. `@!override` adding `@overload` tags) takes effect on the
+      # next read. Only call when `@overload` tags changed.
       #
       # @return [void]
       def invalidate_signatures!

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -101,14 +101,20 @@ module Solargraph
         nil
       end
 
-      # Discards memoized #signatures/#overloads so a docstring mutation
-      # (e.g. `@!override` adding `@overload` tags) takes effect on the
-      # next read. Only call when `@overload` tags changed.
+      # Apply the `@overload` tags an `@!override` just added. RBS-sourced
+      # signatures cannot be rebuilt from the docstring, so they are kept
+      # behind the new overloads; docstring-derived ones are rebuilt, which
+      # also makes a repeated call idempotent.
       #
       # @return [void]
-      def invalidate_signatures!
-        @signatures = nil
+      def apply_override_overloads!
+        previous = @signatures
         @overloads = nil
+        return if docstring.tags(:overload).none?(&:parameters)
+
+        keep = previous ? previous.select { |sig| sig.source == :rbs } : []
+        @signatures = keep.empty? ? nil : overloads + keep
+        nil
       end
 
       def all_rooted?

--- a/spec/api_map/index_spec.rb
+++ b/spec/api_map/index_spec.rb
@@ -61,4 +61,67 @@ describe Solargraph::ApiMap::Index do
       expect(first_parameter.return_type.tag).to eq('String')
     end
   end
+
+  describe '#map_overrides with @overload tags' do
+    let(:passthrough) do
+      Solargraph::Pin::Namespace.new(name: 'Passthrough')
+    end
+
+    let(:identity) do
+      meth = Solargraph::Pin::Method.new(name: 'identity',
+                                         scope: :instance,
+                                         parameters: [],
+                                         closure: passthrough)
+      param = Solargraph::Pin::Parameter.new(name: 'arguments', closure: meth)
+      meth.parameters << param
+      meth
+    end
+
+    let(:identity_override) do
+      Solargraph::Pin::Reference::Override.from_comment('Passthrough#identity', <<~COMMENT)
+        @overload identity(arguments)
+          @param arguments [Array<Hash>]
+          @return [Array<Hash>]
+        @overload identity(arguments)
+          @param arguments [Array<String>]
+          @return [Array<String>]
+      COMMENT
+    end
+
+    let(:input_pins) do
+      [
+        passthrough,
+        identity,
+        identity_override
+      ]
+    end
+
+    it 'produces one dispatchable signature per @overload tag, not just the first' do
+      method_pin = output_pins.find { |pin| pin.path == 'Passthrough#identity' }
+      expect(method_pin.signatures.length).to eq(2)
+      expect(method_pin.signatures.map { |sig| sig.parameters.first.return_type.tag }).to eq(['Array<Hash>', 'Array<String>'])
+      expect(method_pin.signatures.map { |sig| sig.return_type.tag }).to eq(['Array<Hash>', 'Array<String>'])
+    end
+
+    context 'when overriding a method that already had its signatures computed' do
+      let(:input_pins) do
+        [
+          passthrough,
+          identity,
+          identity_override
+        ]
+      end
+
+      it 'still applies every @overload tag, not zero of them' do
+        # Force memoization of the original (un-overridden) signatures,
+        # simulating an earlier pass over the ApiMap having already
+        # read #signatures before the override was applied.
+        identity.signatures
+
+        method_pin = output_pins.find { |pin| pin.path == 'Passthrough#identity' }
+        expect(method_pin.signatures.length).to eq(2)
+        expect(method_pin.signatures.map { |sig| sig.return_type.tag }).to eq(['Array<Hash>', 'Array<String>'])
+      end
+    end
+  end
 end

--- a/spec/api_map/index_spec.rb
+++ b/spec/api_map/index_spec.rb
@@ -113,9 +113,7 @@ describe Solargraph::ApiMap::Index do
       end
 
       it 'still applies every @overload tag, not zero of them' do
-        # Force memoization of the original (un-overridden) signatures,
-        # simulating an earlier pass over the ApiMap having already
-        # read #signatures before the override was applied.
+        # Simulates #signatures already being read before the override applied.
         identity.signatures
 
         method_pin = output_pins.find { |pin| pin.path == 'Passthrough#identity' }
@@ -162,10 +160,7 @@ describe Solargraph::ApiMap::Index do
 
     context 'when overriding a method that already had its signatures computed' do
       it 'still redefines the return type' do
-        # Force memoization before the override applies, matching how a
-        # real consumer (e.g. solargraph-rspec's @!override annotations
-        # for ActionController::TestCase::Behavior#request/#response)
-        # can hit a pin whose signatures were already resolved.
+        # Mirrors solargraph-rspec's @!override hitting an already-resolved pin.
         measure.signatures
 
         method_pin = output_pins.find { |pin| pin.path == 'Benchmark.measure' }

--- a/spec/api_map/index_spec.rb
+++ b/spec/api_map/index_spec.rb
@@ -124,4 +124,53 @@ describe Solargraph::ApiMap::Index do
       end
     end
   end
+
+  # https://solargraph.org/guides/yard documents @!override with a bare
+  # @return tag (no @overload) as its primary example, using
+  # Benchmark.measure as the sample target:
+  #
+  #   # @!override Benchmark.measure
+  #   #   @return [Benchmark::Tms]
+  describe '#map_overrides with a bare @return tag' do
+    let(:benchmark_module) do
+      Solargraph::Pin::Namespace.new(name: 'Benchmark')
+    end
+
+    let(:measure) do
+      Solargraph::Pin::Method.new(name: 'measure',
+                                  scope: :class,
+                                  parameters: [],
+                                  closure: benchmark_module)
+    end
+
+    let(:measure_override) do
+      Solargraph::Pin::Reference::Override.from_comment('Benchmark.measure', '@return [Benchmark::Tms]')
+    end
+
+    let(:input_pins) do
+      [
+        benchmark_module,
+        measure,
+        measure_override
+      ]
+    end
+
+    it 'redefines the return type documented on solargraph.org' do
+      method_pin = output_pins.find { |pin| pin.path == 'Benchmark.measure' }
+      expect(method_pin.return_type.tag).to eq('Benchmark::Tms')
+    end
+
+    context 'when overriding a method that already had its signatures computed' do
+      it 'still redefines the return type' do
+        # Force memoization before the override applies, matching how a
+        # real consumer (e.g. solargraph-rspec's @!override annotations
+        # for ActionController::TestCase::Behavior#request/#response)
+        # can hit a pin whose signatures were already resolved.
+        measure.signatures
+
+        method_pin = output_pins.find { |pin| pin.path == 'Benchmark.measure' }
+        expect(method_pin.return_type.tag).to eq('Benchmark::Tms')
+      end
+    end
+  end
 end

--- a/spec/api_map/index_spec.rb
+++ b/spec/api_map/index_spec.rb
@@ -168,4 +168,50 @@ describe Solargraph::ApiMap::Index do
       end
     end
   end
+
+  # The signatures of an RBS-sourced method live only on the pin -- the
+  # docstring cannot express them -- so an override must refine that set
+  # rather than rebuild it from the docstring alone.
+  describe '#map_overrides on a method whose signatures came from RBS' do
+    let(:collection) do
+      Solargraph::Pin::Namespace.new(name: 'Collection')
+    end
+
+    let(:first) do
+      meth = Solargraph::Pin::Method.new(name: 'first',
+                                         scope: :instance,
+                                         parameters: [],
+                                         closure: collection,
+                                         signatures: [])
+      count = Solargraph::Pin::Parameter.new(name: 'count',
+                                             closure: meth,
+                                             return_type: Solargraph::ComplexType.parse('Integer'))
+      meth.signatures << Solargraph::Pin::Signature.new(parameters: [count],
+                                                        return_type: Solargraph::ComplexType.parse('Array<String>'),
+                                                        closure: meth,
+                                                        source: :rbs)
+      meth
+    end
+
+    let(:first_override) do
+      Solargraph::Pin::Reference::Override.from_comment('Collection#first', <<~COMMENT)
+        @overload first(count)
+          @param count [Symbol]
+          @return [Array<Symbol>]
+      COMMENT
+    end
+
+    let(:input_pins) do
+      [
+        collection,
+        first,
+        first_override
+      ]
+    end
+
+    it 'keeps the RBS signature the override did not describe' do
+      method_pin = output_pins.find { |pin| pin.path == 'Collection#first' }
+      expect(method_pin.signatures.map { |sig| sig.return_type.tag }).to eq(['Array<Symbol>', 'Array<String>'])
+    end
+  end
 end


### PR DESCRIPTION
**Claude:**

**Problem:** An `@!override` with two `@overload` tags only ever applies the first one, so Solargraph rejects calls that actually match the second.

```ruby
# @!override Passthrough#identity
#   @overload identity(arguments)
#     @param arguments [Array<Hash>]
#     @return [Array<Hash>]
#   @overload identity(arguments)
#     @param arguments [Array<String>]
#     @return [Array<String>]

Passthrough.identity(['str'])
# Solargraph flags this: expected Array<Hash>, got Array<String>
# Wrong -- the second @overload matches, but only the first ever applies
```

On RBS-sourced pins like `Array#sum`, the override doesn't apply at all — Solargraph keeps using the original untyped signature.

**Solution:** Apply all of an override's tags to the docstring before invalidating `@signatures`/`@overloads` once, gated on the override actually carrying `@overload` tags, since an unconditional invalidate broke 34 unrelated specs that only redefine a return type via bare `@return`/`@param`.

Full suite green; one pre-existing test-order flake on `master`, unrelated to this change.
