### PR TITLE
Point run_solargraph_rspec_specs at the precision-fix branch

### DIFF
--- a/.github/workflows/plugins.yml
+++ b/.github/workflows/plugins.yml
@@ -129,8 +129,10 @@ jobs:
     - name: clone https://github.com/lekemula/solargraph-rspec/
       run: |
        cd ..
-       git clone https://github.com/lekemula/solargraph-rspec.git
+       # pending https://github.com/lekemula/solargraph-rspec/pull/36
+       git clone https://github.com/apiology/solargraph-rspec.git
        cd solargraph-rspec
+       git checkout fix-hash-literal-type-precision
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

**Problem:** `run_solargraph_rspec_specs` clones `lekemula/solargraph-rspec` directly with no checkout, so it always runs against that fork's default branch. That branch's Hash/Array-literal assertions predate this repo's more precise `Hash{Symbol => String}` / `Array<Integer>` inference output.

**Solution:** Point the clone at `apiology/solargraph-rspec` and check out `fix-hash-literal-type-precision`, which tolerates the precise inference output and backs an open PR against lekemula/solargraph-rspec (lekemula/solargraph-rspec#36, still open).
