### PR TITLE
Stop a log message from giving a pin the wrong path

### DIFF
--- a/lib/solargraph/pin/base.rb
+++ b/lib/solargraph/pin/base.rb
@@ -69,8 +69,10 @@ module Solargraph
       def assert_location_provided
         return unless best_location.nil? && %i[yardoc source rbs].include?(source)
 
+        # @path, not #path: the reader caches its result, and @scope is not
+        # assigned until Pin::Closure#initialize, after super returns here.
         Solargraph.assert_or_log(:best_location,
-                                 "Neither location nor type_location provided - #{path} #{source} #{self.class}")
+                                 "Neither location nor type_location provided - #{@path} #{source} #{self.class}")
       end
 
       # @return [Pin::Closure, nil]

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -786,4 +786,13 @@ describe Solargraph::Pin::Method do
       expect { pin.signatures }.not_to raise_error
     end
   end
+
+  # Building the missing-location log message used to call #path, whose
+  # result is cached, before Pin::Closure#initialize had assigned @scope.
+  it 'keeps an instance method path when built with a source and no location' do
+    closure = Solargraph::Pin::Namespace.new(name: 'Collection')
+    pin = described_class.new(name: 'first', scope: :instance, parameters: [], closure: closure,
+                              source: :rbs)
+    expect(pin.path).to eq('Collection#first')
+  end
 end


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

**Problem:** A method pin built with a source but no location is filed under a class-method path even though its scope is `:instance`, so completion and go-to-definition can't find it.

```ruby
c = Solargraph::Pin::Namespace.new(name: 'Collection')
Solargraph::Pin::Method.new(name: 'first', scope: :instance, parameters: [], closure: c).path
# => "Collection#first"
Solargraph::Pin::Method.new(name: 'first', scope: :instance, parameters: [], closure: c, source: :rbs).path
# => "Collection.first"   <- scope is still :instance
```

The cause is the log message that reports the missing location. Interpolating `#path` caches `@path` while `@scope` is still nil, because `Pin::Closure#initialize` assigns it after `super` has reached `Base`.
