### PR TITLE
Document every option in the generated .solargraph.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,10 @@ Once installed, you can also insert your own local overrides and definitions in 
 
 As of version 0.33.0, Solargraph includes a [type checker](https://github.com/castwide/solargraph/issues/192) that uses a combination of YARD tags and code analysis to report missing type definitions. In strict mode, it performs type inference to determine whether the tags match the types it detects from code.  In strong mode it will ask you to clarify your intentions by adding annotations for better validation.
 
+Run it with `bundle exec solargraph typecheck --level <normal|typed|strict|strong|alpha>`. Each level turns on additional rules on top of the previous one.
+
+To adopt a stricter level gradually on an existing codebase, `.solargraph.yml`'s `type_checker.rules` section can override where an individual rule kicks in, independent of the rest of the level. Run `bundle exec solargraph config` to generate a `.solargraph.yml` with every option, including this one, documented inline - or see the [configuration guide](https://solargraph.org/guides/configuration).
+
 ### The Documentation Cache
 
 Solargraph uses a cache directory to store documentation for the Ruby core and gems. The default location is `~/.cache/solargraph`, e.g., `/home/<username>/.cache/solargraph` on Linux or `C:\Users\<username>\.cache\solargraph` on Windows.

--- a/lib/solargraph/shell.rb
+++ b/lib/solargraph/shell.rb
@@ -79,14 +79,10 @@ module Solargraph
         end
       end
       conf = Solargraph::Workspace::Config.new.raw_data
-      unless matches.empty?
-        matches.each do |m|
-          conf['extensions'].push m
-        end
-      end
+      conf['extensions'].concat(matches)
       # @param file [File]
       File.open(File.join(directory, '.solargraph.yml'), 'w') do |file|
-        file.puts conf.to_yaml
+        file.puts Solargraph::Workspace::Config.commented_yaml(conf)
       end
       $stdout.puts 'Configuration file initialized.'
     end

--- a/lib/solargraph/type_checker/rules.rb
+++ b/lib/solargraph/type_checker/rules.rb
@@ -28,7 +28,7 @@ module Solargraph
                   Solargraph.logger.warn "Unrecognized TypeChecker level #{level}, assuming normal"
                   0
                 end
-        @level = LEVELS[LEVELS.values.index(@rank)]
+        @level = LEVELS.key(@rank)
         @overrides = overrides
       end
 

--- a/lib/solargraph/type_checker/rules.rb
+++ b/lib/solargraph/type_checker/rules.rb
@@ -29,7 +29,7 @@ module Solargraph
                   0
                 end
         @level = LEVELS.key(@rank)
-        @overrides = overrides
+        @overrides = recognized_overrides(overrides)
       end
 
       def ignore_all_undefined?
@@ -151,6 +151,19 @@ module Solargraph
       # @param level [Symbol]
       def report? type, level
         rank >= LEVELS[@overrides.fetch(type, level)]
+      end
+
+      # Keeps nil out of the rank comparison in #report?.
+      #
+      # @param overrides [Hash{Symbol => Symbol}]
+      # @return [Hash{Symbol => Symbol}]
+      def recognized_overrides overrides
+        overrides.select do |type, level|
+          next true if LEVELS.key?(level)
+
+          Solargraph.logger.warn "Unrecognized TypeChecker level #{level} for #{type}, ignoring"
+          false
+        end
       end
     end
   end

--- a/lib/solargraph/workspace.rb
+++ b/lib/solargraph/workspace.rb
@@ -54,7 +54,9 @@ module Solargraph
     # @param level [Symbol]
     # @return [TypeChecker::Rules]
     def rules level
-      @rules ||= TypeChecker::Rules.new(level, config.type_checker_rules)
+      # @type [Hash{Symbol => TypeChecker::Rules}]
+      @rules ||= {}
+      @rules[level] ||= TypeChecker::Rules.new(level, config.type_checker_rules)
     end
 
     # Merge the source. A merge will update the existing source for the file

--- a/lib/solargraph/workspace/config.rb
+++ b/lib/solargraph/workspace/config.rb
@@ -11,6 +11,44 @@ module Solargraph
       # The workspace's .solargraph.yml can override this value.
       MAX_FILES = 5000
 
+      # Doc comment written above each top-level key when `solargraph
+      # config` generates a .solargraph.yml - see .commented_yaml. A
+      # key with no entry here (or not present in the config at all)
+      # is rendered without a comment.
+      #
+      # @return [Hash{String => Array<String>}]
+      CONFIG_DOCS = {
+        'include' => [
+          'Files to include in the workspace, as glob patterns relative to',
+          'this directory.'
+        ],
+        'exclude' => [
+          'Files to exclude from the workspace, as glob patterns (checked',
+          'after include, so an excluded file stays excluded).'
+        ],
+        'require' => ['Paths to require before indexing the workspace.'],
+        'domains' => [
+          'Namespaces to include in the global namespace - e.g. to expose a',
+          "DSL's methods without qualifying them."
+        ],
+        'reporters' => ['Diagnostics reporters to run - see `solargraph reporters`.'],
+        'formatter' => ['Options for diagnostics reporters that support them.'],
+        'type_checker' => [
+          'Per-rule overrides for `solargraph typecheck --level <level>` -',
+          'see lib/solargraph/type_checker/rules.rb for the current list',
+          'of rule names. Each value is a level name (normal, typed,',
+          'strict, strong, alpha) the rule starts reporting at instead',
+          'of its default.'
+        ],
+        'require_paths' => ['Load paths for the paths listed in require above.'],
+        'plugins' => ['Plugins to require - see https://solargraph.org/guides/plugins'],
+        'max_files' => ['Maximum number of files Solargraph will index in this workspace.'],
+        'extensions' => [
+          'solargraph-*-ext gems to require automatically. Populated by',
+          '`solargraph config`; pass --no-extensions to skip.'
+        ]
+      }.freeze
+
       # @return [String]
       attr_reader :directory
 
@@ -128,6 +166,26 @@ module Solargraph
         end
       end
 
+      class << self
+        # Render config data as YAML, with a doc comment from
+        # CONFIG_DOCS above each top-level key.
+        #
+        # @param conf [Hash{String => undefined}]
+        # @return [String]
+        def commented_yaml conf
+          conf.map do |key, value|
+            comment = CONFIG_DOCS.fetch(key, []).map { |line| "# #{line}" }.join("\n")
+            # @sg-ignore Psych.dump's RBS also declares optional kwargs
+            # (indentation:, line_width:, ...), so a positional Hash
+            # argument built with => gets misread as an attempt at
+            # those kwargs - literal error: "Unrecognized keyword
+            # argument key to Psych.dump"
+            yaml = YAML.dump({ key => value }).sub(/\A---\n/, '')
+            [comment, yaml].reject(&:empty?).join("\n")
+          end.join("\n")
+        end
+      end
+
       private
 
       # @return [String]
@@ -186,7 +244,8 @@ module Solargraph
           },
           'require_paths' => [],
           'plugins' => [],
-          'max_files' => MAX_FILES
+          'max_files' => MAX_FILES,
+          'extensions' => []
         }
       end
 

--- a/lib/solargraph/workspace/config.rb
+++ b/lib/solargraph/workspace/config.rb
@@ -11,10 +11,8 @@ module Solargraph
       # The workspace's .solargraph.yml can override this value.
       MAX_FILES = 5000
 
-      # Doc comment written above each top-level key when `solargraph
-      # config` generates a .solargraph.yml - see .commented_yaml. A
-      # key with no entry here (or not present in the config at all)
-      # is rendered without a comment.
+      # Per-key doc comment for `solargraph config`'s generated YAML
+      # (see .commented_yaml) - a key missing here gets no comment.
       #
       # @return [Hash{String => Array<String>}]
       CONFIG_DOCS = {
@@ -175,11 +173,7 @@ module Solargraph
         def commented_yaml conf
           conf.map do |key, value|
             comment = CONFIG_DOCS.fetch(key, []).map { |line| "# #{line}" }.join("\n")
-            # @sg-ignore Psych.dump's RBS also declares optional kwargs
-            # (indentation:, line_width:, ...), so a positional Hash
-            # argument built with => gets misread as an attempt at
-            # those kwargs - literal error: "Unrecognized keyword
-            # argument key to Psych.dump"
+            # @sg-ignore Psych.dump's RBS also misreads a positional Hash arg as kwargs
             yaml = YAML.dump({ key => value }).sub(/\A---\n/, '')
             [comment, yaml].reject(&:empty?).join("\n")
           end.join("\n")

--- a/spec/shell_spec.rb
+++ b/spec/shell_spec.rb
@@ -61,6 +61,32 @@ describe Solargraph::Shell do
     end
   end
 
+  describe 'config' do
+    it 'writes a config file with every key documented' do
+      shell.config(temp_dir)
+      conf_path = File.join(temp_dir, '.solargraph.yml')
+      contents = File.read(conf_path)
+
+      expect(YAML.safe_load(contents)).to eq(Solargraph::Workspace::Config.new.raw_data)
+      Solargraph::Workspace::Config::CONFIG_DOCS.each_value do |lines|
+        expect(contents).to include(lines.first)
+      end
+    end
+
+    it 'does not crash when an extension gem is installed' do
+      shell.options = { extensions: true }
+      allow(Gem::Specification).to receive(:each).and_yield(
+        instance_double(Gem::Specification, name: 'solargraph-rails-ext')
+      )
+      allow(shell).to receive(:require).with('solargraph-rails-ext')
+
+      expect { shell.config(temp_dir) }.not_to raise_error
+
+      conf = YAML.safe_load_file(File.join(temp_dir, '.solargraph.yml'))
+      expect(conf['extensions']).to eq(['solargraph-rails-ext'])
+    end
+  end
+
   describe 'scan' do
     context 'with mocked dependencies' do
       let(:api_map) { instance_double(Solargraph::ApiMap) }

--- a/spec/type_checker/rules_spec.rb
+++ b/spec/type_checker/rules_spec.rb
@@ -1,6 +1,16 @@
 # frozen_string_literal: true
 
 describe Solargraph::TypeChecker::Rules do
+  it 'exposes the resolved level' do
+    expect(described_class.new(:strict, {}).level).to be(:strict)
+  end
+
+  it 'falls back to normal for an unrecognized level' do
+    allow(Solargraph.logger).to receive(:warn)
+    expect(described_class.new(:not_a_real_level, {}).level).to be(:normal)
+    expect(Solargraph.logger).to have_received(:warn)
+  end
+
   it 'sets normal rules' do
     rules = described_class.new(:normal, {})
     expect(rules.ignore_all_undefined?).to be(true)

--- a/spec/type_checker/rules_spec.rb
+++ b/spec/type_checker/rules_spec.rb
@@ -11,6 +11,13 @@ describe Solargraph::TypeChecker::Rules do
     expect(Solargraph.logger).to have_received(:warn)
   end
 
+  it 'falls back to the rule default when an override names an unrecognized level' do
+    allow(Solargraph.logger).to receive(:warn)
+    rules = described_class.new(:strong, { validate_calls: :not_a_real_level })
+    expect(rules.validate_calls?).to be(true)
+    expect(Solargraph.logger).to have_received(:warn)
+  end
+
   it 'sets normal rules' do
     rules = described_class.new(:normal, {})
     expect(rules.ignore_all_undefined?).to be(true)

--- a/spec/workspace/config_spec.rb
+++ b/spec/workspace/config_spec.rb
@@ -52,4 +52,39 @@ describe Solargraph::Workspace::Config do
     expect(config.reporters).to include('rubocop')
     expect(config.reporters).to include('require_not_found')
   end
+
+  it 'has no type checker rule overrides by default' do
+    config = described_class.new(dir_path)
+    expect(config.type_checker_rules).to eq({})
+  end
+
+  it 'symbolizes a level override for a type checker rule' do
+    File.write(File.join(dir_path, '.solargraph.yml'), %(
+      type_checker:
+        rules:
+          validate_calls: typed
+    ))
+    config = described_class.new(dir_path)
+    expect(config.type_checker_rules).to eq(validate_calls: :typed)
+  end
+
+  describe '.commented_yaml' do
+    it 'renders a doc comment above a key with a CONFIG_DOCS entry' do
+      yaml = described_class.commented_yaml('max_files' => 5000)
+      expect(yaml).to eq(<<~YAML)
+        # Maximum number of files Solargraph will index in this workspace.
+        max_files: 5000
+      YAML
+    end
+
+    it 'renders a key with no CONFIG_DOCS entry without a comment' do
+      yaml = described_class.commented_yaml('not_a_real_key' => 'value')
+      expect(yaml).to eq("not_a_real_key: value\n")
+    end
+
+    it 'round-trips to the same data it was given' do
+      conf = described_class.new(dir_path).raw_data
+      expect(YAML.safe_load(described_class.commented_yaml(conf))).to eq(conf)
+    end
+  end
 end

--- a/spec/workspace_spec.rb
+++ b/spec/workspace_spec.rb
@@ -145,4 +145,12 @@ describe Solargraph::Workspace do
       described_class.new('./path', config)
     end.not_to raise_error
   end
+
+  it 'caches rules separately per level' do
+    normal_rules = workspace.rules(:normal)
+    strict_rules = workspace.rules(:strict)
+    expect(normal_rules.level).to be(:normal)
+    expect(strict_rules.level).to be(:strict)
+    expect(workspace.rules(:normal)).to be(normal_rules)
+  end
 end


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

**Problem:** `solargraph config` writes a file that says nothing about what any setting does or what values it accepts.

```yaml
---
include:
- Rakefile
- Gemfile
- "*.gemspec"
- "./**/*.rb"
exclude:
- spec/**/*
require: []
domains: []
```

`type_checker.rules` is the sharpest case: it takes a level name per rule, and nothing in the generated file or an error message says so, while a misspelled level took down the whole typecheck run with `comparison of Integer with nil failed`.

**Solution:** Emit a documented comment above each key, and drop rule overrides naming a level that does not exist so a typo warns and falls back instead of raising.

