### PR TITLE
Merge Namespace pins in GemPins.combine, not just Method

### DIFF
--- a/lib/solargraph.rb
+++ b/lib/solargraph.rb
@@ -93,11 +93,7 @@ module Solargraph
       # @todo :api_map_namespace_pin_stack triggers in a badly handled
       #   self type case - 'keeps track of self type in method
       #   parameters in subclass' in call_spec.rb
-      # @todo :combine_with_type can legitimately disagree when an RBS
-      #   signature goes stale relative to the gem's real source (a
-      #   class redeclared a module in a newer gem release than the
-      #   signature was written against)
-      return if %i[api_map_namespace_pin_stack combine_with_visibility combine_with_type].include?(type)
+      return if %i[api_map_namespace_pin_stack combine_with_visibility].include?(type)
 
       raise msg
     end

--- a/lib/solargraph.rb
+++ b/lib/solargraph.rb
@@ -93,7 +93,11 @@ module Solargraph
       # @todo :api_map_namespace_pin_stack triggers in a badly handled
       #   self type case - 'keeps track of self type in method
       #   parameters in subclass' in call_spec.rb
-      return if %i[api_map_namespace_pin_stack combine_with_visibility].include?(type)
+      # @todo :combine_with_type can legitimately disagree when an RBS
+      #   signature goes stale relative to the gem's real source (a
+      #   class redeclared a module in a newer gem release than the
+      #   signature was written against)
+      return if %i[api_map_namespace_pin_stack combine_with_visibility combine_with_type].include?(type)
 
       raise msg
     end

--- a/lib/solargraph/gem_pins.rb
+++ b/lib/solargraph/gem_pins.rb
@@ -11,13 +11,20 @@ module Solargraph
       include Logging
     end
 
-    # @param pins [Array<Pin::Method>]
-    # @return [Pin::Method, nil]
-    def self.combine_method_pins(*pins)
-      # @type [Pin::Method, nil]
+    # Pin classes whose YARD- and RBS-derived pins for the same path
+    # should be merged via combine_with, rather than one side simply
+    # winning. Both Pin::Method and Pin::Namespace have combine_with
+    # overrides that know how to preserve their own attributes (see
+    # Pin::Namespace#combine_with for generics/type/visibility/gates).
+    COMBINABLE_PIN_TYPES = [Pin::Method, Pin::Namespace].freeze
+
+    # @param pins [Array<Pin::Base>]
+    # @return [Pin::Base, nil]
+    def self.combine_pins(*pins)
+      # @type [Pin::Base, nil]
       combined_pin = nil
-      # @param memo [Pin::Method, nil]
-      # @param pin [Pin::Method]
+      # @param memo [Pin::Base, nil]
+      # @param pin [Pin::Base]
       out = pins.reduce(combined_pin) do |memo, pin|
         next pin if memo.nil?
         if memo == pin && memo.source != :combined
@@ -28,7 +35,7 @@ module Solargraph
         end
         memo.combine_with(pin)
       end
-      logger.debug { "GemPins.combine_method_pins(pins.length=#{pins.length}, pins=#{pins}) => #{out.inspect}" }
+      logger.debug { "GemPins.combine_pins(pins.length=#{pins.length}, pins=#{pins}) => #{out.inspect}" }
       out
     end
 
@@ -51,16 +58,15 @@ module Solargraph
       rbs_api_map = Solargraph::ApiMap.new(pins: rbs_pins)
       combined = yard_pins.map do |yard_pin|
         in_yard.add yard_pin.path
-        rbs_pin = rbs_api_map.get_path_pins(yard_pin.path).filter { |pin| pin.is_a? Pin::Method }.first
-        next yard_pin unless rbs_pin && yard_pin.instance_of?(Pin::Method)
+        next yard_pin unless COMBINABLE_PIN_TYPES.any? { |type| yard_pin.instance_of?(type) }
 
+        rbs_pin = rbs_api_map.get_path_pins(yard_pin.path).find { |pin| pin.instance_of?(yard_pin.class) }
         unless rbs_pin
-          # @sg-ignore https://github.com/castwide/solargraph/pull/1114
-          logger.debug { "GemPins.combine: No rbs pin for #{yard_pin.path} - using YARD's '#{yard_pin.inspect} (return_type=#{yard_pin.return_type}; signatures=#{yard_pin.signatures})" }
+          logger.debug { "GemPins.combine: No rbs pin for #{yard_pin.path} - using YARD's '#{yard_pin.inspect}" }
           next yard_pin
         end
 
-        out = combine_method_pins(rbs_pin, yard_pin)
+        out = combine_pins(rbs_pin, yard_pin)
         logger.debug { "GemPins.combine: Combining yard.path=#{yard_pin.path} - rbs=#{rbs_pin.inspect} with yard=#{yard_pin.inspect} into #{out}" }
         out
       end

--- a/lib/solargraph/gem_pins.rb
+++ b/lib/solargraph/gem_pins.rb
@@ -11,11 +11,8 @@ module Solargraph
       include Logging
     end
 
-    # Pin classes whose YARD- and RBS-derived pins for the same path
-    # should be merged via combine_with, rather than one side simply
-    # winning. Both Pin::Method and Pin::Namespace have combine_with
-    # overrides that know how to preserve their own attributes (see
-    # Pin::Namespace#combine_with for generics/type/visibility/gates).
+    # Pin types whose YARD/RBS pins should merge via #combine_with
+    # instead of one side simply winning.
     COMBINABLE_PIN_TYPES = [Pin::Method, Pin::Namespace].freeze
 
     # @param pins [Array<Pin::Base>]

--- a/lib/solargraph/pin/closure.rb
+++ b/lib/solargraph/pin/closure.rb
@@ -29,7 +29,8 @@ module Solargraph
       def combine_with other, attrs = {}
         new_attrs = {
           scope: assert_same(other, :scope),
-          generics: generics.empty? ? other.generics : generics
+          generics: generics.empty? ? other.generics : generics,
+          generic_defaults: generic_defaults.empty? ? other.generic_defaults : generic_defaults
         }.merge(attrs)
         super(other, new_attrs)
       end

--- a/lib/solargraph/pin/namespace.rb
+++ b/lib/solargraph/pin/namespace.rb
@@ -117,6 +117,27 @@ module Solargraph
                      [path] + @open_gates
                    end
       end
+
+      # @param other [self]
+      # @param attrs [Hash{Symbol => Object}]
+      # @return [self]
+      def combine_with other, attrs = {}
+        new_attrs = {
+          type: assert_same(other, :type),
+          visibility: choose(other, :visibility),
+          gates: open_gates == [''] ? other.open_gates : open_gates
+        }.merge(attrs)
+        super(other, new_attrs)
+      end
+
+      protected
+
+      # The gates this namespace itself opens up for name resolution,
+      # as passed to the constructor - not to be confused with #gates,
+      # which additionally prepends this namespace's own #path.
+      #
+      # @return [::Array<String>]
+      attr_reader :open_gates
     end
   end
 end

--- a/lib/solargraph/pin/namespace.rb
+++ b/lib/solargraph/pin/namespace.rb
@@ -149,7 +149,7 @@ module Solargraph
       def combine_type other
         return type if type == other.type
 
-        Solargraph.logger.warn { "Namespace#combine_with: :type disagreement for #{path} - self=#{inspect}, other=#{other.inspect}" }
+        Solargraph.logger.debug { "Namespace#combine_with: :type disagreement for #{path} - self=#{inspect}, other=#{other.inspect}" }
         return type if source == :yardoc
         return other.type if other.source == :yardoc
 

--- a/lib/solargraph/pin/namespace.rb
+++ b/lib/solargraph/pin/namespace.rb
@@ -123,7 +123,7 @@ module Solargraph
       # @return [self]
       def combine_with other, attrs = {}
         new_attrs = {
-          type: assert_same(other, :type),
+          type: combine_type(other),
           visibility: choose(other, :visibility),
           gates: open_gates == [''] ? other.open_gates : open_gates
         }.merge(attrs)
@@ -138,6 +138,24 @@ module Solargraph
       #
       # @return [::Array<String>]
       attr_reader :open_gates
+
+      private
+
+      # An RBS signature's class/module keyword can go stale relative
+      # to the gem's real source; prefer the pin parsed from it.
+      #
+      # @param other [self]
+      # @return [::Symbol]
+      def combine_type other
+        return type if type == other.type
+
+        Solargraph.assert_or_log(:combine_with_type,
+                                 "Inconsistent :type values between \nself =#{inspect} and \nother=#{other.inspect}")
+        return type if source == :yardoc
+        return other.type if other.source == :yardoc
+
+        type
+      end
     end
   end
 end

--- a/lib/solargraph/pin/namespace.rb
+++ b/lib/solargraph/pin/namespace.rb
@@ -149,8 +149,7 @@ module Solargraph
       def combine_type other
         return type if type == other.type
 
-        Solargraph.assert_or_log(:combine_with_type,
-                                 "Inconsistent :type values between \nself =#{inspect} and \nother=#{other.inspect}")
+        Solargraph.logger.warn { "Namespace#combine_with: :type disagreement for #{path} - self=#{inspect}, other=#{other.inspect}" }
         return type if source == :yardoc
         return other.type if other.source == :yardoc
 

--- a/spec/gem_pins_combine_spec.rb
+++ b/spec/gem_pins_combine_spec.rb
@@ -2,12 +2,9 @@
 
 describe Solargraph::GemPins, '.combine' do
   context 'with a namespace pin split across YARD and RBS' do
-    # A real YARD-derived namespace pin always carries a location (the
-    # .rb file it was parsed from), while a real RBS-derived one only
-    # ever sets type_location - so the two are never Pin::Base#==
-    # equal, and combine_pins always actually merges them rather than
-    # taking its identical-pin shortcut. Set location here so this
-    # fixture matches that.
+    # location: makes this fixture match a real YARD pin (a real RBS
+    # pin only sets type_location), so the two aren't Pin::Base#==
+    # and combine_pins actually merges them.
     let(:yard_pin) do
       Solargraph::Pin::Namespace.new(
         name: 'Foo::Bar',

--- a/spec/gem_pins_combine_spec.rb
+++ b/spec/gem_pins_combine_spec.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+describe Solargraph::GemPins, '.combine' do
+  context 'with a namespace pin split across YARD and RBS' do
+    # A real YARD-derived namespace pin always carries a location (the
+    # .rb file it was parsed from), while a real RBS-derived one only
+    # ever sets type_location - so the two are never Pin::Base#==
+    # equal, and combine_pins always actually merges them rather than
+    # taking its identical-pin shortcut. Set location here so this
+    # fixture matches that.
+    let(:yard_pin) do
+      Solargraph::Pin::Namespace.new(
+        name: 'Foo::Bar',
+        type: :class,
+        location: Solargraph::Location.new('foo/bar.rb', Solargraph::Range.from_to(0, 0, 0, 0)),
+        closure: Solargraph::Pin::ROOT_PIN,
+        source: :yardoc
+      )
+    end
+
+    let(:rbs_pin) do
+      Solargraph::Pin::Namespace.new(
+        name: 'Foo::Bar',
+        type: :class,
+        generics: %w[T U],
+        closure: Solargraph::Pin::ROOT_PIN,
+        source: :rbs
+      )
+    end
+
+    let(:combined) { described_class.combine([yard_pin], [rbs_pin]) }
+
+    it 'merges the two pins into one, rather than dropping the RBS pin' do
+      expect(combined.length).to eq(1)
+    end
+
+    it 'keeps the RBS-derived generics on the merged pin' do
+      expect(combined.first.generics).to eq(%w[T U])
+    end
+
+    it 'marks the merged pin as combined' do
+      expect(combined.first.source).to eq(:combined)
+    end
+  end
+end

--- a/spec/pin/combine_with_spec.rb
+++ b/spec/pin/combine_with_spec.rb
@@ -64,4 +64,55 @@ describe Solargraph::Pin::Base, '#combine_with' do
       expect(combined.return_type.to_s).to eq('self')
     end
   end
+
+  context 'with namespace pins' do
+    let(:yard_pin) do
+      Solargraph::Pin::Namespace.new(
+        name: 'Foo::Bar',
+        type: :module,
+        visibility: :public,
+        gates: ['Foo', ''],
+        closure: Solargraph::Pin::ROOT_PIN,
+        source: :yardoc
+      )
+    end
+
+    let(:rbs_pin) do
+      Solargraph::Pin::Namespace.new(
+        name: 'Foo::Bar',
+        type: :module,
+        generics: %w[T U],
+        generic_defaults: { 'U' => Solargraph::ComplexType.try_parse('String') },
+        closure: Solargraph::Pin::ROOT_PIN,
+        source: :rbs
+      )
+    end
+
+    it 'takes generics from the RBS side when the YARD side has none' do
+      combined = rbs_pin.combine_with(yard_pin)
+      expect(combined.generics).to eq(%w[T U])
+    end
+
+    it 'takes generic_defaults from the RBS side when the YARD side has none' do
+      combined = rbs_pin.combine_with(yard_pin)
+      expect(combined.generic_defaults.keys).to eq(['U'])
+    end
+
+    it 'keeps the real type instead of resetting to the constructor default' do
+      combined = rbs_pin.combine_with(yard_pin)
+      expect(combined.type).to eq(:module)
+    end
+
+    it 'keeps the real gates instead of resetting to the constructor default' do
+      combined = rbs_pin.combine_with(yard_pin)
+      expect(combined.gates).to eq(['Foo::Bar', 'Foo', ''])
+    end
+
+    it 'produces the same result regardless of combine order' do
+      combined = yard_pin.combine_with(rbs_pin)
+      expect(combined.generics).to eq(%w[T U])
+      expect(combined.type).to eq(:module)
+      expect(combined.gates).to eq(['Foo::Bar', 'Foo', ''])
+    end
+  end
 end

--- a/spec/pin/namespace_spec.rb
+++ b/spec/pin/namespace_spec.rb
@@ -34,4 +34,10 @@ describe Solargraph::Pin::Namespace do
     expect(pin.generics).to eq(['GenericType'])
     expect(pin.to_rbs).to eq('class ::Foo[GenericType]')
   end
+
+  it 'prefers the YARD pin type when combining with a disagreeing RBS pin' do
+    rbs_pin = described_class.new(name: 'Foo', type: :class, source: :rbs)
+    yard_pin = described_class.new(name: 'Foo', type: :module, source: :yardoc)
+    expect(rbs_pin.combine_with(yard_pin).type).to eq(:module)
+  end
 end

--- a/spec/pin/namespace_spec.rb
+++ b/spec/pin/namespace_spec.rb
@@ -40,4 +40,10 @@ describe Solargraph::Pin::Namespace do
     yard_pin = described_class.new(name: 'Foo', type: :module, source: :yardoc)
     expect(rbs_pin.combine_with(yard_pin).type).to eq(:module)
   end
+
+  it 'falls back to its own type when neither disagreeing pin is from YARD' do
+    rbs_pin1 = described_class.new(name: 'Foo', type: :class, source: :rbs)
+    rbs_pin2 = described_class.new(name: 'Foo', type: :module, source: :rbs)
+    expect(rbs_pin1.combine_with(rbs_pin2).type).to eq(:class)
+  end
 end


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

GemPins.combine merges a gem's YARD and RBS pins for the same path, but only for Pin::Method - a Pin::Namespace hits the same early exit before RBS is checked, and the leftover RBS pin is then dropped entirely:

```ruby
# ActiveSupport::HashWithIndifferentAccess has plain Ruby source
# (no generics syntax) and a separate RBS signature:
#   class HashWithIndifferentAccess[T, U] < Hash[T, U]
Solargraph::GemPins.combine(yard_pins, rbs_pins)
  .find { |p| p.path == 'ActiveSupport::HashWithIndifferentAccess' }
  .generics
# => [] (RBS's ["T", "U"] silently dropped)
```

Routes Namespace pins through the same combine_with merge Method pins already use. Namespace needs its own combine_with, since the base implementation resets unset attributes (type, visibility, gates) to constructor defaults instead of carrying them over; Closure#combine_with gains generic_defaults, which had the same drop.

Merging Namespace pins this way surfaced a real cross-source disagreement: ruby/gem_rbs_collection's nokogiri signature still says `class Nokogiri::XML::XPath`, unchanged since nokogiri 1.11, though nokogiri redeclared it a module at 1.12. combine_with now prefers the YARD-derived pin's :type when the two disagree, since it comes from parsing the real keyword rather than a signature that can go stale.

Pin::Reference::Superclass has an analogous symptom but a different mechanism (both pins survive, ApiMap::Store#get_superclass just picks the first by insertion order) - left for separate follow-up.

