### PR TITLE
Fix crash in solargraph gems core

### DIFF
--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -189,8 +189,7 @@ module Solargraph
         warn("Caching these gems: #{names}")
         names.each do |name|
           if name == 'core'
-            # @sg-ignore cache_core and core? are dynamically defined
-            PinCache.cache_core(out: $stdout) # if !PinCache.core? || options[:rebuild]
+            RbsMap::CoreMap.new.cache_core(out: $stdout)
             next
           end
 

--- a/spec/shell_spec.rb
+++ b/spec/shell_spec.rb
@@ -114,11 +114,13 @@ describe Solargraph::Shell do
       end
 
       it 'caches core without erroring out' do
-        capture_both do
-          shell.uncache('core')
-        end
+        core_map = instance_double(Solargraph::RbsMap::CoreMap)
+        allow(Solargraph::RbsMap::CoreMap).to receive(:new).and_return(core_map)
+        allow(core_map).to receive(:cache_core).and_return([])
 
-        expect { shell.cache('core') }.not_to raise_error
+        capture_both { shell.gems('core') }
+
+        expect(core_map).to have_received(:cache_core)
       end
 
       it 'gives sensible error for gem that does not exist' do

--- a/spec/shell_spec.rb
+++ b/spec/shell_spec.rb
@@ -114,6 +114,14 @@ describe Solargraph::Shell do
       end
 
       it 'caches core without erroring out' do
+        capture_both do
+          shell.uncache('core')
+        end
+
+        expect { shell.cache('core') }.not_to raise_error
+      end
+
+      it 'caches core pins from the gems command' do
         core_map = instance_double(Solargraph::RbsMap::CoreMap)
         allow(Solargraph::RbsMap::CoreMap).to receive(:new).and_return(core_map)
         allow(core_map).to receive(:cache_core).and_return([])


### PR DESCRIPTION
**Problem:** `solargraph gems core` crashes instead of caching core pins.

```
$ solargraph gems core
lib/solargraph/shell.rb:193:in `block in gems': undefined method `cache_core'
  for Solargraph::PinCache:Module (NoMethodError)
```

`cache_core` is an instance method on `RbsMap::CoreMap`; nothing defines it, or `core?`, on `PinCache`. The `@sg-ignore` above the call asserting that both are dynamically defined is simply wrong, so the marker was suppressing a genuine error rather than a tooling gap.

**Solution:** Call `RbsMap::CoreMap.new.cache_core` and drop the false marker.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
