### PR TITLE
Resolve a module's ivar types from its includers

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -382,8 +382,27 @@ module Solargraph
     # @param scope [Symbol] :instance or :class
     # @return [Array<Solargraph::Pin::InstanceVariable>]
     def get_instance_variable_pins namespace, scope = :instance
+      result = own_instance_variable_pins(namespace, scope)
+
+      includer_fqns_list = store.get_includers(namespace)
+      unless includer_fqns_list.empty?
+        per_includer = includer_fqns_list.map { |includer_fqns| own_instance_variable_pins(includer_fqns, scope) }
+        result.concat merge_includer_instance_variable_pins(per_includer)
+      end
+
+      result
+    end
+
+    # Instance variable pins assigned directly in namespace or inherited
+    # through its superclass chain - not through any module it includes.
+    # Shared by #get_instance_variable_pins for both the queried namespace
+    # and each of its includers.
+    #
+    # @param namespace [String] A fully qualified namespace
+    # @param scope [Symbol] :instance or :class
+    # @return [Array<Solargraph::Pin::InstanceVariable>]
+    def own_instance_variable_pins namespace, scope
       result = []
-      [namespace]
       result.concat store.get_instance_variables(namespace, scope)
       sc_fqns = namespace
       while (sc = store.get_superclass(sc_fqns))
@@ -393,6 +412,28 @@ module Solargraph
       end
       result
     end
+    private :own_instance_variable_pins
+
+    # Only accept includer-sourced ivar pins for a name when every includer
+    # that assigns it agrees on the type. If two includers assign the same
+    # ivar name with conflicting types, a module method reading that ivar
+    # could be looking at either one, so exclude the name entirely rather
+    # than pick a includer's pin arbitrarily.
+    #
+    # @param per_includer [Array<Array<Solargraph::Pin::InstanceVariable>>]
+    # @return [Array<Solargraph::Pin::InstanceVariable>]
+    def merge_includer_instance_variable_pins per_includer
+      # @type [Hash{String => Array<Solargraph::Pin::InstanceVariable>}]
+      pins_by_name = per_includer.flatten.group_by(&:name)
+      # @type [Array<Solargraph::Pin::InstanceVariable>]
+      result = []
+      pins_by_name.each_value do |pins|
+        types = pins.map { |pin| pin.probe(self).tag }.uniq
+        result.concat(pins) if types.length <= 1
+      end
+      result
+    end
+    private :merge_includer_instance_variable_pins
 
     # Find a variable pin by name and where it is used.
     #

--- a/lib/solargraph/api_map/store.rb
+++ b/lib/solargraph/api_map/store.rb
@@ -32,6 +32,7 @@ module Solargraph
 
         # @todo Fix this map
         @fqns_pins_map = nil
+        @includer_map = nil
         return catalog(pinsets) if changed.zero?
 
         # @sg-ignore Need to add nil check here
@@ -110,6 +111,15 @@ module Solargraph
       # @return [Array<Pin::Reference::Include>]
       def get_includes fqns
         include_references[fqns] || []
+      end
+
+      # Fully qualified namespaces that include the given module, directly
+      # or transitively (an includer of an includer of `fqns` is included).
+      #
+      # @param fqns [String]
+      # @return [Array<String>]
+      def get_includers fqns
+        includer_map[fqns] || []
       end
 
       # @param fqns [String]
@@ -314,6 +324,7 @@ module Solargraph
         @index = @index.merge(block.call) if block
         constants.clear
         cached_qualify_superclass.clear
+        @includer_map = nil
         true
       end
 
@@ -368,6 +379,57 @@ module Solargraph
       # @return [Enumerable<Pin::InstanceVariable>]
       def all_instance_variables
         index.pins_by_class(Pin::InstanceVariable)
+      end
+
+      # Inverts the forward include_references index (includer fqns -> its
+      # included module refs) into module fqns -> includer fqns, closed
+      # transitively so a module included by another included module still
+      # resolves back to the original includer.
+      #
+      # @return [Hash{String => Array<String>}]
+      def includer_map
+        @includer_map ||= begin
+          direct = Hash.new { |h, k| h[k] = [] }
+          # Snapshot the keys before iterating: include_references is a
+          # Hash.new{...} that inserts an empty array for any missing key
+          # it's read with, and #constants.dereference below can read other
+          # keys of this same hash as a side effect (resolving an ancestor
+          # chain, via #get_includes' own `include_references[fqns]`) -
+          # #each_key would iterate the live hash and raise "can't add a
+          # new key into hash during iteration" the moment that happens.
+          # rubocop:disable Style/HashEachMethods -- see comment above
+          include_references.keys.each do |includer_fqns|
+            include_references.fetch(includer_fqns, []).each do |ref|
+              module_fqns = constants.dereference(ref)
+              next unless module_fqns
+              direct[module_fqns] << includer_fqns
+            end
+          end
+          # rubocop:enable Style/HashEachMethods
+
+          Hash.new { |h, k| h[k] = [] }.tap do |result|
+            direct.each_key { |module_fqns| result[module_fqns] = transitive_includers(module_fqns, direct) }
+          end
+        end
+      end
+
+      # @param module_fqns [String]
+      # @param direct [Hash{String => Array<String>}]
+      # @return [Array<String>]
+      def transitive_includers module_fqns, direct
+        visited = Set.new
+        # #fetch instead of #[] - direct is a Hash.new{...} that would
+        # otherwise insert an empty array for any fqns queried here that
+        # has no includers of its own, mutating the hash #includer_map is
+        # still iterating over above.
+        queue = direct.fetch(module_fqns, []).dup
+        until queue.empty?
+          current = queue.shift
+          next if visited.include?(current)
+          visited.add(current)
+          queue.concat(direct.fetch(current, []))
+        end
+        visited.to_a
       end
 
       # @param fqns [String]

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -415,6 +415,74 @@ describe Solargraph::ApiMap do
     expect(pins.map(&:name)).to include('@foo')
   end
 
+  it 'gets instance variables assigned by a single includer of the queried module' do
+    source = Solargraph::Source.load_string(%(
+      module Loggable
+        def log_message
+          @logger
+        end
+      end
+      class Widget
+        include Loggable
+        def initialize
+          @logger = Logger.new($stdout)
+        end
+      end
+    ))
+    @api_map.map source
+    pins = @api_map.get_instance_variable_pins('Loggable')
+    expect(pins.map(&:name)).to include('@logger')
+  end
+
+  it 'gets instance variables through a transitive includer' do
+    source = Solargraph::Source.load_string(%(
+      module Loggable
+        def log_message
+          @logger
+        end
+      end
+      module LoggableWidget
+        include Loggable
+      end
+      class Widget
+        include LoggableWidget
+        def initialize
+          @logger = Logger.new($stdout)
+        end
+      end
+    ))
+    @api_map.map source
+    pins = @api_map.get_instance_variable_pins('Loggable')
+    expect(pins.map(&:name)).to include('@logger')
+  end
+
+  it 'excludes instance variables that conflicting includers assign with different types' do
+    source = Solargraph::Source.load_string(%(
+      module Loggable
+        def log_message
+          @logger
+        end
+      end
+      class WidgetA
+        include Loggable
+        def initialize
+          # @return [Logger]
+          @logger = Logger.new($stdout)
+        end
+      end
+      class WidgetB
+        include Loggable
+        def initialize
+          # @return [String]
+          @logger = 'not a logger'
+        end
+      end
+    ))
+    @api_map.map source
+    pins = @api_map.get_instance_variable_pins('Loggable')
+    expect(pins.map(&:name)).not_to include('@logger')
+  end
+
   it 'gets methods from extended modules' do
     source = Solargraph::Source.load_string(%(
       module Mixin


### PR DESCRIPTION
**Claude:**

## Summary

`get_instance_variable_pins('Loggable')` returned `[]` for a module whose methods read an ivar only assigned by classes that include it — it only walked `ApiMap::Store#get_superclass`, never the include direction. This made a `@return`-declared return type on a mixin method that reads an instance variable uninferrable, even when every includer assigns that ivar consistently.

```ruby
module Loggable
  # @return [Logger]
  def log_message
    @logger  # return type could not be inferred
  end
end

class Widget
  include Loggable
  def initialize
    @logger = Logger.new($stdout)
  end
end
```

`Store#includer_map` inverts the existing `include_references` index (includer fqns -> included module refs) into module fqns -> includer fqns, closed transitively so a module included by another included module still resolves back to the original includer. `get_instance_variable_pins` now also walks each includer's own ivar pins (and their superclass chains) for the queried module, gated by `ApiMap#merge_includer_instance_variable_pins`: if two includers assign the same ivar name with conflicting probed types, both are excluded rather than picking one arbitrarily.

Cost: the gate probes every candidate pin's type on each query, so a module with many includers pays O(includers) probes per ivar lookup — did not move suite timing in testing.

## Test plan

- Repro above: return type could not be inferred before, resolves to `Logger` after.
- 3 new specs added to `spec/api_map_spec.rb` (single includer, transitive includer, conflicting-type exclusion) — all pass.
- `spec/api_map_spec.rb`: 70 examples, 0 failures, 4 pending.
- Rubocop clean on the diff (3 pre-existing offenses on `master` in these files, unrelated to this change, confirmed unchanged before/after).
