### PR TITLE
Add time_limit_seconds guards to 7 slow specs

### DIFF
--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -117,15 +117,15 @@ describe Solargraph::ApiMap do
     end
   end
 
-  describe '#get_method_stack' do
+  describe '#get_method_stack', time_limit_seconds: 400 do
     let(:out) { StringIO.new }
     let(:api_map) { described_class.load_with_cache(Dir.pwd, out) }
 
-    context 'with stdlib that has vital dependencies' do
+    context 'with stdlib that has vital dependencies', time_limit_seconds: 400 do
       let(:external_requires) { ['yaml'] }
       let(:method_stack) { api_map.get_method_stack('YAML', 'safe_load', scope: :class) }
 
-      it 'handles the YAML gem aliased to Psych' do
+      it 'handles the YAML gem aliased to Psych', time_limit_seconds: 400 do
         expect(method_stack).not_to be_empty
       end
     end

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -7,7 +7,7 @@ describe Solargraph::ApiMap do
     @api_map = described_class.new
   end
 
-  it 'returns core methods' do
+  it 'returns core methods', time_limit_seconds: 200 do
     pins = @api_map.get_methods('String')
     expect(pins.map(&:path)).to include('String#upcase')
   end

--- a/spec/language_server/host_spec.rb
+++ b/spec/language_server/host_spec.rb
@@ -275,7 +275,7 @@ describe Solargraph::LanguageServer::Host do
       expect(symbols).not_to be_empty
     end
 
-    it 'opens a file outside of prepared libraries' do
+    it 'opens a file outside of prepared libraries', time_limit_seconds: 200 do
       @host.prepare(File.absolute_path(File.join('spec', 'fixtures', 'workspace')))
       @host.open('file:///file.rb', 'class Foo; end', 1)
       symbols = @host.document_symbols('file:///file.rb')

--- a/spec/language_server/protocol_spec.rb
+++ b/spec/language_server/protocol_spec.rb
@@ -424,7 +424,7 @@ describe Protocol do
     expect(response['result']['available']).to be_a(String)
   end
 
-  it 'handles $/solargraph/documentGems' do
+  it 'handles $/solargraph/documentGems', time_limit_seconds: 200 do
     @protocol.request '$/solargraph/documentGems', {}
     response = @protocol.response
     expect(response['error']).to be_nil

--- a/spec/workspace/gemspecs_fetch_dependencies_spec.rb
+++ b/spec/workspace/gemspecs_fetch_dependencies_spec.rb
@@ -77,7 +77,7 @@ describe Solargraph::Workspace::Gemspecs, '#fetch_dependencies' do
     context 'with gem that exists in our bundle' do
       let(:gem_name) { 'undercover' }
 
-      it 'finds dependencies' do
+      it 'finds dependencies', time_limit_seconds: 200 do
         expect(deps.map(&:name)).to include('ast')
       end
     end
@@ -85,7 +85,7 @@ describe Solargraph::Workspace::Gemspecs, '#fetch_dependencies' do
     context 'with gem does not exist in our bundle' do
       let(:gem_name) { 'activerecord' }
 
-      it 'gives a useful message' do
+      it 'gives a useful message', time_limit_seconds: 200 do
         dep_names = nil
         output = capture_both { dep_names = deps.map(&:name) }
         expect(output).to include('Please install the gem activerecord')


### PR DESCRIPTION
## Summary
- Splits the `time_limit_seconds:` RSpec metadata additions out of castwide/solargraph#1252 into their own PR, per review request there.
- Tags the 7 slowest specs found across `spec/api_map_method_spec.rb`, `spec/api_map_spec.rb`, `spec/language_server/host_spec.rb`, `spec/language_server/protocol_spec.rb`, and `spec/workspace/gemspecs_fetch_dependencies_spec.rb` with an explicit time budget (200-400s).

Companion to apiology/solargraph#33 (Add rspec-time-guard to catch hanging specs), which adds the mechanism that reads this metadata.

## Test plan
- [x] `bundle exec rspec spec/api_map_method_spec.rb spec/api_map_spec.rb spec/language_server/host_spec.rb spec/language_server/protocol_spec.rb spec/workspace/gemspecs_fetch_dependencies_spec.rb` - 149 examples, 0 failures
- [x] `bundle exec rubocop` on the 5 modified files - no new offenses

This PR was written by Claude, Anthropic AI assistant, on behalf of @apiology.