### PR TITLE
Remove dead TypeMethods#qualify

### DIFF
--- a/lib/solargraph/complex_type/type_methods.rb
+++ b/lib/solargraph/complex_type/type_methods.rb
@@ -209,25 +209,6 @@ module Solargraph
         tag == other.tag
       end
 
-      # Generate a ComplexType that fully qualifies this type's namespaces.
-      #
-      # @param api_map [ApiMap] The ApiMap that performs qualification
-      # @param context [String] The namespace from which to resolve names
-      # @return [self, ComplexType, UniqueType] The generated ComplexType
-      def qualify api_map, context = ''
-        transform do |t|
-          next t if t.name == GENERIC_TAG_NAME
-          next t if t.duck_type? || t.void? || t.undefined?
-          recon = (t.rooted? ? '' : context)
-          fqns = api_map.qualify(t.name, recon)
-          if fqns.nil?
-            next UniqueType::BOOLEAN if t.tag == 'Boolean'
-            next UniqueType::UNDEFINED
-          end
-          t.recreate(new_name: fqns, make_rooted: true)
-        end
-      end
-
       # @yieldparam [UniqueType]
       # @return [void]
       # @overload each_unique_type()


### PR DESCRIPTION
**Problem:** `ComplexType::TypeMethods#qualify` cannot be called. `TypeMethods` is included only by `UniqueType`, which defines its own `#qualify`, and a method defined directly in a class wins over one from an included module. `ComplexType` does not include `TypeMethods` at all — it reaches the module only through a `method_missing` forward to `@items.first`, which never fires for a name the class defines itself, and it defines its own `#qualify` too.

```ruby
UniqueType.instance_method(:qualify).owner   # => UniqueType
ComplexType.instance_method(:qualify).owner  # => ComplexType
ComplexType.ancestors.include?(TypeMethods)  # => false
```

The two live implementations also take `(api_map, *gates)` rather than this one's `(api_map, context = '')`, so a caller written against it would not work against either.

**Solution:** Delete it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
