### PR TITLE
Pass the require path to find_by_path

### DIFF
--- a/lib/solargraph/workspace/gemspecs.rb
+++ b/lib/solargraph/workspace/gemspecs.rb
@@ -44,8 +44,7 @@ module Solargraph
         return auto_required_gemspecs_from_bundler if require == 'bundler/require'
 
         # Determine gem name based on the require path
-        file = "lib/#{require}.rb"
-        spec_with_path = Gem::Specification.find_by_path(file)
+        spec_with_path = Gem::Specification.find_by_path(require)
 
         all_gemspecs = all_gemspecs_from_bundle
 
@@ -73,6 +72,7 @@ module Solargraph
 
           # look ourselves just in case this is hanging out somewhere
           # that find_by_path doesn't index
+          file = "lib/#{require}.rb"
           gemspec = all_gemspecs.find do |spec|
             spec = to_gem_specification(spec) unless spec.respond_to?(:files)
 

--- a/spec/workspace/gemspecs_resolve_require_spec.rb
+++ b/spec/workspace/gemspecs_resolve_require_spec.rb
@@ -153,6 +153,31 @@ describe Solargraph::Workspace::Gemspecs, '#resolve_require' do
       end
     end
 
+    context 'with a require path that does not textually match the gem name' do
+      # e.g. activesupport ships as 'active_support' - neither
+      # require.tr('/', '-') nor require.split('/').first can guess
+      # 'activesupport' from 'active_support', so this can only be
+      # resolved via Gem::Specification.find_by_path, and only if the
+      # require path itself (not "lib/#{require}.rb") is passed to it
+      let(:require) { 'active_support' }
+      let(:mismatched_spec) { instance_double(Gem::Specification, name: 'activesupport', files: []) }
+
+      before do
+        allow(Gem::Specification).to receive(:find_by_path).and_call_original
+        allow(Gem::Specification).to receive(:find_by_path).with(require).and_return(mismatched_spec)
+        allow(gemspecs).to receive(:all_gemspecs_from_bundle).and_return([mismatched_spec])
+      end
+
+      it 'resolves to the right known gem' do
+        expect(specs.map(&:name)).to eq(['activesupport'])
+      end
+
+      it 'passes the require path directly to find_by_path, not prefixed with lib/' do
+        specs
+        expect(Gem::Specification).to have_received(:find_by_path).with(require)
+      end
+    end
+
     context 'with Bundler.require' do
       let(:require) { 'bundler/require' }
 


### PR DESCRIPTION
**Problem:** `Gem::Specification.find_by_path` matches a requirable path — the same string that appears in a `require` statement. `resolve_require` was handing it a lib-relative filename instead, which it can never match, so that lookup always returned nil.

```ruby
Gem::Specification.find_by_path("yard")         # => the yard gemspec
Gem::Specification.find_by_path("lib/yard.rb")  # => nil
```

Resolution then fell through to guessing the gem name from the require path and, failing that, scanning every bundled gemspec and reading its file list.

**Solution:** Pass the require path itself, and move the lib-relative filename down to the manual `spec.files` scan, which is the only remaining reader of it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
