### PR TITLE
Infer a block parameter whose receiver is another block call

### DIFF
--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -492,9 +492,9 @@ module Solargraph
 
       # @param new_name [String, nil]
       # @param make_rooted [Boolean, nil]
-      # @param new_key_types [Array<ComplexType>, nil]
+      # @param new_key_types [Array<ComplexType, UniqueType>, nil]
       # @param make_rooted [Boolean, nil]
-      # @param new_subtypes [Array<ComplexType>, nil]
+      # @param new_subtypes [Array<ComplexType, UniqueType>, nil]
       # @return [self]
       def recreate new_name: nil, make_rooted: nil, new_key_types: nil, new_subtypes: nil
         raise "Please remove leading :: and set rooted instead - #{new_name}" if new_name&.start_with?('::')

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -374,9 +374,26 @@ module Solargraph
           # @sg-ignore Need to add nil check here
           node_location = Solargraph::Location.from_node(block.node)
           return if node_location.nil?
-          block_pins = api_map.get_block_pins
-          # @sg-ignore Need to add nil check here
-          block_pins.find { |pin| pin.location.contain?(node_location) }
+
+          # block.node is the block's body, so an enclosing block contains it
+          # too; locate_closure_pin picks the innermost, which is this block.
+          position = node_location.range.start
+          closure = api_map.source_map(node_location.filename)
+                           .locate_closure_pin(position.line, position.character)
+          closure if closure.is_a?(Pin::Block)
+        end
+
+        # The block's own parameters. The block declares them, so they are
+        # absent from the caller's locals, and the body cannot resolve without
+        # them.
+        #
+        # @param api_map [ApiMap]
+        # @return [::Array<Pin::Parameter>]
+        def block_parameters api_map
+          block_pin = find_block_pin(api_map)
+          return [] if block_pin.nil?
+
+          block_pin.parameters
         end
 
         # @param api_map [ApiMap]
@@ -391,7 +408,7 @@ module Solargraph
           # here will only be defined inside the block itself and we
           # need to be able to see them
           # @sg-ignore Need to add nil check here
-          block.infer(api_map, block_pin, locals)
+          block.infer(api_map, block_pin, locals | block_parameters(api_map))
         end
 
         protected

--- a/lib/solargraph/source/chain/call.rb
+++ b/lib/solargraph/source/chain/call.rb
@@ -408,7 +408,7 @@ module Solargraph
           # here will only be defined inside the block itself and we
           # need to be able to see them
           # @sg-ignore Need to add nil check here
-          block.infer(api_map, block_pin, locals | block_parameters(api_map))
+          block.infer(api_map, block_pin, locals.union(block_parameters(api_map)))
         end
 
         protected

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1887,6 +1887,50 @@ describe Solargraph::SourceMap::Clip do
     expect(type.to_s).to eq('Set<Integer>')
   end
 
+  it 'infers a block parameter whose receiver is another block call' do
+    source = Solargraph::Source.load_string(%(
+      # @param arr [Array<String>]
+      # @return [void]
+      def chained arr
+        arr.map { |s| s }.each { |t| t.upcase }
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [4, 38])
+    type = clip.infer
+    expect(type.to_s).to eq('String')
+  end
+
+  it 'infers a chained block parameter when the receiver block declares a local' do
+    pending 'only the block parameters join the locals; a local the body assigns does not'
+    source = Solargraph::Source.load_string(%(
+      # @param arr [Array<String>]
+      # @return [void]
+      def chained arr
+        arr.map { |s| x = s; x }.each { |t| t.upcase }
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [4, 45])
+    type = clip.infer
+    expect(type.to_s).to eq('String')
+  end
+
+  it 'keeps same-named parameters of separate blocks distinct' do
+    source = Solargraph::Source.load_string(%(
+      # @param arr [Array<String>]
+      # @param nums [Array<Integer>]
+      # @return [void]
+      def siblings arr, nums
+        arr.map { |v| v }.each { |t| t.upcase }
+        nums.map { |v| v }.each { |u| u.abs }
+      end
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    expect(api_map.clip_at('test.rb', [5, 38]).infer.to_s).to eq('String')
+    expect(api_map.clip_at('test.rb', [6, 39]).infer.to_s).to eq('Integer')
+  end
+
   it 'erases unresolvable class generics' do
     source = Solargraph::Source.load_string(%(
       # @generic T


### PR DESCRIPTION
**Problem:** A block parameter has no type when its receiver is another block call, so ordinary chained enumerable code fails to typecheck.

```ruby
# @param arr [Array<String>]
# @return [void]
def chained arr
  arr.map { |s| s }.each { |t| t.upcase }
  #                             ^ Unresolved call to upcase -- t is undefined, not String
end
```

Any producer whose return generic binds from its own block is affected (`map`, `flat_map`, `group_by`); assigning the receiver to a local first is the only workaround.

**Solution:** `block_call_type` now finds the block pin via `SourceMap#locate_closure_pin` rather than the first pin containing `block.node` — which is the block's *body*, so every enclosing block matched and the outermost won — and adds that pin's own parameters to the locals used to type the body, since a block declares its parameters and the caller's locals never hold them.

A local the body itself assigns is still not visible; a pending example covers that.

Self-typecheck goes 531 to 536. All five are the `internal_or_core?` branch firing on calls that now resolve, not new type errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
