### PR TITLE
Cached RBS types leak between open workspace folders

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -93,6 +93,13 @@ Metrics/PerceivedComplexity:
 RSpec/ExampleLength:
   Max: 310
 
+# CollectionType rejects Hash<Key, Value> as ambiguous, so no Hash type
+# satisfies both cops: long style is unwritable for a Hash, and short style
+# would rewrite every Array<T> in the codebase as Array[T]. CollectionType
+# alone already matches what we write - Array<T> and Hash{K => V}.
+YARD/CollectionStyle:
+  Enabled: false
+
 plugins:
   - rubocop-rspec
   - rubocop-rake

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -347,6 +347,13 @@ Style/SuperArguments:
     - 'lib/solargraph/pin/method.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
+# Configuration parameters: EnforcedStyle.
+# SupportedStyles: long, short
+YARD/CollectionStyle:
+  Exclude:
+    - 'lib/solargraph/pin_cache.rb'
+
+# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStylePrototypeName.
 # SupportedStylesPrototypeName: before, after
 YARD/MismatchName:

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -347,13 +347,6 @@ Style/SuperArguments:
     - 'lib/solargraph/pin/method.rb'
 
 # This cop supports safe autocorrection (--autocorrect).
-# Configuration parameters: EnforcedStyle.
-# SupportedStyles: long, short
-YARD/CollectionStyle:
-  Exclude:
-    - 'lib/solargraph/pin_cache.rb'
-
-# This cop supports safe autocorrection (--autocorrect).
 # Configuration parameters: EnforcedStylePrototypeName.
 # SupportedStylesPrototypeName: before, after
 YARD/MismatchName:

--- a/lib/solargraph/doc_map.rb
+++ b/lib/solargraph/doc_map.rb
@@ -98,7 +98,7 @@ module Solargraph
       rbs_version_cache_key = rbs_map.cache_key
       # cache pins even if result is zero, so we don't retry building pins
       pins ||= []
-      PinCache.serialize_rbs_collection_gem(gemspec, rbs_version_cache_key, pins)
+      pin_cache.serialize_rbs_collection_gem(gemspec, pins)
       logger.info { "Cached #{pins.length} RBS collection pins for gem #{gemspec.name} #{gemspec.version} with cache_key #{rbs_version_cache_key.inspect}" unless pins.empty? }
     end
 
@@ -150,15 +150,12 @@ module Solargraph
       self.class.all_rbs_collection_gems_in_memory[rbs_collection_path] ||= {}
     end
 
-    # @return [Hash{Array(String, String) => Array<Pin::Base>}] Indexed by gemspec name and version
-    def self.all_combined_pins_in_memory
-      @all_combined_pins_in_memory ||= {}
-    end
-
-    # @todo this should also include an index by the hash of the RBS collection
-    # @return [Hash{Array(String, String) => Array<Pin::Base>}] Indexed by gemspec name and version
-    def combined_pins_in_memory
-      self.class.all_combined_pins_in_memory
+    # The cache scoped to this doc map's RBS configuration.
+    #
+    # @return [PinCache]
+    def pin_cache
+      @pin_cache ||= PinCache.new(rbs_collection_path: rbs_collection_path,
+                                  rbs_collection_config_path: rbs_collection_config_path)
     end
 
     # @return [Array<String>]
@@ -233,41 +230,30 @@ module Solargraph
     # @param gemspec [Gem::Specification]
     # @return [void]
     def deserialize_combined_pin_cache gemspec
-      unless combined_pins_in_memory[[gemspec.name, gemspec.version]].nil?
-        return combined_pins_in_memory[[gemspec.name, gemspec.version]]
-      end
-
-      rbs_map = RbsMap.from_gemspec(gemspec, rbs_collection_path, rbs_collection_config_path)
-      rbs_version_cache_key = rbs_map.cache_key
-
-      cached = PinCache.deserialize_combined_gem(gemspec, rbs_version_cache_key)
+      cached = pin_cache.deserialize_combined_gem(gemspec)
       if cached
         logger.info { "Loaded #{cached.length} cached YARD pins from #{gemspec.name}:#{gemspec.version}" }
-        combined_pins_in_memory[[gemspec.name, gemspec.version]] = cached
-        return combined_pins_in_memory[[gemspec.name, gemspec.version]]
+        return cached
       end
 
-      rbs_collection_pins = deserialize_rbs_collection_cache gemspec, rbs_version_cache_key
+      rbs_collection_pins = deserialize_rbs_collection_cache gemspec
 
       yard_pins = deserialize_yard_pin_cache gemspec
 
       if !rbs_collection_pins.nil? && !yard_pins.nil?
         logger.debug { "Combining pins for #{gemspec.name}:#{gemspec.version}" }
         combined_pins = GemPins.combine(yard_pins, rbs_collection_pins)
-        PinCache.serialize_combined_gem(gemspec, rbs_version_cache_key, combined_pins)
-        combined_pins_in_memory[[gemspec.name, gemspec.version]] = combined_pins
-        logger.info { "Generated #{combined_pins_in_memory[[gemspec.name, gemspec.version]].length} combined pins for #{gemspec.name} #{gemspec.version}" }
+        pin_cache.serialize_combined_gem(gemspec, combined_pins)
+        logger.info { "Generated #{combined_pins.length} combined pins for #{gemspec.name} #{gemspec.version}" }
         return combined_pins
       end
 
       if !yard_pins.nil?
         logger.debug { "Using only YARD pins for #{gemspec.name}:#{gemspec.version}" }
-        combined_pins_in_memory[[gemspec.name, gemspec.version]] = yard_pins
-        combined_pins_in_memory[[gemspec.name, gemspec.version]]
+        yard_pins
       elsif !rbs_collection_pins.nil?
         logger.debug { "Using only RBS collection pins for #{gemspec.name}:#{gemspec.version}" }
-        combined_pins_in_memory[[gemspec.name, gemspec.version]] = rbs_collection_pins
-        combined_pins_in_memory[[gemspec.name, gemspec.version]]
+        rbs_collection_pins
       else
         logger.debug { "Pins not yet cached for #{gemspec.name}:#{gemspec.version}" }
         nil
@@ -291,11 +277,11 @@ module Solargraph
     end
 
     # @param gemspec [Gem::Specification]
-    # @param rbs_version_cache_key [String]
     # @return [Array<Pin::Base>, nil]
-    def deserialize_rbs_collection_cache gemspec, rbs_version_cache_key
+    def deserialize_rbs_collection_cache gemspec
+      rbs_version_cache_key = pin_cache.cache_key_for(gemspec)
       return if rbs_collection_pins_in_memory.key?([gemspec, rbs_version_cache_key])
-      cached = PinCache.deserialize_rbs_collection_gem(gemspec, rbs_version_cache_key)
+      cached = pin_cache.deserialize_rbs_collection_gem(gemspec)
       if cached
         logger.info { "Loaded #{cached.length} pins from RBS collection cache for #{gemspec.name}:#{gemspec.version}" } unless cached.empty?
         rbs_collection_pins_in_memory[[gemspec, rbs_version_cache_key]] = cached

--- a/lib/solargraph/library.rb
+++ b/lib/solargraph/library.rb
@@ -625,6 +625,11 @@ module Solargraph
           end
           end_cache_progress
           catalog
+          # A run can exit cleanly and still leave the gem uncached, because
+          # it writes under the cache key its own RBS configuration produces
+          # rather than ours. Retrying reruns the same subprocess forever, so
+          # treat that like any other cache failure.
+          cache_errors.add spec if api_map.uncached_gemspecs.include?(spec)
           sync_catalog
         end
       end

--- a/lib/solargraph/pin_cache.rb
+++ b/lib/solargraph/pin_cache.rb
@@ -4,7 +4,100 @@ require 'pathname' # @todo Required by RBS but not loaded in some use cases
 require 'rbs'
 
 module Solargraph
-  module PinCache
+  class PinCache
+    include Logging
+
+    attr_reader :rbs_collection_path, :rbs_collection_config_path
+
+    # Combined pins already deserialized in this process, shared across
+    # instances and keyed by the RBS cache key as well as the gem, so two
+    # configurations resolving the same gem differently cannot collide.
+    #
+    # @return [Hash{Array(String, Gem::Version, String) => Array<Pin::Base>}]
+    def self.all_combined_pins_in_memory
+      @all_combined_pins_in_memory ||= {}
+    end
+
+    # @param rbs_collection_path [String, nil]
+    # @param rbs_collection_config_path [String, nil]
+    def initialize rbs_collection_path:, rbs_collection_config_path:
+      @rbs_collection_path = rbs_collection_path
+      @rbs_collection_config_path = rbs_collection_config_path
+    end
+
+    # Which RBS source this configuration resolves the gem to, and so which
+    # cache entry it names.
+    #
+    # @param gemspec [Gem::Specification]
+    # @return [String]
+    def cache_key_for gemspec
+      RbsMap.from_gemspec(gemspec, rbs_collection_path, rbs_collection_config_path).cache_key
+    end
+
+    # @param gemspec [Gem::Specification]
+    # @return [Boolean]
+    def cached? gemspec
+      self.class.has_combined?(gemspec, cache_key_for(gemspec))
+    end
+
+    # @param gemspec [Gem::Specification]
+    # @return [Array<Pin::Base>, nil]
+    def deserialize_combined_gem gemspec
+      key = memory_key(gemspec)
+      return self.class.all_combined_pins_in_memory[key] if self.class.all_combined_pins_in_memory.key?(key)
+
+      cached = self.class.deserialize_combined_gem(gemspec, cache_key_for(gemspec))
+      self.class.all_combined_pins_in_memory[key] = cached if cached
+      cached
+    end
+
+    # @param gemspec [Gem::Specification]
+    # @param pins [Array<Pin::Base>]
+    # @return [void]
+    def serialize_combined_gem gemspec, pins
+      key = memory_key(gemspec)
+      self.class.serialize_combined_gem(gemspec, cache_key_for(gemspec), pins)
+      self.class.all_combined_pins_in_memory[key] = pins
+    end
+
+    # @param gemspec [Gem::Specification]
+    # @return [Array<Pin::Base>, nil]
+    def deserialize_rbs_collection_gem gemspec
+      self.class.deserialize_rbs_collection_gem(gemspec, cache_key_for(gemspec))
+    end
+
+    # @param gemspec [Gem::Specification]
+    # @param pins [Array<Pin::Base>]
+    # @return [void]
+    def serialize_rbs_collection_gem gemspec, pins
+      self.class.serialize_rbs_collection_gem(gemspec, cache_key_for(gemspec), pins)
+    end
+
+    # @param gemspec [Gem::Specification]
+    # @return [Boolean]
+    def has_rbs_collection? gemspec
+      self.class.has_rbs_collection?(gemspec, cache_key_for(gemspec))
+    end
+
+    # Drops the on-disk entries and the in-memory one, which the class-level
+    # version cannot reach.
+    #
+    # @param gemspec [Gem::Specification]
+    # @param out [IO, StringIO, nil]
+    # @return [void]
+    def uncache_gem gemspec, out: nil
+      self.class.uncache_gem(gemspec, out: out)
+      self.class.all_combined_pins_in_memory.delete(memory_key(gemspec))
+    end
+
+    private
+
+    # @param gemspec [Gem::Specification]
+    # @return [Array(String, Gem::Version, String)]
+    def memory_key gemspec
+      [gemspec.name, gemspec.version, cache_key_for(gemspec)]
+    end
+
     class << self
       include Logging
 
@@ -105,7 +198,7 @@ module Solargraph
       # @param gemspec [Gem::Specification]
       # @param hash [String, nil]
       # @return [String]
-      def rbs_collection_path gemspec, hash
+      def rbs_collection_gem_path gemspec, hash
         File.join(work_dir, 'rbs', "#{gemspec.name}-#{gemspec.version}-#{hash || 0}.ser")
       end
 
@@ -119,7 +212,7 @@ module Solargraph
       # @param hash [String, nil]
       # @return [Array<Pin::Base>, nil]
       def deserialize_rbs_collection_gem gemspec, hash
-        load(rbs_collection_path(gemspec, hash))
+        load(rbs_collection_gem_path(gemspec, hash))
       end
 
       # @param gemspec [Gem::Specification]
@@ -127,7 +220,7 @@ module Solargraph
       # @param pins [Array<Pin::Base>]n
       # @return [void]
       def serialize_rbs_collection_gem gemspec, hash, pins
-        save(rbs_collection_path(gemspec, hash), pins)
+        save(rbs_collection_gem_path(gemspec, hash), pins)
       end
 
       # @param gemspec [Gem::Specification]
@@ -162,7 +255,14 @@ module Solargraph
       # @param hash [String, nil]
       # @return [Boolean]
       def has_rbs_collection? gemspec, hash
-        exist?(rbs_collection_path(gemspec, hash))
+        exist?(rbs_collection_gem_path(gemspec, hash))
+      end
+
+      # @param gemspec [Gem::Specification]
+      # @param hash [String, nil]
+      # @return [Boolean]
+      def has_combined? gemspec, hash
+        exist?(combined_path(gemspec, hash))
       end
 
       # @return [void]

--- a/spec/library_spec.rb
+++ b/spec/library_spec.rb
@@ -678,4 +678,31 @@ describe Solargraph::Library do
       expect { library.send(:sync_catalog) }.not_to raise_error
     end
   end
+
+  describe '#cache_next_gemspec' do
+    # `solargraph cache` resolves the gem under its own RBS configuration and
+    # writes the entry under the key that configuration produces. When that
+    # key is not the one this process computes, the run exits 0 and the gem
+    # is still uncached, so the catalog cycle offers it again immediately and
+    # the same subprocess is spawned forever.
+    it 'gives up on a gem whose successful cache run leaves it still uncached' do
+      library = described_class.new
+      api_map = library.send(:api_map)
+      gemspec = instance_double(Gem::Specification, name: 'stuck', version: Gem::Version.new('1.0.0'))
+      allow(api_map).to receive(:catalog)
+      allow(api_map).to receive_messages(uncached_yard_gemspecs: [gemspec], uncached_rbs_collection_gemspecs: [],
+                                         uncached_gemspecs: [gemspec], source_maps: [], pins: [])
+      allow(Solargraph::Yardoc).to receive(:processing?).and_return(false)
+      allow(Open3).to receive(:capture3).and_return(['', '', instance_double(Process::Status, success?: true)])
+      # Run the caching thread inline, and keep it out of the catalog cycle
+      # so the example tests one pass rather than the loop itself.
+      allow(Thread).to receive(:new).and_yield
+      allow(library).to receive(:catalog)
+      allow(library).to receive(:sync_catalog)
+
+      library.send(:cache_next_gemspec)
+
+      expect(library.send(:cache_errors)).to include(gemspec)
+    end
+  end
 end

--- a/spec/pin_cache_spec.rb
+++ b/spec/pin_cache_spec.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+describe Solargraph::PinCache do
+  let(:workspace) { Solargraph::Workspace.new(Dir.pwd) }
+
+  let(:configured) do
+    described_class.new(rbs_collection_path: workspace.rbs_collection_path,
+                        rbs_collection_config_path: workspace.rbs_collection_config_path)
+  end
+
+  let(:unconfigured) do
+    described_class.new(rbs_collection_path: nil, rbs_collection_config_path: nil)
+  end
+
+  describe '#cache_key_for' do
+    it 'differs between configurations that resolve the gem differently' do
+      gemspec = Gem::Specification.find_by_name('addressable')
+
+      expect(configured.cache_key_for(gemspec)).not_to eq(unconfigured.cache_key_for(gemspec))
+    end
+  end
+
+  describe '#deserialize_combined_gem' do
+    it 'does not serve one configuration the pins held for another' do
+      gemspec = Gem::Specification.find_by_name('addressable')
+      pins = [Solargraph::Pin::Namespace.new(name: 'Fixture')]
+      described_class.all_combined_pins_in_memory[
+        [gemspec.name, gemspec.version, configured.cache_key_for(gemspec)]
+      ] = pins
+
+      allow(described_class).to receive(:deserialize_combined_gem).and_return(nil)
+
+      expect(unconfigured.deserialize_combined_gem(gemspec)).to be_nil
+    end
+  end
+
+  describe '#uncache_gem' do
+    it 'drops the in-memory entry as well as the files' do
+      gemspec = Gem::Specification.find_by_name('backport')
+      key = [gemspec.name, gemspec.version, configured.cache_key_for(gemspec)]
+      described_class.all_combined_pins_in_memory[key] = []
+      allow(described_class).to receive(:uncache_gem)
+
+      configured.uncache_gem(gemspec, out: nil)
+
+      expect(described_class.all_combined_pins_in_memory).not_to have_key(key)
+    end
+  end
+
+  after do
+    described_class.all_combined_pins_in_memory.clear
+  end
+end

--- a/spec/pin_cache_spec.rb
+++ b/spec/pin_cache_spec.rb
@@ -12,6 +12,10 @@ describe Solargraph::PinCache do
     described_class.new(rbs_collection_path: nil, rbs_collection_config_path: nil)
   end
 
+  after do
+    described_class.all_combined_pins_in_memory.clear
+  end
+
   describe '#cache_key_for' do
     it 'differs between configurations that resolve the gem differently' do
       gemspec = Gem::Specification.find_by_name('addressable')
@@ -45,9 +49,5 @@ describe Solargraph::PinCache do
 
       expect(described_class.all_combined_pins_in_memory).not_to have_key(key)
     end
-  end
-
-  after do
-    described_class.all_combined_pins_in_memory.clear
   end
 end


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

**Problem:** Open two projects in one editor window and they can be served each other's gem types. Each workspace folder gets its own `Library`, but the in-memory pin index they share is keyed on gem name and version alone — so for a gem both projects use at the same version, whichever loads first supplies the pins for both, whatever either project's `rbs_collection.yaml` says.

```ruby
# one process, two RBS configurations, index keyed on [name, version]
configured.deserialize_combined_gem(addressable)    # => 263 pins
unconfigured.deserialize_combined_gem(addressable)  # => 263 pins  <- the other folder's

# separate process, same second configuration
unconfigured.deserialize_combined_gem(addressable)  # => nil       <- correctly no entry
```

Restarting does not fix it, it just re-runs the race. With one folder open the same bug is milder but still there: edit `rbs_collection.yaml`, re-cache, and the old types persist for the life of the process — `uncache_gem` does not clear the entry either.

**Solution:** Make `PinCache` instantiable from a collection path and config path so it resolves the RBS cache key once, keys the shared index by that key as well as the gem, and drops the entry on uncache. The on-disk cache already separates entries this way; only the in-memory index did not.

**Test plan:** Measured the collision above by simulating the current keying in one process. Ran the suite with a plugin configured, as CI's `rspec` and `regression` jobs do.
