### PR TITLE
Fix TypeChecker::Rules#level always returning nil

### DIFF
--- a/lib/solargraph/type_checker/rules.rb
+++ b/lib/solargraph/type_checker/rules.rb
@@ -28,7 +28,7 @@ module Solargraph
                   Solargraph.logger.warn "Unrecognized TypeChecker level #{level}, assuming normal"
                   0
                 end
-        @level = LEVELS[LEVELS.values.index(@rank)]
+        @level = LEVELS.key(@rank)
         @overrides = overrides
       end
 

--- a/spec/type_checker/rules_spec.rb
+++ b/spec/type_checker/rules_spec.rb
@@ -36,4 +36,9 @@ describe Solargraph::TypeChecker::Rules do
     expect(rules.validate_calls?).to be(true)
     expect(rules.validate_tags?).to be(true)
   end
+
+  it 'sets level to the matching symbol' do
+    rules = described_class.new(:strong, {})
+    expect(rules.level).to eq(:strong)
+  end
 end


### PR DESCRIPTION
**Claude:**

**Problem:**

`TypeChecker::Rules#level` (`attr_reader :level`, documented `@return [Symbol]`) has silently returned `nil` since it was introduced in 2020 ([38e0da2a9](https://github.com/castwide/solargraph/commit/38e0da2a9), PR #311), and it's public API via the public `attr_reader` `TypeChecker#rules`.

```ruby
LEVELS = { normal: 0, typed: 1, strict: 2, strong: 3, alpha: 4 }.freeze
@rank = LEVELS[level]        # level: Symbol → @rank: Integer
@level = LEVELS[LEVELS.values.index(@rank)]
```

`LEVELS.values.index(@rank)` returns an `Integer`, and indexing the `Symbol`-keyed `LEVELS` hash with an `Integer` never matches any key.

**Solution:**

Replace the broken reverse lookup with `LEVELS.key(@rank)`, `Hash#key`'s correct value-to-key lookup, and add a regression spec.
