### PR TITLE
Stop dropping union members a module guard could match

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -736,6 +736,14 @@ module Solargraph
       store.get_includes(host_ns).map { |inc_tag| inc_tag.type.name }.include?(module_ns)
     end
 
+    # Check whether a namespace is a module rather than a class.
+    #
+    # @param fqns [String] A fully qualified namespace
+    # @return [Boolean]
+    def module? fqns
+      get_namespace_type(fqns) == :module
+    end
+
     # @param pins [Enumerable<Pin::Base>]
     # @param visibility [Enumerable<Symbol>]
     # @return [Array<Pin::Base>]

--- a/lib/solargraph/complex_type.rb
+++ b/lib/solargraph/complex_type.rb
@@ -405,6 +405,12 @@ module Solargraph
             types << int_type
           elsif ut.conforms_to?(api_map, int_type, :assignment)
             types << ut
+          elsif api_map.module?(int_type.name) || api_map.module?(ut.name)
+            # Two classes are disjoint under single inheritance, so a member
+            # failing the guard is dropped. A module on either side is not:
+            # a subclass can mix it in. Keeping the guard is the closest sound
+            # answer available without an intersection type.
+            types << int_type
           end
         end
       end

--- a/lib/solargraph/complex_type/unique_type.rb
+++ b/lib/solargraph/complex_type/unique_type.rb
@@ -135,6 +135,12 @@ module Solargraph
               types << ut
             elsif int_type.conforms_to?(api_map, ut, :assignment)
               types << int_type
+            elsif api_map.module?(int_type.name) || api_map.module?(ut.name)
+              # Two classes are disjoint under single inheritance, so a member
+              # failing the guard is dropped. A module on either side is not:
+              # a subclass can mix it in. Keeping the guard is the closest sound
+              # answer available without an intersection type.
+              types << int_type
             end
           end
         end

--- a/spec/api_map_spec.rb
+++ b/spec/api_map_spec.rb
@@ -636,6 +636,17 @@ describe Solargraph::ApiMap do
     expect(@api_map.super_and_sub?('Foo', 'Bar')).to be(false)
   end
 
+  it 'distinguishes modules from classes and unknown namespaces' do
+    source = Solargraph::Source.load_string(%(
+      module Foo; end
+      class Bar; end
+    ))
+    @api_map.map source
+    expect(@api_map.module?('Foo')).to be(true)
+    expect(@api_map.module?('Bar')).to be(false)
+    expect(@api_map.module?('Baz')).to be(false)
+  end
+
   it 'adds prepended methods to the ancestor tree' do
     source = Solargraph::Source.load_string(%(
       module Prepended

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -765,4 +765,35 @@ describe 'YARD type specifier list parsing' do
       expect(atype.conforms_to?(api_map, ptype, :method_call)).to be(true)
     end
   end
+
+  context 'when narrowing a union down to the members that pass a mixin guard' do
+    let(:mixin_api_map) do
+      api_map = Solargraph::ApiMap.new
+      api_map.map Solargraph::Source.load_string(%(
+        module M; end
+        class A; end
+        class B; end
+        class A_with_M < A; include M; end
+        class B_with_M < B; include M; end
+      ), 'test.rb')
+      api_map
+    end
+
+    # A_with_M satisfies the declared A and mixes in M, so it is a real
+    # inhabitant of 'A, B_with_M' that an is_a?(M) guard admits.
+    let(:declared) { Solargraph::ComplexType.parse('A, B_with_M').qualify(mixin_api_map, '') }
+    let(:guard) { Solargraph::ComplexType.parse('M').qualify(mixin_api_map, '') }
+    let(:inhabitant) { Solargraph::ComplexType.parse('A_with_M').qualify(mixin_api_map, '') }
+
+    it 'still admits a value satisfying both the declared type and the guard' do
+      narrowed = declared.intersect_with(guard, mixin_api_map)
+      expect(inhabitant.conforms_to?(mixin_api_map, narrowed, :assignment)).to be(true)
+    end
+
+    it 'intersects the member the guard neither implies nor is implied by' do
+      pending 'https://github.com/castwide/solargraph/pull/1231'
+      narrowed = declared.intersect_with(guard, mixin_api_map)
+      expect(narrowed.rooted_tags).to eq('::A & ::M, ::B_with_M')
+    end
+  end
 end

--- a/spec/complex_type_spec.rb
+++ b/spec/complex_type_spec.rb
@@ -796,4 +796,32 @@ describe 'YARD type specifier list parsing' do
       expect(narrowed.rooted_tags).to eq('::A & ::M, ::B_with_M')
     end
   end
+  context 'when narrowing a union whose module member could satisfy a class guard' do
+    let(:mirror_api_map) do
+      api_map = Solargraph::ApiMap.new
+      api_map.map Solargraph::Source.load_string(%(
+        module M1; end
+        class C; end
+        class B; end
+        class D < C; include M1; end
+      ), 'test.rb')
+      api_map
+    end
+
+    # D subclasses C and mixes in M1, so it is a real inhabitant of
+    # 'M1, B' that an is_a?(C) guard admits.
+    let(:declared) { Solargraph::ComplexType.parse('M1, B').qualify(mirror_api_map, '') }
+    let(:guard) { Solargraph::ComplexType.parse('C').qualify(mirror_api_map, '') }
+    let(:inhabitant) { Solargraph::ComplexType.parse('D').qualify(mirror_api_map, '') }
+
+    it 'still admits a value satisfying both the declared type and the guard' do
+      narrowed = declared.intersect_with(guard, mirror_api_map)
+      expect(inhabitant.conforms_to?(mirror_api_map, narrowed, :assignment)).to be(true)
+    end
+
+    it 'drops the class member that single inheritance proves disjoint' do
+      narrowed = declared.intersect_with(guard, mirror_api_map)
+      expect(narrowed.rooted_tags).to eq('::C')
+    end
+  end
 end


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

**Problem:** When a guard tests for a module, a union member not already known to include it is dropped — so the inferred type omits a value that can actually occur.

```ruby
module M; end
class A; end
class B; end
class A_with_M < A; include M; end
class B_with_M < B; include M; end

# @param x [A, B_with_M]
# @return [nil]
def f(x)
  return x if x.is_a?(M)

  nil
end
# Declared return type nil does not match inferred type ::B_with_M, nil for #f
```

`A_with_M` satisfies the declared `A`, passes the guard, and is returned, yet the inferred type admits only `B_with_M`. The mirror case — a module member against a class guard — is quieter still: every member drops, the empty result falls back to `undefined`, and the file reports no problems at all.

**Solution:** Keep the guard's type when the two types are related in neither direction and either side is a module, since a subclass can always mix a module in. Two unrelated classes remain disjoint under single inheritance and are still dropped.

The exact answer is their intersection, which cannot be spelled yet; a pending spec asserts it against castwide/solargraph#1231.

**Test plan:**

- [x] Strong self-typecheck against an `origin/master` baseline: 531 problems in 90 of 250 files on both sides, problem lists identical after normalizing paths and line numbers.
