### PR TITLE
Infer precise Hash{K => V} types from hash literals

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -134,7 +134,7 @@ jobs:
        # pending https://github.com/lekemula/solargraph-rspec/pull/31
        git clone https://github.com/apiology/solargraph-rspec.git
        cd solargraph-rspec
-       git checkout test_solargraph_prereleases
+       git checkout fix-stale-hash-literal-assertions
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -126,12 +126,14 @@ jobs:
       BUNDLE_PATH: ${{ github.workspace }}/../solargraph-rspec/vendor/bundle
     steps:
     - uses: actions/checkout@v3
-    - name: clone https://github.com/lekemula/solargraph-rspec/
+    # lekemula/solargraph-rspec#36 raises the expectations this branch's
+    # more precise Hash record inference now satisfies.
+    - name: clone https://github.com/lekemula/solargraph-rspec/ pull/36
       run: |
        cd ..
-       git clone https://github.com/lekemula/solargraph-rspec.git
+       # git clone https://github.com/lekemula/solargraph-rspec.git
+       git clone --branch fix-hash-literal-type-precision https://github.com/apiology/solargraph-rspec.git
        cd solargraph-rspec
-       # git checkout fix-stale-hash-literal-assertions
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:

--- a/lib/solargraph/language_server/message/base.rb
+++ b/lib/solargraph/language_server/message/base.rb
@@ -88,6 +88,7 @@ module Solargraph
             # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#cancelRequest
             # cancel should send response RequestCancelled
             Solargraph::Logging.logger.info "Cancelled response to ##{id} #{method}"
+            # @sg-ignore https://github.com/castwide/solargraph/pull/1223
             set_result nil
             set_error ErrorCodes::REQUEST_CANCELLED, 'Cancelled by client'
           else

--- a/lib/solargraph/language_server/message/base.rb
+++ b/lib/solargraph/language_server/message/base.rb
@@ -63,11 +63,14 @@ module Solargraph
           return if id.nil?
 
           accept_or_cancel
+          # @type [Hash{Symbol => String, Integer, Hash, Array, nil}]
           response = {
             jsonrpc: '2.0',
             id: id
           }
+          # @sg-ignore https://github.com/castwide/solargraph/pull/1223
           response[:result] = result unless result.nil?
+          # @sg-ignore https://github.com/castwide/solargraph/pull/1223
           response[:error] = error unless error.nil?
           response[:result] = nil if result.nil? && error.nil?
           json = response.to_json

--- a/lib/solargraph/language_server/message/initialize.rb
+++ b/lib/solargraph/language_server/message/initialize.rb
@@ -14,6 +14,7 @@ module Solargraph
           else
             host.prepare params['rootPath']
           end
+          # @type [Hash{Symbol => Hash{Symbol => Boolean, Integer, String, Hash}}]
           result = {
             capabilities: {
               textDocumentSync: 2, # @todo What should this be?
@@ -26,29 +27,29 @@ module Solargraph
             }
           }
           # FIXME: lsp default is utf-16, may have different position
-          result[:capabilities][:positionEncoding] = 'utf-32' if params.dig('capabilities', 'general',
-                                                                            'positionEncodings')&.include?('utf-32')
-          result[:capabilities].merge! static_completion unless dynamic_registration_for?('textDocument', 'completion')
-          result[:capabilities].merge! static_signature_help unless dynamic_registration_for?('textDocument',
-                                                                                              'signatureHelp')
-          # result[:capabilities].merge! static_on_type_formatting unless dynamic_registration_for?('textDocument', 'onTypeFormatting')
-          result[:capabilities].merge! static_hover unless dynamic_registration_for?('textDocument', 'hover')
-          result[:capabilities].merge! static_document_formatting unless dynamic_registration_for?('textDocument',
-                                                                                                   'formatting')
-          result[:capabilities].merge! static_document_symbols unless dynamic_registration_for?('textDocument',
-                                                                                                'documentSymbol')
-          result[:capabilities].merge! static_definitions unless dynamic_registration_for?('textDocument', 'definition')
-          result[:capabilities].merge! static_type_definitions unless dynamic_registration_for?('textDocument',
-                                                                                                'typeDefinition')
-          result[:capabilities].merge! static_rename unless dynamic_registration_for?('textDocument', 'rename')
-          result[:capabilities].merge! static_references unless dynamic_registration_for?('textDocument', 'references')
-          result[:capabilities].merge! static_workspace_symbols unless dynamic_registration_for?('workspace', 'symbol')
-          result[:capabilities].merge! static_folding_range unless dynamic_registration_for?('textDocument',
-                                                                                             'foldingRange')
-          result[:capabilities].merge! static_highlights unless dynamic_registration_for?('textDocument',
-                                                                                          'documentHighlight')
+          result.fetch(:capabilities)[:positionEncoding] = 'utf-32' if params.dig('capabilities', 'general',
+                                                                                  'positionEncodings')&.include?('utf-32')
+          result.fetch(:capabilities).merge! static_completion unless dynamic_registration_for?('textDocument', 'completion')
+          result.fetch(:capabilities).merge! static_signature_help unless dynamic_registration_for?('textDocument',
+                                                                                                    'signatureHelp')
+          # result.fetch(:capabilities).merge! static_on_type_formatting unless dynamic_registration_for?('textDocument', 'onTypeFormatting')
+          result.fetch(:capabilities).merge! static_hover unless dynamic_registration_for?('textDocument', 'hover')
+          result.fetch(:capabilities).merge! static_document_formatting unless dynamic_registration_for?('textDocument',
+                                                                                                         'formatting')
+          result.fetch(:capabilities).merge! static_document_symbols unless dynamic_registration_for?('textDocument',
+                                                                                                      'documentSymbol')
+          result.fetch(:capabilities).merge! static_definitions unless dynamic_registration_for?('textDocument', 'definition')
+          result.fetch(:capabilities).merge! static_type_definitions unless dynamic_registration_for?('textDocument',
+                                                                                                      'typeDefinition')
+          result.fetch(:capabilities).merge! static_rename unless dynamic_registration_for?('textDocument', 'rename')
+          result.fetch(:capabilities).merge! static_references unless dynamic_registration_for?('textDocument', 'references')
+          result.fetch(:capabilities).merge! static_workspace_symbols unless dynamic_registration_for?('workspace', 'symbol')
+          result.fetch(:capabilities).merge! static_folding_range unless dynamic_registration_for?('textDocument',
+                                                                                                   'foldingRange')
+          result.fetch(:capabilities).merge! static_highlights unless dynamic_registration_for?('textDocument',
+                                                                                                'documentHighlight')
           # @todo Temporarily disabled
-          # result[:capabilities].merge! static_code_action unless dynamic_registration_for?('textDocument', 'codeAction')
+          # result.fetch(:capabilities).merge! static_code_action unless dynamic_registration_for?('textDocument', 'codeAction')
           set_result result
         end
 

--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -146,7 +146,7 @@ module Solargraph
               result.push Chain::BlockVariable.new("&#{block_variable_name_node.children[0]}")
             end
           elsif n.type == :hash
-            result.push Chain::Hash.new('::Hash', n, hash_is_splatted?(n))
+            result.push Chain::Hash.new('::Hash', n, hash_is_splatted?(n), hash_pairs(n))
           elsif n.type == :array
             chained_children = n.children.map { |c| NodeChainer.chain(c) }
             result.push Source::Chain::Array.new(chained_children, n)
@@ -166,6 +166,27 @@ module Solargraph
             return false
           end
           true
+        end
+
+        # Chains each key/value pair of a literal hash so Chain::Hash
+        # can infer Hash{K => V} from its actual contents, the same
+        # way Chain::Array infers Array<T> from its elements. Returns
+        # nil (falling back to a bare, unparameterized Hash) when any
+        # entry isn't a plain `key => value` pair - a `**splat` entry
+        # contributes key/value types we have no node to chain.
+        #
+        # @param node [Parser::AST::Node]
+        # @return [::Array<::Array(Chain, Chain)>, nil]
+        def hash_pairs node
+          return nil unless Parser.is_ast_node?(node) && node.type == :hash
+          # @sg-ignore https://github.com/castwide/solargraph/pull/1223
+          return nil unless node.children.all? { |pair| Parser.is_ast_node?(pair) && pair.type == :pair }
+
+          node.children.map do |pair|
+            # @sg-ignore https://github.com/castwide/solargraph/pull/1223
+            key_node, value_node = pair.children
+            [NodeChainer.chain(key_node, @filename, pair), NodeChainer.chain(value_node, @filename, pair)]
+          end
         end
 
         # @param node [Parser::AST::Node]

--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -168,12 +168,9 @@ module Solargraph
           true
         end
 
-        # Chains each key/value pair of a literal hash so Chain::Hash
-        # can infer Hash{K => V} from its actual contents, the same
-        # way Chain::Array infers Array<T> from its elements. Returns
-        # nil (falling back to a bare, unparameterized Hash) when any
-        # entry isn't a plain `key => value` pair - a `**splat` entry
-        # contributes key/value types we have no node to chain.
+        # Chains each key/value pair so Chain::Hash can infer
+        # Hash{K => V}, mirroring how Chain::Array infers Array<T>.
+        # Returns nil for a `**splat` entry, which has no node to chain.
         #
         # @param node [Parser::AST::Node]
         # @return [::Array<::Array(Chain, Chain)>, nil]

--- a/lib/solargraph/parser/parser_gem/node_chainer.rb
+++ b/lib/solargraph/parser/parser_gem/node_chainer.rb
@@ -176,11 +176,9 @@ module Solargraph
         # @return [::Array<::Array(Chain, Chain)>, nil]
         def hash_pairs node
           return nil unless Parser.is_ast_node?(node) && node.type == :hash
-          # @sg-ignore https://github.com/castwide/solargraph/pull/1223
           return nil unless node.children.all? { |pair| Parser.is_ast_node?(pair) && pair.type == :pair }
 
           node.children.map do |pair|
-            # @sg-ignore https://github.com/castwide/solargraph/pull/1223
             key_node, value_node = pair.children
             [NodeChainer.chain(key_node, @filename, pair), NodeChainer.chain(value_node, @filename, pair)]
           end

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -227,10 +227,18 @@ module Solargraph
         ptype = typify api_map
         return true if ptype.undefined?
 
+        # :allow_unmatched_interface is included so that an
+        # RBS-interface-typed parameter (e.g. Hash#fetch's `_Key`) doesn't
+        # reject every argument that isn't nominally included in that
+        # interface via CoreFills::INCLUDES. Without it, no overload of a
+        # method like Hash#fetch ever matches a plain argument, and
+        # Pin::Method#return_type falls back to unioning every overload's
+        # return type together - including unbound generics from
+        # overloads that were never actually selected.
         return true if atype.conforms_to?(api_map,
                                           ptype,
                                           :method_call,
-                                          %i[allow_empty_params allow_undefined])
+                                          %i[allow_empty_params allow_undefined allow_unmatched_interface])
         ptype.generic?
       end
 

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -227,14 +227,9 @@ module Solargraph
         ptype = typify api_map
         return true if ptype.undefined?
 
-        # :allow_unmatched_interface is included so that an
-        # RBS-interface-typed parameter (e.g. Hash#fetch's `_Key`) doesn't
-        # reject every argument that isn't nominally included in that
-        # interface via CoreFills::INCLUDES. Without it, no overload of a
-        # method like Hash#fetch ever matches a plain argument, and
-        # Pin::Method#return_type falls back to unioning every overload's
-        # return type together - including unbound generics from
-        # overloads that were never actually selected.
+        # :allow_unmatched_interface lets an RBS-interface-typed
+        # parameter (e.g. Hash#fetch's `_Key`) accept an argument not
+        # nominally included in that interface via CoreFills::INCLUDES.
         return true if atype.conforms_to?(api_map,
                                           ptype,
                                           :method_call,

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -227,13 +227,10 @@ module Solargraph
         ptype = typify api_map
         return true if ptype.undefined?
 
-        # :allow_unmatched_interface lets an RBS-interface-typed
-        # parameter (e.g. Hash#fetch's `_Key`) accept an argument not
-        # nominally included in that interface via CoreFills::INCLUDES.
         return true if atype.conforms_to?(api_map,
                                           ptype,
                                           :method_call,
-                                          %i[allow_empty_params allow_undefined allow_unmatched_interface])
+                                          %i[allow_empty_params allow_undefined])
         ptype.generic?
       end
 

--- a/lib/solargraph/position.rb
+++ b/lib/solargraph/position.rb
@@ -121,6 +121,7 @@ module Solargraph
     # @return [Position]
     def self.normalize object
       return object if object.is_a?(Position)
+      # @sg-ignore https://github.com/castwide/solargraph/pull/1223
       return Position.new(object[0], object[1]) if object.is_a?(Array)
       raise ArgumentError, "Unable to convert #{object.class} to Position"
     end

--- a/lib/solargraph/position.rb
+++ b/lib/solargraph/position.rb
@@ -34,7 +34,7 @@ module Solargraph
     # Get a hash of the position. This representation is suitable for use in
     # the language server protocol.
     #
-    # @return [Hash]
+    # @return [Hash{Symbol => Integer}]
     def to_hash
       {
         line: line,

--- a/lib/solargraph/range.rb
+++ b/lib/solargraph/range.rb
@@ -32,7 +32,7 @@ module Solargraph
     # Get a hash of the range. This representation is suitable for use in
     # the language server protocol.
     #
-    # @return [Hash{Symbol => Position}]
+    # @return [Hash{Symbol => Hash{Symbol => Integer}}]
     def to_hash
       {
         start: start.to_hash,

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -7,17 +7,27 @@ module Solargraph
         # @param type [String]
         # @param node [Parser::AST::Node]
         # @param splatted [Boolean]
-        def initialize type, node, splatted = false
+        # @param pairs [::Array<::Array(Chain, Chain)>, nil] Each key/value
+        #   pair's key and value chained separately, or nil if the literal
+        #   isn't just a plain list of `key => value` pairs (e.g. it
+        #   contains a `**splat`) - see NodeChainer#hash_pairs.
+        def initialize type, node, splatted = false, pairs = nil
           super(type, node)
           @splatted = splatted
+          # @type [::Array<::Array(Chain, Chain)>, nil]
+          @pairs = pairs
         end
 
         def word
           @word ||= "<#{@type}>"
         end
 
-        def resolve api_map, name_pin, locals
-          [Pin::ProxyType.anonymous(@complex_type, source: :chain)]
+        # @param api_map [ApiMap]
+        # @param name_pin [Pin::Base]
+        # @param locals [::Array<Pin::Base>]
+        # @param _receiver_path [::Array<String>, nil]
+        def resolve api_map, name_pin, locals, _receiver_path = nil
+          [Pin::ProxyType.anonymous(inferred_type(api_map, name_pin, locals), source: :chain)]
         end
 
         def splatted?
@@ -30,6 +40,39 @@ module Solargraph
         def equality_fields
           # @sg-ignore literal arrays in this module turn into ::Solargraph::Source::Chain::Array
           super + [@splatted]
+        end
+
+        private
+
+        # Infers Hash{K => V} from the literal's actual key/value pairs,
+        # the same way Chain::Array infers Array<T> from its elements
+        # (see Chain::Array#resolve). Falls back to the bare, generic-less
+        # ::Hash type - the only type a splatted hash or one that fails to
+        # infer any pair concretely ever had - rather than reporting a
+        # partial/incorrect Hash{K => V}.
+        #
+        # @param api_map [ApiMap]
+        # @param name_pin [Pin::Base]
+        # @param locals [::Array<Pin::Base>]
+        # @return [ComplexType]
+        def inferred_type api_map, name_pin, locals
+          # @type [::Array<::Array(Chain, Chain)>, nil]
+          pairs = @pairs
+          return @complex_type if pairs.nil? || pairs.empty?
+
+          key_types = []
+          value_types = []
+          pairs.each do |pair|
+            key_chain, value_chain = pair
+            key_type = key_chain.infer(api_map, name_pin, locals).simplify_literals
+            value_type = value_chain.infer(api_map, name_pin, locals).simplify_literals
+            return @complex_type if key_type.undefined? || value_type.undefined?
+
+            key_types.push key_type
+            value_types.push value_type
+          end
+          ComplexType.new([ComplexType::UniqueType.new('Hash', key_types.uniq, value_types.uniq,
+                                                       rooted: true, parameters_type: :hash)])
         end
       end
     end

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -14,7 +14,6 @@ module Solargraph
         def initialize type, node, splatted = false, pairs = nil
           super(type, node)
           @splatted = splatted
-          # @type [::Array<::Array(Chain, Chain)>, nil]
           @pairs = pairs
         end
 

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -7,10 +7,9 @@ module Solargraph
         # @param type [String]
         # @param node [Parser::AST::Node]
         # @param splatted [Boolean]
-        # @param pairs [::Array<::Array(Chain, Chain)>, nil] Each key/value
-        #   pair's key and value chained separately, or nil if the literal
-        #   isn't just a plain list of `key => value` pairs (e.g. it
-        #   contains a `**splat`) - see NodeChainer#hash_pairs.
+        # @param pairs [::Array<::Array(Chain, Chain)>, nil] Chained key/value
+        #   pairs, or nil for a splatted or non-plain-pairs literal - see
+        #   NodeChainer#hash_pairs.
         def initialize type, node, splatted = false, pairs = nil
           super(type, node)
           @splatted = splatted
@@ -43,12 +42,9 @@ module Solargraph
 
         private
 
-        # Infers Hash{K => V} from the literal's actual key/value pairs,
-        # the same way Chain::Array infers Array<T> from its elements
-        # (see Chain::Array#resolve). Falls back to the bare, generic-less
-        # ::Hash type - the only type a splatted hash or one that fails to
-        # infer any pair concretely ever had - rather than reporting a
-        # partial/incorrect Hash{K => V}.
+        # Infers Hash{K => V} from the literal's pairs, mirroring
+        # Chain::Array's element inference. Falls back to bare ::Hash
+        # when splatted or any pair fails to infer.
         #
         # @param api_map [ApiMap]
         # @param name_pin [Pin::Base]

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -51,7 +51,6 @@ module Solargraph
         # @param locals [::Array<Pin::Base>]
         # @return [ComplexType]
         def inferred_type api_map, name_pin, locals
-          # @type [::Array<::Array(Chain, Chain)>, nil]
           pairs = @pairs
           return @complex_type if pairs.nil? || pairs.empty?
 

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -23,8 +23,7 @@ module Solargraph
         # @param api_map [ApiMap]
         # @param name_pin [Pin::Base]
         # @param locals [::Array<Pin::Base>]
-        # @param _receiver_path [::Array<String>, nil]
-        def resolve api_map, name_pin, locals, _receiver_path = nil
+        def resolve api_map, name_pin, locals
           [Pin::ProxyType.anonymous(inferred_type(api_map, name_pin, locals), source: :chain)]
         end
 

--- a/lib/solargraph/source/chain/hash.rb
+++ b/lib/solargraph/source/chain/hash.rb
@@ -55,7 +55,9 @@ module Solargraph
           pairs = @pairs
           return @complex_type if pairs.nil? || pairs.empty?
 
+          # @type [::Array<ComplexType>]
           key_types = []
+          # @type [::Array<ComplexType>]
           value_types = []
           pairs.each do |pair|
             key_chain, value_chain = pair

--- a/lib/solargraph/type_checker/rules.rb
+++ b/lib/solargraph/type_checker/rules.rb
@@ -17,18 +17,20 @@ module Solargraph
       attr_reader :level
 
       # @return [Integer]
+      # @sg-ignore https://github.com/castwide/solargraph/pull/1266
       attr_reader :rank
 
       # @param level [Symbol]
       # @param overrides [Hash{Symbol => Symbol}]
       def initialize level, overrides
-        @rank = if LEVELS.key?(level)
-                  LEVELS[level]
-                else
-                  Solargraph.logger.warn "Unrecognized TypeChecker level #{level}, assuming normal"
-                  0
-                end
-        @level = LEVELS[LEVELS.values.index(@rank)]
+        if LEVELS.key?(level)
+          @rank = LEVELS.fetch(level)
+          @level = level
+        else
+          Solargraph.logger.warn "Unrecognized TypeChecker level #{level}, assuming normal"
+          @rank = 0
+          @level = :normal
+        end
         @overrides = overrides
       end
 
@@ -150,7 +152,8 @@ module Solargraph
       # @param type [Symbol]
       # @param level [Symbol]
       def report? type, level
-        rank >= LEVELS[@overrides.fetch(type, level)]
+        # @sg-ignore https://github.com/castwide/solargraph/pull/1266
+        rank >= LEVELS.fetch(@overrides.fetch(type, level))
       end
     end
   end

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -101,6 +101,32 @@ describe Solargraph::TypeChecker do
       expect(checker.problems.map(&:message)).to be_empty
     end
 
+    it 'does not leak an unbound generic from an unmatched Hash#fetch overload' do
+      checker = type_checker(%(
+        class A
+          # @param b [Hash{String => Integer}]
+          # @return [Integer]
+          def a b
+            b.fetch('x')
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
+    it 'infers nil as part of Hash#[] on a plainly-typed Hash' do
+      checker = type_checker(%(
+        class A
+          # @param b [Hash{String => Integer}]
+          # @return [Integer, nil]
+          def a b
+            b['x']
+          end
+        end
+      ))
+      expect(checker.problems.map(&:message)).to be_empty
+    end
+
     it 'respects pin visibility in if/nil? pattern' do
       checker = type_checker(%(
         class Foo

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -102,6 +102,7 @@ describe Solargraph::TypeChecker do
     end
 
     it 'does not leak an unbound generic from an unmatched Hash#fetch overload' do
+      pending 'https://github.com/castwide/solargraph/pull/1266'
       checker = type_checker(%(
         class A
           # @param b [Hash{String => Integer}]

--- a/spec/type_checker/levels/strong_spec.rb
+++ b/spec/type_checker/levels/strong_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'rbs'
+
 describe Solargraph::TypeChecker do
   context 'with level set to strong' do
     def type_checker code
@@ -102,7 +104,9 @@ describe Solargraph::TypeChecker do
     end
 
     it 'does not leak an unbound generic from an unmatched Hash#fetch overload' do
-      pending 'https://github.com/castwide/solargraph/pull/1266'
+      # Hash#fetch only takes its key as the _Key interface (rather than
+      # the generic K) as of RBS 4.1.0 - see ruby/rbs core/hash.rbs.
+      pending 'https://github.com/castwide/solargraph/pull/1266' if Gem::Version.new(RBS::VERSION) >= Gem::Version.new('4.1.0')
       checker = type_checker(%(
         class A
           # @param b [Hash{String => Integer}]


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

A Hash literal infers only the bare `::Hash` — far less precise than an Array literal, which already infers `Array<T>` from its elements.

```ruby
# @return [Hash{String => Integer}]
def h
  { 'a' => 1 }   # infers ::Hash, not Hash{String => Integer}
end
```

That imprecision costs anything downstream that needs the Hash's real key/value types to type-check — `#fetch`, `#[]`, `#each`, and the per-conjunct Hash-record dispatch in castwide/solargraph#1231.

## Solution

`NodeChainer#hash_pairs` chains each key/value pair of a hash literal, and `Chain::Hash#inferred_type` infers `Hash{K => V}` from those pairs' own inferred types, mirroring how `Chain::Array` already infers `Array<T>`. The `plugins.yml` repoint tests this against lekemula/solargraph-rspec#36, which expects the added precision.

Dropped the `:allow_unmatched_interface` addition to `Pin::Parameter#compatible_arg?` that was bundled here to fix #1227 — castwide/solargraph#1266 already fixes that properly via real structural conformance, and #1231's own Hash-record dispatch is the more complete answer for the record-shaped case. The #1227 regression spec is now `pending`, citing #1266.
