### PR TITLE
Add rspec-time-guard to catch hanging specs

### DIFF
--- a/solargraph.gemspec
+++ b/solargraph.gemspec
@@ -59,6 +59,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency 'public_suffix', '~> 3.1'
   s.add_development_dependency 'rake', '~> 13.2'
   s.add_development_dependency 'rspec', '~> 3.5'
+  s.add_development_dependency 'rspec-time-guard', '~> 0.2.0'
   #
   # very specific development-time RuboCop version patterns for CI
   # stability - feel free to update in an isolated PR

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -117,15 +117,15 @@ describe Solargraph::ApiMap do
     end
   end
 
-  describe '#get_method_stack' do
+  describe '#get_method_stack', time_limit_seconds: 240 do
     let(:out) { StringIO.new }
     let(:api_map) { described_class.load_with_cache(Dir.pwd, out) }
 
-    context 'with stdlib that has vital dependencies' do
+    context 'with stdlib that has vital dependencies', time_limit_seconds: 240 do
       let(:external_requires) { ['yaml'] }
       let(:method_stack) { api_map.get_method_stack('YAML', 'safe_load', scope: :class) }
 
-      it 'handles the YAML gem aliased to Psych' do
+      it 'handles the YAML gem aliased to Psych', time_limit_seconds: 240 do
         expect(method_stack).not_to be_empty
       end
     end

--- a/spec/api_map_method_spec.rb
+++ b/spec/api_map_method_spec.rb
@@ -117,15 +117,15 @@ describe Solargraph::ApiMap do
     end
   end
 
-  describe '#get_method_stack', time_limit_seconds: 240 do
+  describe '#get_method_stack', time_limit_seconds: 400 do
     let(:out) { StringIO.new }
     let(:api_map) { described_class.load_with_cache(Dir.pwd, out) }
 
-    context 'with stdlib that has vital dependencies', time_limit_seconds: 240 do
+    context 'with stdlib that has vital dependencies', time_limit_seconds: 400 do
       let(:external_requires) { ['yaml'] }
       let(:method_stack) { api_map.get_method_stack('YAML', 'safe_load', scope: :class) }
 
-      it 'handles the YAML gem aliased to Psych', time_limit_seconds: 240 do
+      it 'handles the YAML gem aliased to Psych', time_limit_seconds: 400 do
         expect(method_stack).not_to be_empty
       end
     end

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -7,7 +7,7 @@ describe Solargraph::ApiMap do
     @api_map = described_class.new
   end
 
-  it 'returns core methods' do
+  it 'returns core methods', time_limit_seconds: 120 do
     pins = @api_map.get_methods('String')
     expect(pins.map(&:path)).to include('String#upcase')
   end

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -7,7 +7,7 @@ describe Solargraph::ApiMap do
     @api_map = described_class.new
   end
 
-  it 'returns core methods', time_limit_seconds: 120 do
+  it 'returns core methods', time_limit_seconds: 200 do
     pins = @api_map.get_methods('String')
     expect(pins.map(&:path)).to include('String#upcase')
   end

--- a/spec/language_server/host_spec.rb
+++ b/spec/language_server/host_spec.rb
@@ -275,7 +275,7 @@ describe Solargraph::LanguageServer::Host do
       expect(symbols).not_to be_empty
     end
 
-    it 'opens a file outside of prepared libraries' do
+    it 'opens a file outside of prepared libraries', time_limit_seconds: 120 do
       @host.prepare(File.absolute_path(File.join('spec', 'fixtures', 'workspace')))
       @host.open('file:///file.rb', 'class Foo; end', 1)
       symbols = @host.document_symbols('file:///file.rb')

--- a/spec/language_server/host_spec.rb
+++ b/spec/language_server/host_spec.rb
@@ -275,7 +275,7 @@ describe Solargraph::LanguageServer::Host do
       expect(symbols).not_to be_empty
     end
 
-    it 'opens a file outside of prepared libraries', time_limit_seconds: 120 do
+    it 'opens a file outside of prepared libraries', time_limit_seconds: 200 do
       @host.prepare(File.absolute_path(File.join('spec', 'fixtures', 'workspace')))
       @host.open('file:///file.rb', 'class Foo; end', 1)
       symbols = @host.document_symbols('file:///file.rb')

--- a/spec/language_server/protocol_spec.rb
+++ b/spec/language_server/protocol_spec.rb
@@ -424,7 +424,7 @@ describe Protocol do
     expect(response['result']['available']).to be_a(String)
   end
 
-  it 'handles $/solargraph/documentGems' do
+  it 'handles $/solargraph/documentGems', time_limit_seconds: 120 do
     @protocol.request '$/solargraph/documentGems', {}
     response = @protocol.response
     expect(response['error']).to be_nil

--- a/spec/language_server/protocol_spec.rb
+++ b/spec/language_server/protocol_spec.rb
@@ -424,7 +424,7 @@ describe Protocol do
     expect(response['result']['available']).to be_a(String)
   end
 
-  it 'handles $/solargraph/documentGems', time_limit_seconds: 120 do
+  it 'handles $/solargraph/documentGems', time_limit_seconds: 200 do
     @protocol.request '$/solargraph/documentGems', {}
     response = @protocol.response
     expect(response['error']).to be_nil

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,12 +2,12 @@
 
 require 'bundler/setup'
 require 'webmock/rspec'
+require 'rspec_time_guard'
 WebMock.disable_net_connect!(allow_localhost: true)
 unless ENV['SIMPLECOV_DISABLED']
   # set up lcov reporting for undercover
   require 'simplecov'
   require 'undercover/simplecov_formatter'
-
   SimpleCov.start do
     cname = ENV.fetch('TEST_COVERAGE_COMMAND_NAME', 'ad-hoc')
     command_name cname
@@ -27,6 +27,12 @@ RSpec.configure do |c|
   # Allow use of --only-failures with rspec, handy for local development
   c.example_status_persistence_file_path = 'rspec-examples.txt'
 end
+RspecTimeGuard.setup
+RspecTimeGuard.configure do |config|
+  config.global_time_limit_seconds = 60
+  config.continue_on_timeout = false
+end
+
 require 'solargraph'
 # execute any logging blocks to make sure they don't blow up
 Solargraph::Logging.logger.sev_threshold = Logger::DEBUG

--- a/spec/workspace/gemspecs_fetch_dependencies_spec.rb
+++ b/spec/workspace/gemspecs_fetch_dependencies_spec.rb
@@ -77,7 +77,7 @@ describe Solargraph::Workspace::Gemspecs, '#fetch_dependencies' do
     context 'with gem that exists in our bundle' do
       let(:gem_name) { 'undercover' }
 
-      it 'finds dependencies' do
+      it 'finds dependencies', time_limit_seconds: 120 do
         expect(deps.map(&:name)).to include('ast')
       end
     end
@@ -85,7 +85,7 @@ describe Solargraph::Workspace::Gemspecs, '#fetch_dependencies' do
     context 'with gem does not exist in our bundle' do
       let(:gem_name) { 'activerecord' }
 
-      it 'gives a useful message' do
+      it 'gives a useful message', time_limit_seconds: 120 do
         dep_names = nil
         output = capture_both { dep_names = deps.map(&:name) }
         expect(output).to include('Please install the gem activerecord')

--- a/spec/workspace/gemspecs_fetch_dependencies_spec.rb
+++ b/spec/workspace/gemspecs_fetch_dependencies_spec.rb
@@ -77,7 +77,7 @@ describe Solargraph::Workspace::Gemspecs, '#fetch_dependencies' do
     context 'with gem that exists in our bundle' do
       let(:gem_name) { 'undercover' }
 
-      it 'finds dependencies', time_limit_seconds: 120 do
+      it 'finds dependencies', time_limit_seconds: 200 do
         expect(deps.map(&:name)).to include('ast')
       end
     end
@@ -85,7 +85,7 @@ describe Solargraph::Workspace::Gemspecs, '#fetch_dependencies' do
     context 'with gem does not exist in our bundle' do
       let(:gem_name) { 'activerecord' }
 
-      it 'gives a useful message', time_limit_seconds: 120 do
+      it 'gives a useful message', time_limit_seconds: 200 do
         dep_names = nil
         output = capture_both { dep_names = deps.map(&:name) }
         expect(output).to include('Please install the gem activerecord')


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

**Problem:**
A spec that hangs — on a network call, an infinite loop, an unresponsive external process — blocks the whole CI run indefinitely instead of failing with a clear timeout, since nothing in the suite currently enforces a time limit.

```ruby
# before: no limit -- a hang here blocks CI until the job's own timeout kills the whole run
it 'handles the YAML gem aliased to Psych' do
  expect(method_stack).not_to be_empty
end

# after: fails in 400s with a clear timeout instead
it 'handles the YAML gem aliased to Psych', time_limit_seconds: 400 do
  expect(method_stack).not_to be_empty
end
```

**Solution:**
Adds the `rspec-time-guard` gem with a 60s global default (`spec_helper.rb`), plus longer explicit `time_limit_seconds:` overrides on the handful of specs that legitimately run longer — pure dev/test tooling, no runtime behavior change.

Each non-default limit reflects a real, CI-observed duration: stdlib/gem resolution and YAML/Thor lookups are legitimately slow, not hung, and the YAML/Psych spec timed out in CI at 240.33s against its first 240s limit — a 0.14% margin.
