### PR TITLE
Define Boolean so its operators resolve

### DIFF
--- a/rbs/fills/boolean/0/boolean.rbs
+++ b/rbs/fills/boolean/0/boolean.rbs
@@ -1,0 +1,12 @@
+# Boolean is Solargraph's name for the RBS `bool` type. Store#get_superclass
+# already gives TrueClass and FalseClass `Boolean` as their superclass, but
+# nothing defined it, so it had no pin and carried only Object's methods.
+#
+# The members are the ones TrueClass and FalseClass share beyond Object.
+class Boolean
+  def &: (untyped obj) -> bool
+
+  def ^: (untyped obj) -> bool
+
+  def |: (untyped obj) -> bool
+end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -997,5 +997,20 @@ describe Solargraph::TypeChecker do
       # an error when trying to declare sub as Subclass
       expect(checker.problems.map(&:message)).not_to include('Unresolved call to bar on Base')
     end
+
+    it 'resolves the operators TrueClass and FalseClass share on Boolean' do
+      checker = type_checker(%(
+        class Foo
+          # @return [Boolean]
+          def flag; true; end
+
+          # @return [Boolean]
+          def combined
+            flag & flag
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
   end
 end


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

**Problem:** a value documented `@return [Boolean]` cannot answer the three operators `TrueClass` and `FalseClass` both define.

```ruby
# @return [Boolean]
def flag; true; end

flag & flag
# Unresolved call to & on Boolean
```

`Store#get_superclass` gives `TrueClass` and `FalseClass` a superclass of `Boolean`, and `try_special_superclasses` gives `Boolean` a superclass of `Object`, but nothing ever declared `Boolean` - so it had no namespace pin and carried only `Object`'s methods, 53 against its subclasses' 60. The missing three were `&`, `^` and `|`.

**Solution:** declare `Boolean` in the core fills with those three members, completing the inheritance chain Solargraph already assumed rather than replacing it. Strong typecheck is unchanged at 531 problems.
