### PR TITLE
Bump overcommit to 0.72.0 for worktree merge fix

### DIFF
--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -65,7 +65,7 @@ Gem::Specification.new do |s|
   #
   # even more specific on RuboCop itself, which is written into _todo
   # file.
-  s.add_development_dependency 'overcommit', '~> 0.71.0'
+  s.add_development_dependency 'overcommit', '~> 0.72.0'
   s.add_development_dependency 'rubocop', '~> 1.80.0.0'
   s.add_development_dependency 'rubocop-rake', '~> 0.7.1'
   s.add_development_dependency 'rubocop-rspec', '~> 3.6.0'


### PR DESCRIPTION
**Claude:**

**Problem:** In a `git worktree` — the default working style for AI coding agents — merging and committing silently produces a commit that says it is a merge but that git does not record as one, so the branch still looks unmerged and gets merged again.

    $ git log --oneline -1
    abc1234 Merge branch 'my-branch'      # says merged

    $ git branch --merged | grep my-branch
                                          # nothing — git disagrees

**Solution:** Bump to overcommit 0.72.0, which carries sds/overcommit#887 — 0.71.0 looked for git's merge bookkeeping in the main checkout rather than the worktree's own.

