### PR TITLE
Kernel#send doesn't work with splat blocks

### DIFF
--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -43,32 +43,18 @@ module Solargraph
 
       # @param yield_types [::Array<ComplexType>]
       # @param parameters [::Array<Parameter>]
-      # @param yield_params [::Array<Parameter>, nil] the yielding method's
-      #   own block signature parameters that produced yield_types - used to
-      #   tell a genuine single yielded value apart from a splat
-      #   ("*arg") standing in for an unknown number of values (e.g. a
-      #   dynamically-dispatched `.send(...) { ... }` block, whose RBS
-      #   signature is `(*arg ::Array) -> untyped`)
+      # @param yield_params [::Array<Parameter>, nil] the yielding method's own block parameters
       #
       # @return [::Array<ComplexType>]
-      # @sg-ignore Declared return type does not match inferred - adding the
-      #   splat-detection return below changes how Solargraph merges this
-      #   method's multiple return paths, and it now infers Enumerator
-      #   instead of Array for the tail expression even though that
-      #   expression is unchanged from before this method had more than
-      #   one return path, when it typechecked cleanly.
+      # @sg-ignore Adding the splat-detection return path changes the merged return type Solargraph infers for the unchanged tail expression
       def destructure_yield_types yield_types, parameters, yield_params = nil
         # yielding a tuple into a block will destructure the tuple
         if yield_types.length == 1
           yield_type = yield_types.first
           return yield_type.all_params if yield_type.tuple? && yield_type.all_params.length == parameters.length
         end
-        # A lone splat block parameter on the yielding method means "an
-        # unknown number of values will be yielded," not "one value,
-        # typed as an Array, was yielded." Binding that whole Array type
-        # to the block's own first parameter is wrong whenever that
-        # parameter isn't itself a splat - Ruby truncates to the first
-        # yielded value there, it doesn't collect them into an Array.
+        # A lone splat yield param means unknown arity was yielded, not one
+        # Array value - don't bind the whole Array to a non-splat block param.
         if single_unknown_arity_splat?(yield_params) && !(parameters.length == 1 && parameters.first&.restarg?)
           return parameters.map { ComplexType::UNDEFINED }
         end

--- a/lib/solargraph/pin/block.rb
+++ b/lib/solargraph/pin/block.rb
@@ -43,15 +43,44 @@ module Solargraph
 
       # @param yield_types [::Array<ComplexType>]
       # @param parameters [::Array<Parameter>]
+      # @param yield_params [::Array<Parameter>, nil] the yielding method's
+      #   own block signature parameters that produced yield_types - used to
+      #   tell a genuine single yielded value apart from a splat
+      #   ("*arg") standing in for an unknown number of values (e.g. a
+      #   dynamically-dispatched `.send(...) { ... }` block, whose RBS
+      #   signature is `(*arg ::Array) -> untyped`)
       #
       # @return [::Array<ComplexType>]
-      def destructure_yield_types yield_types, parameters
+      # @sg-ignore Declared return type does not match inferred - adding the
+      #   splat-detection return below changes how Solargraph merges this
+      #   method's multiple return paths, and it now infers Enumerator
+      #   instead of Array for the tail expression even though that
+      #   expression is unchanged from before this method had more than
+      #   one return path, when it typechecked cleanly.
+      def destructure_yield_types yield_types, parameters, yield_params = nil
         # yielding a tuple into a block will destructure the tuple
         if yield_types.length == 1
           yield_type = yield_types.first
           return yield_type.all_params if yield_type.tuple? && yield_type.all_params.length == parameters.length
         end
+        # A lone splat block parameter on the yielding method means "an
+        # unknown number of values will be yielded," not "one value,
+        # typed as an Array, was yielded." Binding that whole Array type
+        # to the block's own first parameter is wrong whenever that
+        # parameter isn't itself a splat - Ruby truncates to the first
+        # yielded value there, it doesn't collect them into an Array.
+        if single_unknown_arity_splat?(yield_params) && !(parameters.length == 1 && parameters.first&.restarg?)
+          return parameters.map { ComplexType::UNDEFINED }
+        end
         parameters.map.with_index { |_, idx| yield_types[idx] || ComplexType::UNDEFINED }
+      end
+
+      # @param yield_params [::Array<Parameter>, nil]
+      # @return [Boolean]
+      def single_unknown_arity_splat? yield_params
+        return false if yield_params.nil? || yield_params.length != 1
+
+        yield_params.first&.restarg? == true
       end
 
       # @param api_map [ApiMap]
@@ -69,10 +98,12 @@ module Solargraph
           next if meth.block.nil?
 
           # @sg-ignore flow sensitive typing needs to handle attrs
-          yield_types = meth.block.parameters.map(&:return_type)
+          yield_params = meth.block.parameters
+          # @sg-ignore flow sensitive typing needs to handle attrs
+          yield_types = yield_params.map(&:return_type)
           # 'arguments' is what the method says it will yield to the
           # block; 'parameters' is what the block accepts
-          argument_types = destructure_yield_types(yield_types, parameters)
+          argument_types = destructure_yield_types(yield_types, parameters, yield_params)
           param_types = argument_types.each_with_index.map do |arg_type, idx|
             param = parameters[idx]
             param_type = chain.base.infer(api_map, param, locals)

--- a/spec/pin/block_spec.rb
+++ b/spec/pin/block_spec.rb
@@ -9,4 +9,34 @@ describe Solargraph::Pin::Block do
     pin = described_class.new(args: [foo, bar, block])
     expect(pin.parameter_names).to eq(%w[foo bar block])
   end
+
+  it 'leaves a block parameter undefined when dispatched via #send' do
+    # Kernel#send's own block signature is a real splat -
+    # `(*arg ::Array) -> untyped` - representing "however many values
+    # the dynamically-dispatched method yields," not "one value, typed
+    # as an Array, was yielded." A direct call to the same method with
+    # the same block infers the declared @yieldparam type; the #send
+    # call must not fall back to typing the block parameter as the
+    # whole Array.
+    source = Solargraph::Source.load_string(%(
+      class SendDispatch
+        # @param items [Array<String>]
+        # @yieldparam item [String]
+        # @return [void]
+        def each_item(items)
+          items.each { |raw| yield raw }
+        end
+      end
+
+      SendDispatch.new.each_item(['a']) { |item| item }
+      SendDispatch.new.send(:each_item, ['a']) { |item| item }
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    locals = api_map.source_map('test.rb').locals.select { |l| l.name == 'item' }
+    expect(locals.length).to eq(2)
+    direct, dispatched = locals
+    expect(direct.typify(api_map).tag).to eq('String')
+    expect(dispatched.typify(api_map)).to be_undefined
+  end
 end

--- a/spec/pin/block_spec.rb
+++ b/spec/pin/block_spec.rb
@@ -11,13 +11,8 @@ describe Solargraph::Pin::Block do
   end
 
   it 'leaves a block parameter undefined when dispatched via #send' do
-    # Kernel#send's own block signature is a real splat -
-    # `(*arg ::Array) -> untyped` - representing "however many values
-    # the dynamically-dispatched method yields," not "one value, typed
-    # as an Array, was yielded." A direct call to the same method with
-    # the same block infers the declared @yieldparam type; the #send
-    # call must not fall back to typing the block parameter as the
-    # whole Array.
+    # Kernel#send's own block signature is a real splat (`(*arg ::Array) -> untyped`),
+    # not a promise that one Array-typed value was yielded.
     source = Solargraph::Source.load_string(%(
       class SendDispatch
         # @param items [Array<String>]


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

**Problem:**

```ruby
3.times { |i| i }          # i: Integer (correct)
3.send(:times) { |i| i }   # i: Array (wrong — should be undefined)
```

**Cause:**

```ruby
# def send: (name interned, *arg_1 Array, **arg_2 Hash[Symbol, Object])
#   { (*arg ::Array) -> untyped } -> untyped
```

`Pin::Block#typify_parameters` treated the splat's `return_type` as a genuine single yielded value, so the `.send`-dispatched block bound the whole `Array` to its parameter instead of leaving it undefined.

**Solution:**

`destructure_yield_types` now also takes the yielding method's own block parameter pins, not just their resolved types, so a new `single_unknown_arity_splat?` check can tell a lone splat (`*arg`) apart from a genuine single yielded value.

When it fires, every declared block parameter is left `UNDEFINED` instead of bound to the whole `Array`.

Found while auditing `@sg-ignore` suppressions in a downstream project.
