### PR TITLE
Rebind block self from RBS block self types

### DIFF
--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -106,8 +106,8 @@ module Solargraph
         receiver_pin = chain.define(api_map, closure, locals).first
         return ComplexType::UNDEFINED unless receiver_pin
 
-        types = receiver_pin.docstring.tag(:yieldreceiver)&.types
-        return ComplexType::UNDEFINED unless types&.any?
+        bound = declared_binding(receiver_pin)
+        return ComplexType::UNDEFINED if bound.nil?
 
         name_pin = self
         # if we have Foo.bar { |x| ... }, and the bar method references self...
@@ -120,7 +120,22 @@ module Solargraph
                    closure.full_context
                  end
 
-        ComplexType.try_parse(*types).qualify(api_map, *receiver_pin.gates).self_to_type(target)
+        bound.qualify(api_map, *receiver_pin.gates).self_to_type(target)
+      end
+
+      # A @yieldreceiver tag outranks an RBS `[self: Foo]` binding, because
+      # CoreFills uses the tag to state a binding more precisely than RBS
+      # does: Module#define_method is `[self: top]` in RBS and
+      # `::Object<self>` here.
+      #
+      # @param receiver_pin [Pin::Base]
+      # @return [ComplexType, nil]
+      def declared_binding receiver_pin
+        types = receiver_pin.docstring.tag(:yieldreceiver)&.types
+        return ComplexType.try_parse(*types) if types&.any?
+        return nil unless receiver_pin.is_a?(Pin::Method)
+
+        receiver_pin.block&.self_type
       end
     end
   end

--- a/lib/solargraph/pin/signature.rb
+++ b/lib/solargraph/pin/signature.rb
@@ -7,6 +7,28 @@ module Solargraph
       # to the method pin
       attr_writer :closure
 
+      # What `self` is inside this signature's body, from an RBS block
+      # binding like `{ () [self: Foo] -> void }`. Nil when the source
+      # declares no binding.
+      #
+      # @return [ComplexType, nil]
+      attr_reader :self_type
+
+      # @param self_type [ComplexType, nil]
+      # @param [Hash{Symbol => Object}] splat
+      def initialize self_type: nil, **splat
+        super(**splat)
+        @self_type = self_type
+      end
+
+      # @param other [self]
+      # @param attrs [Hash{::Symbol => Object}]
+      #
+      # @return [self]
+      def combine_with other, attrs = {}
+        super(other, { self_type: self_type || other.self_type }.merge(attrs))
+      end
+
       def generics
         # @type [Array<::String, nil>]
         @generics ||= [].freeze

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -549,7 +549,8 @@ module Solargraph
           block = if overload.method_type.block
                     block_parameters, block_return_type = parts_of_function(overload.method_type.block, pin, implicit_nil)
                     Pin::Signature.new(generics: generics, parameters: block_parameters, return_type: block_return_type, source: :rbs,
-                                       type_location: type_location, closure: pin)
+                                       type_location: type_location, closure: pin,
+                                       self_type: RbsTranslator.block_self_type(overload.method_type))
                   end
           Pin::Signature.new(generics: generics, parameters: signature_parameters, return_type: signature_return_type, block: block, source: :rbs,
                              type_location: type_location, closure: pin)

--- a/lib/solargraph/rbs_translator.rb
+++ b/lib/solargraph/rbs_translator.rb
@@ -12,7 +12,10 @@ module Solargraph
       'NilClass' => 'nil'
     }
 
-    # @param type [RBS::Types::Bases::Base]
+    # RBS::Types::t is the alias the rbs gem declares for every type node;
+    # only the Bases::* members of it descend from Bases::Base.
+    #
+    # @param type [RBS::Types::t]
     # @return [ComplexType]
     def self.to_complex_type(type)
       tag = type_to_tag(type)
@@ -74,6 +77,26 @@ module Solargraph
       params
     end
 
+    # The `[self: Foo]` binding on a method's block, if it declares one.
+    #
+    # Two forms are skipped. RBS `self` (`Module#class_eval`) means the
+    # receiver unchanged, which no Solargraph tag expresses: it translates to
+    # `self`, and `self_to_type` reduces `Class<Foo>` to `Foo` — right for
+    # RBS `instance`, wrong here. A type variable (`Data.define`'s
+    # `[self: KLASS]`) cannot name a namespace to bind to at all.
+    #
+    # @param method_type [RBS::MethodType]
+    # @return [ComplexType, nil]
+    def self.block_self_type method_type
+      rbs_type = method_type.block&.self_type
+      return nil if rbs_type.nil? || rbs_type.is_a?(RBS::Types::Bases::Self)
+
+      type = to_complex_type(rbs_type)
+      return nil if type.undefined? || type.generic?
+
+      type
+    end
+
     # @param method_type [RBS::MethodType]
     # @param closure [Pin::Closure]
     # @param parameter_names [Array<String>]
@@ -89,7 +112,7 @@ module Solargraph
       block = if method_type.block
         block_parameters = to_parameter_pins(method_type.block, closure)
         block_return_type = to_complex_type(method_type.block.type.return_type)
-        Pin::Signature.new(generics: generics, parameters: block_parameters, return_type: block_return_type, source: :rbs, type_location: closure.location, closure: closure)
+        Pin::Signature.new(generics: generics, parameters: block_parameters, return_type: block_return_type, source: :rbs, type_location: closure.location, closure: closure, self_type: block_self_type(method_type))
       end
       Pin::Signature.new(generics: generics, parameters: parameters, return_type: return_type, block: block, source: :rbs, type_location: closure.location, closure: closure)
     end

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -74,6 +74,40 @@ describe Solargraph::RbsMap::Conversions do
       end
     end
 
+    context 'with a block binding self to a class' do
+      subject(:block_signature) { conversions.pins.find { |pin| pin.path == 'Foo.build' }.signatures.first.block }
+
+      let(:rbs) do
+        <<~RBS
+          class Bar
+          end
+          class Foo
+            def self.build: () { () [self: Bar] -> void } -> void
+          end
+        RBS
+      end
+
+      it 'carries the binding on the block signature, so Pin::Block can rebind without a @yieldreceiver tag' do
+        expect(block_signature.self_type.tag).to eq('Bar')
+      end
+    end
+
+    context 'with a block binding self to the receiver' do
+      subject(:block_signature) { conversions.pins.find { |pin| pin.path == 'Foo.build' }.signatures.first.block }
+
+      let(:rbs) do
+        <<~RBS
+          class Foo
+            def self.build: () { () [self: self] -> void } -> void
+          end
+        RBS
+      end
+
+      it 'drops the binding, because self_to_type would reduce the receiver to its instance type' do
+        expect(block_signature.self_type).to be_nil
+      end
+    end
+
     context 'with untyped response' do
       subject(:method_pin) { conversions.pins.find { |pin| pin.path == 'Foo#bar' } }
 

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -641,6 +641,20 @@ describe Solargraph::SourceMap::Clip do
     expect(clip.complete.pins.map(&:path)).to include('Par#hidden')
   end
 
+  it 'rebinds a block to Refinement inside Module#refine, whose only binding is RBS [self: Refinement]' do
+    source = Solargraph::Source.load_string(%(
+      module Mod
+        refine String do
+          tar
+        end
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    clip = api_map.clip_at('test.rb', [3, 13])
+    expect(clip.complete.pins.map(&:path)).to include('Refinement#target')
+  end
+
   it 'processes @yieldreceiver tags referencing instances from classes' do
     other = Solargraph::SourceMap.load_string(%(
       module Mixin


### PR DESCRIPTION
**Claude:**

**Problem:** Calling an instance method inside an `after_commit` block is reported as unresolved, even though activerecord's RBS declares the block's `self` to be the model instance.

    class Thing < ActiveRecord::Base
      def helper; end

      after_commit do
        helper  # Unresolved call to helper
      end
    end

Every RBS block binding is affected, not just this one: `{ () [self: Foo] -> void }` is dropped during conversion, so today only a YARD `@yieldreceiver` tag can rebind a block.

**Solution:** `Pin::Signature` now carries the RBS block self type, and `Pin::Block#maybe_rebind` falls back to it when no `@yieldreceiver` tag applies.

