### PR TITLE
Skip the embedded undercover check in Plugin jobs

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -20,10 +20,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        # fetch all history for all branches and tags so we can
-        # compare against origin/master
-        fetch-depth: 0
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -52,16 +48,13 @@ jobs:
       # @todo Temporary, expect to revert in 0.60
       continue-on-error: true
     - name: Ensure specs still run
-      run: bundle exec rake spec
+      # full_spec, not spec: skip the embedded undercover check
+      run: bundle exec rake full_spec
   rails:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        # fetch all history for all branches and tags so we can
-        # compare against origin/master
-        fetch-depth: 0
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -91,16 +84,13 @@ jobs:
       # @todo Temporary, expect to revert in 0.60
       continue-on-error: true
     - name: Ensure specs still run
-      run: bundle exec rake spec
+      # full_spec, not spec: skip the embedded undercover check
+      run: bundle exec rake full_spec
   rspec:
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
-      with:
-        # fetch all history for all branches and tags so we can
-        # compare against origin/master
-        fetch-depth: 0
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -128,7 +118,8 @@ jobs:
       # @todo Temporary, expect to revert in 0.60
       continue-on-error: true
     - name: Ensure specs still run
-      run: bundle exec rake spec
+      # full_spec, not spec: skip the embedded undercover check
+      run: bundle exec rake full_spec
 
   run_solargraph_rspec_specs:
     # check out solargraph-rspec as well as this project, and point the former to use the latter as a local gem

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -20,6 +20,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        # fetch all history for all branches and tags so we can
+        # compare against origin/master
+        fetch-depth: 0
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -54,6 +58,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        # fetch all history for all branches and tags so we can
+        # compare against origin/master
+        fetch-depth: 0
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
@@ -89,6 +97,10 @@ jobs:
 
     steps:
     - uses: actions/checkout@v3
+      with:
+        # fetch all history for all branches and tags so we can
+        # compare against origin/master
+        fetch-depth: 0
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -48,7 +48,6 @@ jobs:
       # @todo Temporary, expect to revert in 0.60
       continue-on-error: true
     - name: Ensure specs still run
-      # full_spec, not spec: skip the embedded undercover check
       run: bundle exec rake full_spec
   rails:
     runs-on: ubuntu-latest
@@ -84,7 +83,6 @@ jobs:
       # @todo Temporary, expect to revert in 0.60
       continue-on-error: true
     - name: Ensure specs still run
-      # full_spec, not spec: skip the embedded undercover check
       run: bundle exec rake full_spec
   rspec:
     runs-on: ubuntu-latest
@@ -118,7 +116,6 @@ jobs:
       # @todo Temporary, expect to revert in 0.60
       continue-on-error: true
     - name: Ensure specs still run
-      # full_spec, not spec: skip the embedded undercover check
       run: bundle exec rake full_spec
 
   run_solargraph_rspec_specs:


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

**Problem:** The `undercover` coverage check crashes on every run of the `regression`, `rails`, and `rspec` jobs in `plugins.yml`, and nothing surfaces the failure.

    $ bundle exec rake spec
    ...
    bundler: failed to load command: undercover (...)
    .../undercover/changeset.rb:68:in 'Rugged::Repository#merge_base':
      revspec 'origin/master' not found (Rugged::ReferenceError)

`rake spec`'s embedded `undercover` call never checks the subprocess's exit status, so these three jobs report green while silently never running a coverage check at all.

**Solution:** Run `rake full_spec` instead of `rake spec` in these three jobs, which runs the same rspec suite without the `origin/master` comparison `undercover` needs and these plugin-compatibility jobs do not use.

