### PR TITLE
Resolve RBS type arguments on mixed-in modules

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -759,7 +759,7 @@ module Solargraph
     end
 
     # @param fq_reference_tag [String] A fully qualified whose method should be pulled in
-    # @param namespace_pin [Pin::Base] Namespace pin for the rooted_type
+    # @param namespace_pin [Pin::Base, nil] Namespace pin for the rooted_type
     #   parameter - used to pull generics information
     # @param type [ComplexType] The type which is having its
     #   methods supplemented from fq_reference_tag
@@ -844,7 +844,7 @@ module Solargraph
       if deep && scope == :instance
         store.get_prepends(fqns).reverse.each do |im|
           fqim = store.constants.dereference(im)
-          result.concat inner_get_methods(fqim, scope, visibility, deep, skip, true) unless fqim.nil?
+          result.concat inner_get_methods_from_reference(fqim, namespace_pin, rooted_type, scope, visibility, deep, skip, true) unless fqim.nil?
         end
       end
       # Store#get_methods doesn't know about full tags, just
@@ -876,7 +876,7 @@ module Solargraph
           end
           store.get_extends(fqns).reverse.each do |em|
             fqem = dereference(em)
-            result.concat inner_get_methods(fqem, :instance, visibility, deep, skip, true) unless fqem.nil?
+            result.concat inner_get_methods_from_reference(fqem, namespace_pin, rooted_type, :instance, visibility, deep, skip, true) unless fqem.nil?
           end
           rooted_sc_tag = qualify_superclass(rooted_tag)
           unless rooted_sc_tag.nil?

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -759,7 +759,7 @@ module Solargraph
     end
 
     # @param fq_reference_tag [String] A fully qualified whose method should be pulled in
-    # @param namespace_pin [Pin::Base, nil] Namespace pin for the rooted_type
+    # @param namespace_pin [Pin::Base] Namespace pin for the rooted_type
     #   parameter - used to pull generics information
     # @param type [ComplexType] The type which is having its
     #   methods supplemented from fq_reference_tag

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -759,7 +759,7 @@ module Solargraph
     end
 
     # @param fq_reference_tag [String] A fully qualified whose method should be pulled in
-    # @param namespace_pin [Pin::Base] Namespace pin for the rooted_type
+    # @param namespace_pin [Pin::Base, nil] Namespace pin for the rooted_type
     #   parameter - used to pull generics information
     # @param type [ComplexType] The type which is having its
     #   methods supplemented from fq_reference_tag

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -322,7 +322,7 @@ module Solargraph
       end
     end
 
-    # @param definitions [Pin::Namespace, Pin::Method]
+    # @param definitions [Pin::Namespace, Pin::Method, nil]
     # @param context_type [ComplexType]
     # @return [ComplexType]
     def resolve_generics definitions, context_type

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -322,7 +322,7 @@ module Solargraph
       end
     end
 
-    # @param definitions [Pin::Namespace, Pin::Method, nil]
+    # @param definitions [Pin::Namespace, Pin::Method]
     # @param context_type [ComplexType]
     # @return [ComplexType]
     def resolve_generics definitions, context_type

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -439,7 +439,7 @@ module Solargraph
       # parameters used in this type, and return a new type if
       # possible.
       #
-      # @param definitions [Pin::Namespace, Pin::Method] The module/class/method which uses generic types
+      # @param definitions [Pin::Namespace, Pin::Method, nil] The module/class/method which uses generic types
       # @param context_type [ComplexType] The receiver type
       # @return [UniqueType, ComplexType]
       def resolve_generics definitions, context_type

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -439,7 +439,7 @@ module Solargraph
       # parameters used in this type, and return a new type if
       # possible.
       #
-      # @param definitions [Pin::Namespace, Pin::Method, nil] The module/class/method which uses generic types
+      # @param definitions [Pin::Namespace, Pin::Method] The module/class/method which uses generic types
       # @param context_type [ComplexType] The receiver type
       # @return [UniqueType, ComplexType]
       def resolve_generics definitions, context_type

--- a/lib/solargraph/parser/parser_gem/node_methods.rb
+++ b/lib/solargraph/parser/parser_gem/node_methods.rb
@@ -2,6 +2,7 @@
 
 require 'parser'
 require 'ast'
+require 'rbs'
 
 # https://github.com/whitequark/parser
 # rubocop:disable Metrics/ModuleLength
@@ -79,6 +80,44 @@ module Solargraph
         # @return [Position]
         def get_node_end_position node
           Position.new(node.loc.last_line, node.loc.last_column)
+        end
+
+        # A trailing inline RBS type argument list, e.g. the `#[String]` in
+        # `include Enumerable #[String]`. The inner group recurses so that a
+        # nested `Hash[String, Integer]` is not cut short at its first `]`.
+        TRAILING_TYPE_ARGS = /\A\s*\#(?<outer>\[(?<body>(?:[^\[\]]++|\g<outer>)*)\])/
+
+        # Type arguments from an inline RBS annotation directly after +node+,
+        # as in `class Foo < Array #[String]` or `include Enumerable #[String]`.
+        # RBS requires no space between the hash mark and the bracket; with one,
+        # this is an ordinary comment.
+        #
+        # @param node [Parser::AST::Node] the node the annotation follows
+        # @param code [String] source the node was parsed from
+        # @return [Array<String>]
+        def trailing_rbs_type_args node, code
+          pos = get_node_end_position(node)
+          offset = Position.line_char_to_offset(code, pos.line, pos.character)
+          eol = code.index("\n", offset) || code.length
+          match = code[offset...eol].to_s.match(TRAILING_TYPE_ARGS)
+          return [] unless match
+
+          parse_rbs_type_args match[:body].to_s
+        end
+
+        # Parse an RBS type argument list by wrapping it in a throwaway
+        # generic, which lets RBS split the arguments and gives each one to
+        # RbsTranslator for conversion to Solargraph's own type syntax.
+        #
+        # @param code [String]
+        # @return [Array<String>]
+        def parse_rbs_type_args code
+          type = RBS::Parser.parse_type("Object[#{code}]")
+          return [] unless type.is_a?(RBS::Types::ClassInstance)
+
+          type.args.map { |arg| RbsTranslator.to_complex_type(arg).rooted_tags }
+        rescue RBS::ParsingError
+          []
         end
 
         # @param node [Parser::AST::Node]

--- a/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/namespace_node.rb
@@ -41,26 +41,17 @@ module Solargraph
           private
 
           # Type arguments for a generic superclass in inline RBS syntax, e.g.,
-          # `class Foo < Array #[String]`. Only recognized where RBS defines
-          # it: directly after the superclass, on the same line, with no space
-          # between `#` and `[`. Anything else is an ordinary comment.
+          # `class Foo < Array #[String]`.
           #
           # @return [String, nil]
           def parameters_from_inline_rbs
             superclass = node.children[1]
             return unless superclass
 
-            source = region.source.code
-            pos = get_node_end_position(superclass)
-            offset = Position.line_char_to_offset(source, pos.line, pos.character)
-            eol = source.index("\n", offset) || source.length
-            match = source[offset...eol].to_s.match(/\A\s*#\[([^\]]*)\]/)
-            return unless match
+            args = trailing_rbs_type_args(superclass, region.source.code)
+            return if args.empty?
 
-            code = match[1].strip
-            return if code.empty?
-
-            "<#{code}>"
+            "<#{args.join(', ')}>"
           end
 
           def type_from_node

--- a/lib/solargraph/parser/parser_gem/node_processors/send_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/send_node.rb
@@ -1,11 +1,17 @@
 # frozen_string_literal: true
 
+require 'rbs'
+
 module Solargraph
   module Parser
     module ParserGem
       module NodeProcessors
         class SendNode < Parser::NodeProcessor::Base
           include ParserGem::NodeMethods
+
+          # A trailing inline RBS type argument list, e.g. the `#[String]` in
+          # `include Enumerable #[String]`.
+          TRAILING_TYPE_ARGS = /\A\s*\#(?<outer>\[(?<body>(?:[^\[\]]++|\g<outer>)*)\])/
 
           # @sg-ignore @override is adding, not overriding
           def process
@@ -138,6 +144,7 @@ module Solargraph
                 location: get_node_location(i),
                 closure: cp,
                 name: unpack_name(i),
+                generic_values: mixin_generic_values,
                 source: :parser
               )
             end
@@ -153,6 +160,7 @@ module Solargraph
                 location: get_node_location(i),
                 closure: cp,
                 name: unpack_name(i),
+                generic_values: mixin_generic_values,
                 source: :parser
               )
             end
@@ -175,10 +183,60 @@ module Solargraph
                   location: loc,
                   closure: region.closure,
                   name: unpack_name(i),
+                  generic_values: mixin_generic_values,
                   source: :parser
                 )
               end
             end
+          end
+
+          # Type arguments for a generic module mixed in with inline RBS
+          # syntax, e.g. `include Enumerable #[String]`. RBS recognizes this
+          # for one module argument only, so `include A, B` takes none.
+          #
+          # @return [Array<String>]
+          def mixin_generic_values
+            args = node.children[2..]
+            return [] unless args && args.length == 1
+
+            arg = args.first
+            return [] unless arg.is_a?(AST::Node)
+
+            code = trailing_type_args_code(arg)
+            return [] if code.nil?
+
+            parse_type_args(code)
+          end
+
+          # The text inside a trailing `#[...]` on the same line as +arg+.
+          # RBS requires no space between the `#` and the `[`; with one, this
+          # is an ordinary comment. The inner group recurses so that a nested
+          # `Hash[String, Integer]` is not cut short at its first `]`.
+          #
+          # @param arg [AST::Node]
+          # @return [String, nil]
+          def trailing_type_args_code arg
+            source = region.source.code
+            pos = get_node_end_position(arg)
+            offset = Position.line_char_to_offset(source, pos.line, pos.character)
+            eol = source.index("\n", offset) || source.length
+            match = source[offset...eol].to_s.match(TRAILING_TYPE_ARGS)
+            match && match[:body]
+          end
+
+          # Parse an RBS type argument list by wrapping it in a throwaway
+          # generic, which lets RBS split the arguments and gives each one to
+          # RbsTranslator for conversion to Solargraph's own type syntax.
+          #
+          # @param code [String]
+          # @return [Array<String>]
+          def parse_type_args code
+            type = RBS::Parser.parse_type("Object[#{code}]")
+            return [] unless type.is_a?(RBS::Types::ClassInstance)
+
+            type.args.map { |arg| RbsTranslator.to_complex_type(arg).to_s }
+          rescue RBS::ParsingError
+            []
           end
 
           # @return [void]

--- a/lib/solargraph/parser/parser_gem/node_processors/send_node.rb
+++ b/lib/solargraph/parser/parser_gem/node_processors/send_node.rb
@@ -1,17 +1,11 @@
 # frozen_string_literal: true
 
-require 'rbs'
-
 module Solargraph
   module Parser
     module ParserGem
       module NodeProcessors
         class SendNode < Parser::NodeProcessor::Base
           include ParserGem::NodeMethods
-
-          # A trailing inline RBS type argument list, e.g. the `#[String]` in
-          # `include Enumerable #[String]`.
-          TRAILING_TYPE_ARGS = /\A\s*\#(?<outer>\[(?<body>(?:[^\[\]]++|\g<outer>)*)\])/
 
           # @sg-ignore @override is adding, not overriding
           def process
@@ -202,41 +196,7 @@ module Solargraph
             arg = args.first
             return [] unless arg.is_a?(AST::Node)
 
-            code = trailing_type_args_code(arg)
-            return [] if code.nil?
-
-            parse_type_args(code)
-          end
-
-          # The text inside a trailing `#[...]` on the same line as +arg+.
-          # RBS requires no space between the `#` and the `[`; with one, this
-          # is an ordinary comment. The inner group recurses so that a nested
-          # `Hash[String, Integer]` is not cut short at its first `]`.
-          #
-          # @param arg [AST::Node]
-          # @return [String, nil]
-          def trailing_type_args_code arg
-            source = region.source.code
-            pos = get_node_end_position(arg)
-            offset = Position.line_char_to_offset(source, pos.line, pos.character)
-            eol = source.index("\n", offset) || source.length
-            match = source[offset...eol].to_s.match(TRAILING_TYPE_ARGS)
-            match && match[:body]
-          end
-
-          # Parse an RBS type argument list by wrapping it in a throwaway
-          # generic, which lets RBS split the arguments and gives each one to
-          # RbsTranslator for conversion to Solargraph's own type syntax.
-          #
-          # @param code [String]
-          # @return [Array<String>]
-          def parse_type_args code
-            type = RBS::Parser.parse_type("Object[#{code}]")
-            return [] unless type.is_a?(RBS::Types::ClassInstance)
-
-            type.args.map { |arg| RbsTranslator.to_complex_type(arg).to_s }
-          rescue RBS::ParsingError
-            []
+            trailing_rbs_type_args arg, region.source.code
           end
 
           # @return [void]

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -166,7 +166,7 @@ module Solargraph
         type = build_type(decl.name, decl.args)
         generic_values = type.all_params.map(&:rooted_tags)
         include_pin = Solargraph::Pin::Reference::Include.new(
-          name: type.name,
+          name: type.rooted_name, # reference pins use rooted names
           type_location: location_decl_to_pin_location(decl.location),
           generic_values: generic_values,
           closure: closure,

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -164,9 +164,9 @@ module Solargraph
       # @return [void]
       def convert_self_type_to_pins decl, closure
         type = build_type(decl.name, decl.args)
-        generic_values = type.all_params.map(&:to_s)
+        generic_values = type.all_params.map(&:rooted_tags)
         include_pin = Solargraph::Pin::Reference::Include.new(
-          name: decl.name.relative!.to_s,
+          name: type.name,
           type_location: location_decl_to_pin_location(decl.location),
           generic_values: generic_values,
           closure: closure,
@@ -279,8 +279,7 @@ module Solargraph
         pins.push class_pin
         if decl.super_class
           type = build_type(decl.super_class.name, decl.super_class.args)
-          generic_values = type.all_params.map(&:to_s)
-          superclass_name = decl.super_class.name.to_s
+          generic_values = type.all_params.map(&:rooted_tags)
           pins.push Solargraph::Pin::Reference::Superclass.new(
             type_location: location_decl_to_pin_location(decl.super_class.location),
             closure: class_pin,
@@ -299,7 +298,7 @@ module Solargraph
         class_pin = Solargraph::Pin::Namespace.new(
           type: :module,
           type_location: location_decl_to_pin_location(decl.location),
-          name: decl.name.relative!.to_s,
+          name: fqns(decl.name),
           closure: Solargraph::Pin::ROOT_PIN,
           comments: decl.comment&.string,
           generics: type_parameter_names(decl),
@@ -318,7 +317,7 @@ module Solargraph
       def module_decl_to_pin decl
         module_pin = Solargraph::Pin::Namespace.new(
           type: :module,
-          name: decl.name.relative!.to_s,
+          name: fqns(decl.name),
           type_location: location_decl_to_pin_location(decl.location),
           closure: Solargraph::Pin::ROOT_PIN,
           comments: decl.comment&.string,
@@ -701,9 +700,9 @@ module Solargraph
       # @return [void]
       def include_to_pin decl, closure
         type = build_type(decl.name, decl.args)
-        generic_values = type.all_params.map(&:to_s)
+        generic_values = type.all_params.map(&:rooted_tags)
         pins.push Solargraph::Pin::Reference::Include.new(
-          name: decl.name.relative!.to_s,
+          name: type.rooted_name, # reference pins use rooted names
           type_location: location_decl_to_pin_location(decl.location),
           generic_values: generic_values,
           closure: closure,
@@ -718,8 +717,9 @@ module Solargraph
         type = build_type(decl.name, decl.args)
         generic_values = type.all_params.map(&:rooted_tags)
         pins.push Solargraph::Pin::Reference::Prepend.new(
-          name: decl.name.relative!.to_s,
+          name: type.rooted_name, # reference pins use rooted names
           type_location: location_decl_to_pin_location(decl.location),
+          generic_values: generic_values,
           closure: closure,
           source: :rbs
         )
@@ -732,8 +732,9 @@ module Solargraph
         type = build_type(decl.name, decl.args)
         generic_values = type.all_params.map(&:rooted_tags)
         pins.push Solargraph::Pin::Reference::Extend.new(
-          name: decl.name.relative!.to_s,
+          name: type.rooted_name, # reference pins use rooted names
           type_location: location_decl_to_pin_location(decl.location),
+          generic_values: generic_values,
           closure: closure,
           source: :rbs
         )
@@ -797,9 +798,9 @@ module Solargraph
           # @todo are we handling prepend correctly?
           klass = mixin.is_a?(RBS::AST::Members::Include) ? Pin::Reference::Include : Pin::Reference::Extend
           type = build_type(mixin.name, mixin.args)
-          generic_values = type.all_params.map(&:to_s)
+          generic_values = type.all_params.map(&:rooted_tags)
           pins.push klass.new(
-            name: mixin.name.relative!.to_s,
+            name: type.rooted_name, # reference pins use rooted names
             type_location: location_decl_to_pin_location(mixin.location),
             generic_values: generic_values,
             closure: namespace,

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -716,10 +716,11 @@ module Solargraph
       # @return [void]
       def prepend_to_pin decl, closure
         type = build_type(decl.name, decl.args)
-        generic_values = type.all_params.map(&:rooted_tags)
+        generic_values = type.all_params.map(&:to_s)
         pins.push Solargraph::Pin::Reference::Prepend.new(
           name: decl.name.relative!.to_s,
           type_location: location_decl_to_pin_location(decl.location),
+          generic_values: generic_values,
           closure: closure,
           source: :rbs
         )
@@ -730,10 +731,11 @@ module Solargraph
       # @return [void]
       def extend_to_pin decl, closure
         type = build_type(decl.name, decl.args)
-        generic_values = type.all_params.map(&:rooted_tags)
+        generic_values = type.all_params.map(&:to_s)
         pins.push Solargraph::Pin::Reference::Extend.new(
           name: decl.name.relative!.to_s,
           type_location: location_decl_to_pin_location(decl.location),
+          generic_values: generic_values,
           closure: closure,
           source: :rbs
         )

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -164,7 +164,7 @@ module Solargraph
       # @return [void]
       def convert_self_type_to_pins decl, closure
         type = build_type(decl.name, decl.args)
-        generic_values = type.all_params.map(&:to_s)
+        generic_values = type.all_params.map(&:rooted_tags)
         include_pin = Solargraph::Pin::Reference::Include.new(
           name: decl.name.relative!.to_s,
           type_location: location_decl_to_pin_location(decl.location),
@@ -279,7 +279,7 @@ module Solargraph
         pins.push class_pin
         if decl.super_class
           type = build_type(decl.super_class.name, decl.super_class.args)
-          generic_values = type.all_params.map(&:to_s)
+          generic_values = type.all_params.map(&:rooted_tags)
           superclass_name = decl.super_class.name.to_s
           pins.push Solargraph::Pin::Reference::Superclass.new(
             type_location: location_decl_to_pin_location(decl.super_class.location),
@@ -799,7 +799,7 @@ module Solargraph
           # @todo are we handling prepend correctly?
           klass = mixin.is_a?(RBS::AST::Members::Include) ? Pin::Reference::Include : Pin::Reference::Extend
           type = build_type(mixin.name, mixin.args)
-          generic_values = type.all_params.map(&:to_s)
+          generic_values = type.all_params.map(&:rooted_tags)
           pins.push klass.new(
             name: mixin.name.relative!.to_s,
             type_location: location_decl_to_pin_location(mixin.location),

--- a/lib/solargraph/rbs_map/conversions.rb
+++ b/lib/solargraph/rbs_map/conversions.rb
@@ -701,7 +701,7 @@ module Solargraph
       # @return [void]
       def include_to_pin decl, closure
         type = build_type(decl.name, decl.args)
-        generic_values = type.all_params.map(&:to_s)
+        generic_values = type.all_params.map(&:rooted_tags)
         pins.push Solargraph::Pin::Reference::Include.new(
           name: decl.name.relative!.to_s,
           type_location: location_decl_to_pin_location(decl.location),
@@ -716,7 +716,7 @@ module Solargraph
       # @return [void]
       def prepend_to_pin decl, closure
         type = build_type(decl.name, decl.args)
-        generic_values = type.all_params.map(&:to_s)
+        generic_values = type.all_params.map(&:rooted_tags)
         pins.push Solargraph::Pin::Reference::Prepend.new(
           name: decl.name.relative!.to_s,
           type_location: location_decl_to_pin_location(decl.location),
@@ -731,7 +731,7 @@ module Solargraph
       # @return [void]
       def extend_to_pin decl, closure
         type = build_type(decl.name, decl.args)
-        generic_values = type.all_params.map(&:to_s)
+        generic_values = type.all_params.map(&:rooted_tags)
         pins.push Solargraph::Pin::Reference::Extend.new(
           name: decl.name.relative!.to_s,
           type_location: location_decl_to_pin_location(decl.location),

--- a/spec/parser/node_processor_spec.rb
+++ b/spec/parser/node_processor_spec.rb
@@ -80,6 +80,15 @@ describe Solargraph::Parser::NodeProcessor do
     expect(map.pins.last.type.to_s).to eq('Array<String>')
   end
 
+  it 'translates RBS parameter syntax on a superclass into Solargraph syntax' do
+    map = Solargraph::SourceMap.load_string(%(
+      class Foo < Array #[Hash[String, Integer]]
+      end
+    ), 'test.rb')
+
+    expect(map.pins.last.type.to_s).to eq('Array<Hash{String => Integer}>')
+  end
+
   it 'ignores bracketed comments in the class body' do
     map = Solargraph::SourceMap.load_string(%(
       class Foo < Array

--- a/spec/parser/node_processor_spec.rb
+++ b/spec/parser/node_processor_spec.rb
@@ -156,4 +156,12 @@ describe Solargraph::Parser::NodeProcessor do
       end
     ), Solargraph::Pin::Reference::Include)).to eq('Bar')
   end
+
+  it 'ignores mixin parameters that RBS cannot parse as a type' do
+    expect(mixin_type_for(%(
+      class Foo
+        include Bar #[def]
+      end
+    ), Solargraph::Pin::Reference::Include)).to eq('Bar')
+  end
 end

--- a/spec/parser/node_processor_spec.rb
+++ b/spec/parser/node_processor_spec.rb
@@ -98,4 +98,62 @@ describe Solargraph::Parser::NodeProcessor do
 
     expect(map.pins.last.type.to_s).to eq('Array')
   end
+
+  # @param code [String]
+  # @param klass [Class<Solargraph::Pin::Reference>]
+  # @return [String]
+  def mixin_type_for code, klass
+    map = Solargraph::SourceMap.load_string(code, 'test.rb')
+    map.pins.find { |pin| pin.instance_of?(klass) }.type.to_s
+  end
+
+  it 'parses RBS parameters for included modules' do
+    expect(mixin_type_for(%(
+      class Foo
+        include Bar #[String]
+      end
+    ), Solargraph::Pin::Reference::Include)).to eq('Bar<String>')
+  end
+
+  it 'parses RBS parameters for prepended modules' do
+    expect(mixin_type_for(%(
+      class Foo
+        prepend Bar #[String]
+      end
+    ), Solargraph::Pin::Reference::Prepend)).to eq('Bar<String>')
+  end
+
+  it 'parses RBS parameters for extended modules' do
+    expect(mixin_type_for(%(
+      class Foo
+        extend Bar #[String]
+      end
+    ), Solargraph::Pin::Reference::Extend)).to eq('Bar<String>')
+  end
+
+  it 'translates RBS parameter syntax on mixins into Solargraph syntax' do
+    expect(mixin_type_for(%(
+      class Foo
+        include Bar #[Hash[String, Integer]]
+      end
+    ), Solargraph::Pin::Reference::Include)).to eq('Bar<Hash{String => Integer}>')
+  end
+
+  it 'ignores a bracketed mixin comment separated from the hash' do
+    expect(mixin_type_for(%(
+      class Foo
+        include Bar # [String]
+      end
+    ), Solargraph::Pin::Reference::Include)).to eq('Bar')
+  end
+
+  it 'ignores mixin parameters when one call mixes in several modules' do
+    # RBS rejects this too, as "Mixing multiple modules with one call is
+    # not supported", since the parameters could apply to either module.
+    expect(mixin_type_for(%(
+      class Foo
+        include Bar, Baz #[String]
+      end
+    ), Solargraph::Pin::Reference::Include)).to eq('Bar')
+  end
 end

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -98,31 +98,44 @@ describe Solargraph::RbsMap::Conversions do
       let(:rbs) do
         <<~RBS
           module Prependable[T]
+            def value: () -> T
           end
           module Extendable[T]
+            def build: () -> T
           end
-          class Foo
+          module Includable[T]
+            def fetch: () -> T
+          end
+          class Prepender
             prepend Prependable[Integer]
+          end
+          class Extender
             extend Extendable[String]
+          end
+          class Includer
+            include Includable[Symbol]
           end
         RBS
       end
 
-      # @param klass [Class<Solargraph::Pin::Reference>]
-      # @param name [String]
-      # @return [Array<Solargraph::Pin::Reference>]
-      def references_to klass, name
-        conversions.pins.select { |pin| pin.instance_of?(klass) && pin.name == name }
+      # @param namespace [String]
+      # @param method [String]
+      # @param scope [Symbol]
+      # @return [String, nil]
+      def inferred_type namespace, method, scope
+        api_map.get_method_stack(namespace, method, scope: scope).first&.return_type&.tag
       end
 
-      it 'keeps the type arguments on the prepend reference' do
-        pins = references_to(Solargraph::Pin::Reference::Prepend, 'Prependable')
-        expect(pins.map(&:generic_values)).to all(eq(['Integer']))
+      it 'substitutes the type argument of a prepended module' do
+        expect(inferred_type('Prepender', 'value', :instance)).to eq('Integer')
       end
 
-      it 'keeps the type arguments on the extend reference' do
-        pins = references_to(Solargraph::Pin::Reference::Extend, 'Extendable')
-        expect(pins.map(&:generic_values)).to all(eq(['String']))
+      it 'substitutes the type argument of an extended module' do
+        expect(inferred_type('Extender', 'build', :class)).to eq('String')
+      end
+
+      it 'substitutes the type argument of an included module' do
+        expect(inferred_type('Includer', 'fetch', :instance)).to eq('Symbol')
       end
     end
   end

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -27,6 +27,41 @@ describe Solargraph::RbsMap::Conversions do
 
     attr_reader :temp_dir
 
+    context 'with a generic module prepended and extended' do
+      let(:rbs) do
+        <<~RBS
+          module Wrapper[T]
+          end
+
+          class Holder
+            prepend Wrapper[String]
+            extend Wrapper[Integer]
+          end
+        RBS
+      end
+
+      # @param klass [Class<Solargraph::Pin::Reference>]
+      # @return [Array<Array<String>>]
+      def generic_values_for klass
+        conversions.pins
+                   .select { |pin| pin.instance_of?(klass) && pin.name == '::Wrapper' }
+                   .map(&:generic_values)
+                   .uniq
+      end
+
+      it 'carries the prepended type argument' do
+        expect(generic_values_for(Solargraph::Pin::Reference::Prepend)).to eq([['::String']])
+      end
+
+      it 'carries the extended type argument' do
+        expect(generic_values_for(Solargraph::Pin::Reference::Extend)).to include(['::Integer'])
+      end
+
+      it 'leaves no extend reference pin without its type argument' do
+        expect(generic_values_for(Solargraph::Pin::Reference::Extend)).not_to include([])
+      end
+    end
+
     context 'with overlapping module hierarchies and inheritance' do
       subject(:method_pin) { api_map.get_method_stack('A::B::C', 'foo').first }
 

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -93,6 +93,38 @@ describe Solargraph::RbsMap::Conversions do
         expect(method_pin.return_type.tag).to eq('undefined')
       end
     end
+
+    context 'with generic modules mixed in' do
+      let(:rbs) do
+        <<~RBS
+          module Prependable[T]
+          end
+          module Extendable[T]
+          end
+          class Foo
+            prepend Prependable[Integer]
+            extend Extendable[String]
+          end
+        RBS
+      end
+
+      # @param klass [Class<Solargraph::Pin::Reference>]
+      # @param name [String]
+      # @return [Array<Solargraph::Pin::Reference>]
+      def references_to klass, name
+        conversions.pins.select { |pin| pin.instance_of?(klass) && pin.name == name }
+      end
+
+      it 'keeps the type arguments on the prepend reference' do
+        pins = references_to(Solargraph::Pin::Reference::Prepend, 'Prependable')
+        expect(pins.map(&:generic_values)).to all(eq(['Integer']))
+      end
+
+      it 'keeps the type arguments on the extend reference' do
+        pins = references_to(Solargraph::Pin::Reference::Extend, 'Extendable')
+        expect(pins.map(&:generic_values)).to all(eq(['String']))
+      end
+    end
   end
 
   context 'with standard loads for solargraph project' do

--- a/spec/rbs_map/core_map_spec.rb
+++ b/spec/rbs_map/core_map_spec.rb
@@ -82,7 +82,7 @@ describe Solargraph::RbsMap::CoreMap do
     #   correctly. It would be better to test RbsMap or RbsMap::Conversions
     #   with an RBS fixture.
     core_map = described_class.new
-    pins = core_map.pins.select { |pin| pin.is_a?(Solargraph::Pin::Reference::Include) && pin.name == 'Enumerable' }
+    pins = core_map.pins.select { |pin| pin.is_a?(Solargraph::Pin::Reference::Include) && pin.name == '::Enumerable' }
     expect(pins.map(&:closure).map(&:namespace)).to include('Enumerator')
   end
 

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1917,6 +1917,25 @@ describe Solargraph::SourceMap::Clip do
     expect(type.to_s).to eq('undefined')
   end
 
+  it 'resolves generics from an inline RBS parameter on a prepended module' do
+    source = Solargraph::Source.load_string(%(
+      # @generic T
+      module Mixin
+        # @return [generic<T>]
+        def value; end
+      end
+      class Foo
+        prepend Mixin #[Integer]
+      end
+      a = Foo.new.value
+      a
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new.map(source)
+    clip = api_map.clip_at('test.rb', [10, 6])
+    type = clip.infer
+    expect(type.to_s).to eq('Integer')
+  end
+
   it 'uses simple return value of block to infer return value of Enumerable#map' do
     source = Solargraph::Source.load_string(%(
       a = ['a'].map { 123 }


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

**Problem:** a generic module mixed in with `prepend` or `extend` loses its type argument.

```ruby
# module Prependable[T]
#   def value: () -> T
# end
# class Prepender
#   prepend Prependable[Integer]
# end

api_map.get_method_stack('Prepender', 'value').first.return_type.tag
# => "generic<T>"                          (expected "Integer")
```

RBS's inline form of the same annotation - `prepend Prependable #[Integer]` - was read only after a superclass, so a Ruby class could not express any of these relationships at all.

**Solution:** name reference pins from `type.rooted_name` and namespace pins from `fqns`, build every `generic_values` list from `rooted_tags`, pass those values through on prepend and extend and route both through `inner_get_methods_from_reference` so they resolve, and read the trailing `#[...]` annotation in the three mixin processors through a parser shared with the superclass path.
