### PR TITLE
Resolve RBS aliases to generically inherited methods

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -188,7 +188,6 @@ module Solargraph
     # @param name [String, nil]
     # @return [Solargraph::YardMap::Macro, nil]
     def named_macro name
-      # @sg-ignore Need to add nil check here
       store.named_macros[name]
     end
 

--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -941,8 +941,11 @@ module Solargraph
       original = nil
 
       # Search each ancestor for the original method
-      ancestors.each do |ancestor_fqns|
-        next if ancestor_fqns.nil?
+      ancestors.each do |ancestor_tag|
+        next if ancestor_tag.nil?
+        # A generic superclass arrives parameterized - "Hash<Symbol, undefined>"
+        # rather than "Hash" - and method paths are indexed by bare namespace.
+        ancestor_fqns = ComplexType.try_parse(ancestor_tag).namespace
         ancestor_method_path = if alias_pin.original == 'new' && alias_pin.scope == :class
                                  "#{ancestor_fqns}#initialize"
                                else

--- a/spec/rbs_map/conversions_spec.rb
+++ b/spec/rbs_map/conversions_spec.rb
@@ -93,27 +93,6 @@ describe Solargraph::RbsMap::Conversions do
         expect(method_pin.return_type.tag).to eq('undefined')
       end
     end
-  end
-
-  context 'with standard loads for solargraph project' do
-    before :all do # rubocop:disable RSpec/BeforeAfterAll
-      @api_map = Solargraph::ApiMap.load_with_cache('.')
-    end
-
-    let(:api_map) { @api_map }
-
-    context 'with superclass pin for Parser::AST::Node' do
-      let(:superclass_pin) do
-        api_map.pins.find do |pin|
-          pin.is_a?(Solargraph::Pin::Reference::Superclass) && pin.context.namespace == 'Parser::AST::Node'
-        end
-      end
-
-      it 'generates a rooted pin' do
-        # rooted!
-        expect(superclass_pin&.name).to eq('::AST::Node')
-      end
-    end
 
     # https://github.com/castwide/solargraph/issues/1042
     context 'with Hash superclass with untyped value and alias' do
@@ -137,6 +116,10 @@ describe Solargraph::RbsMap::Conversions do
         expect { sub_alias_stack }.not_to raise_error
       end
 
+      it 'resolves the alias to the inherited method' do
+        expect(sub_alias_stack).not_to be_empty
+      end
+
       it 'finds superclass method pin return type' do
         expect(sup_method_stack.map(&:return_type).map(&:rooted_tags).uniq).to eq(['undefined'])
       end
@@ -153,6 +136,27 @@ describe Solargraph::RbsMap::Conversions do
                    end
         expect(sup_method_stack.flat_map(&:signatures).flat_map(&:parameters).map(&:return_type).map(&:rooted_tags)
                  .uniq).to eq(expected)
+      end
+    end
+  end
+
+  context 'with standard loads for solargraph project' do
+    before :all do # rubocop:disable RSpec/BeforeAfterAll
+      @api_map = Solargraph::ApiMap.load_with_cache('.')
+    end
+
+    let(:api_map) { @api_map }
+
+    context 'with superclass pin for Parser::AST::Node' do
+      let(:superclass_pin) do
+        api_map.pins.find do |pin|
+          pin.is_a?(Solargraph::Pin::Reference::Superclass) && pin.context.namespace == 'Parser::AST::Node'
+        end
+      end
+
+      it 'generates a rooted pin' do
+        # rooted!
+        expect(superclass_pin&.name).to eq('::AST::Node')
       end
     end
   end


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

**Problem:** an RBS `alias` whose target is inherited from a generic superclass resolves to no method at all.

```ruby
# class Sub < Hash[Symbol, untyped]
#   alias meth_alias []
# end

api_map.get_method_stack('Sub', 'meth_alias', scope: :instance)
# => []                                    (expected Hash#[])
```

`resolve_method_alias` joins each `get_ancestors` entry to the method name, but a generic superclass arrives parameterized - `get_ancestors("Sub")` gives `"Hash<Symbol, undefined>"`, not `"Hash"` - so the lookup asks for `"Hash<Symbol, undefined>#[]"` while the path index is keyed `"Hash#[]"`. A plain superclass carries no arguments, which is why only the generic case fails.

**Solution:** reduce each ancestor to its namespace before building the method path; `resolve_method_alias` is the only caller of `get_ancestors`, so nothing else is affected.
