### PR TITLE
Solargraph drops the types gems add to core classes

### DIFF
--- a/lib/solargraph/api_map.rb
+++ b/lib/solargraph/api_map.rb
@@ -750,7 +750,7 @@ module Solargraph
       logger.debug do
         "ApiMap#resolve_method_aliases(pins=#{pins.map(&:name)}, visibility=#{visibility}) => #{with_resolved_aliases.map(&:name)}"
       end
-      with_resolved_aliases
+      GemPins.combine_method_pins_by_path(with_resolved_aliases)
     end
 
     # @return [Workspace, nil]

--- a/lib/solargraph/gem_pins.rb
+++ b/lib/solargraph/gem_pins.rb
@@ -48,10 +48,14 @@ module Solargraph
     # @return [Array<Pin::Base>]
     def self.combine yard_pins, rbs_pins
       in_yard = Set.new
-      rbs_api_map = Solargraph::ApiMap.new(pins: rbs_pins)
+      # Index this gem's own pins rather than looking them up through an
+      # ApiMap, which also loads Ruby core: for a method the gem adds to a
+      # core class, core's pin would be found instead of the gem's, and the
+      # gem's signature dropped.
+      rbs_methods_by_path = rbs_pins.select { |pin| pin.is_a?(Pin::Method) }.group_by(&:path)
       combined = yard_pins.map do |yard_pin|
         in_yard.add yard_pin.path
-        rbs_pin = rbs_api_map.get_path_pins(yard_pin.path).filter { |pin| pin.is_a? Pin::Method }.first
+        rbs_pin = rbs_methods_by_path[yard_pin.path]&.first
         next yard_pin unless rbs_pin && yard_pin.instance_of?(Pin::Method)
 
         unless rbs_pin

--- a/lib/solargraph/gem_pins.rb
+++ b/lib/solargraph/gem_pins.rb
@@ -11,6 +11,19 @@ module Solargraph
       include Logging
     end
 
+    # Combine method pins sharing a path. Core and a gem that reopens a
+    # core class are cached separately, so a method described by both only
+    # meets here.
+    #
+    # @param pins [Array<Pin::Base>]
+    # @return [Array<Pin::Base>]
+    def self.combine_method_pins_by_path pins
+      method_pins, other_pins = pins.partition { |pin| pin.instance_of?(Pin::Method) }
+      by_path = method_pins.group_by(&:path)
+      by_path.transform_values! { |same_path| combine_method_pins(*same_path) }
+      by_path.values + other_pins
+    end
+
     # @param pins [Array<Pin::Method>]
     # @return [Pin::Method, nil]
     def self.combine_method_pins(*pins)

--- a/lib/solargraph/pin/callable.rb
+++ b/lib/solargraph/pin/callable.rb
@@ -131,25 +131,6 @@ module Solargraph
         blockless_parameters.map { |param| param.return_type.tags }
       end
 
-      # e.g., [["T"], "1", "?3", "foo:5"] - parameter arity
-      #   declarations, including the number of unique types in each
-      #   parameter.  Used to determine whether combining two
-      #   signatures has lost useful information mapping specific
-      #   parameter types to specific return types.
-      #
-      # @return [Array<Array, String, nil>]
-      def type_arity
-        [generics, blockless_parameters.map(&:type_arity_decl), block&.type_arity]
-      end
-
-      # Same as type_arity, but includes return type arity at the front.
-      #
-      # @return [Array<Array, String, nil>]
-      def full_type_arity
-        # @sg-ignore flow sensitive typing needs to handle attrs
-        [return_type ? return_type.items.count.to_s : nil] + type_arity
-      end
-
       # @param generics_to_resolve [Enumerable<String>]
       # @param arg_types [Array<ComplexType>, nil]
       # @param return_type_context [ComplexType, nil]

--- a/lib/solargraph/pin/callable.rb
+++ b/lib/solargraph/pin/callable.rb
@@ -122,9 +122,13 @@ module Solargraph
         block.nil? || block.same_parameter_types?(other.block)
       end
 
+      # Rootedness is ignored deliberately: GemPins.combine matches a YARD
+      # pin, whose types are still unqualified, against its RBS counterpart,
+      # whose types are rooted, so String and ::String are one overload here.
+      #
       # @return [Array<String>]
       def parameter_type_tags
-        blockless_parameters.map { |param| param.return_type.rooted_tags }
+        blockless_parameters.map { |param| param.return_type.tags }
       end
 
       # e.g., [["T"], "1", "?3", "foo:5"] - parameter arity

--- a/lib/solargraph/pin/callable.rb
+++ b/lib/solargraph/pin/callable.rb
@@ -108,6 +108,25 @@ module Solargraph
         [generics, blockless_parameters.map(&:arity_decl), block&.arity]
       end
 
+      # Whether +other+ declares the same parameter types, so merging cannot
+      # take away an argument type's ability to select a return type.  Return
+      # types are excluded: widening one is the purpose of merging.
+      #
+      # @param other [Callable]
+      # @return [Boolean]
+      def same_parameter_types? other
+        return false unless generics == other.generics
+        return false unless block.nil? == other.block.nil?
+        return false unless parameter_type_tags == other.parameter_type_tags
+
+        block.nil? || block.same_parameter_types?(other.block)
+      end
+
+      # @return [Array<String>]
+      def parameter_type_tags
+        blockless_parameters.map { |param| param.return_type.rooted_tags }
+      end
+
       # e.g., [["T"], "1", "?3", "foo:5"] - parameter arity
       #   declarations, including the number of unique types in each
       #   parameter.  Used to determine whether combining two

--- a/lib/solargraph/pin/method.rb
+++ b/lib/solargraph/pin/method.rb
@@ -485,58 +485,49 @@ module Solargraph
         elsif other_all_undefined && !all_undefined
           signatures
         else
-          combine_signatures_by_type_arity(*signatures, *other.signatures)
+          combine_signatures_by_arity(*signatures, *other.signatures)
         end
       end
 
       # @param signature_pins [Array<Pin::Signature>]
       #
       # @return [Array<Pin::Signature>]
-      def combine_signatures_by_type_arity(*signature_pins)
+      def combine_signatures_by_arity(*signature_pins)
         # @type [Hash{Array => Array<Pin::Signature>}]
-        by_type_arity = {}
+        by_arity = {}
         signature_pins.each do |signature_pin|
-          by_type_arity[signature_pin.type_arity] ||= []
-          by_type_arity[signature_pin.type_arity] << signature_pin
+          by_arity[signature_pin.arity] ||= []
+          by_arity[signature_pin.arity] << signature_pin
         end
 
-        by_type_arity.transform_values! do |same_type_arity_signatures|
-          combine_same_type_arity_signatures same_type_arity_signatures
+        by_arity.transform_values! do |same_arity_signatures|
+          combine_same_arity_signatures same_arity_signatures
         end
-        by_type_arity.values.flatten
+        by_arity.values.flatten
       end
 
-      # @param same_type_arity_signatures [Array<Pin::Signature>]
+      # @param same_arity_signatures [Array<Pin::Signature>]
       #
       # @return [Array<Pin::Signature>]
-      def combine_same_type_arity_signatures same_type_arity_signatures
+      def combine_same_arity_signatures same_arity_signatures
         # This is an O(n^2) operation, so bail out if n is not small
-        return same_type_arity_signatures if same_type_arity_signatures.length > 10
+        return same_arity_signatures if same_arity_signatures.length > 10
 
         # @param old_signatures [Array<Pin::Signature>]
         # @param new_signature [Pin::Signature]
-        same_type_arity_signatures.reduce([]) do |old_signatures, new_signature|
+        same_arity_signatures.reduce([]) do |old_signatures, new_signature|
           next old_signatures + [new_signature] if old_signatures.empty?
 
           merged = false
           combined = old_signatures.map do |old_signature|
-            potential_new_signature = old_signature.combine_with(new_signature)
+            # Merge only where the parameter types match.  While Ruby does
+            # not dispatch on type, RBS distinguishes overloads by parameter
+            # type, so collapsing two differently-typed signatures would lose
+            # the mapping from argument types to return types.
+            next old_signature unless old_signature.same_parameter_types?(new_signature)
 
-            if potential_new_signature.type_arity == old_signature.type_arity
-              # the number of types in each parameter and return type
-              # match, so we found compatible signatures to merge.  If
-              # we increased the number of types, we'd potentially
-              # have taken away the ability to use parameter types to
-              # choose the correct return type (while Ruby doesn't
-              # dispatch based on type, RBS does distinguish overloads
-              # based on types, not just arity, allowing for type
-              # information describing how methods behave based on
-              # their input types)
-              merged = true
-              potential_new_signature
-            else
-              old_signature
-            end
+            merged = true
+            old_signature.combine_with(new_signature)
           end
           merged ? combined : old_signatures + [new_signature]
         end

--- a/lib/solargraph/pin/parameter.rb
+++ b/lib/solargraph/pin/parameter.rb
@@ -93,11 +93,6 @@ module Solargraph
         end
       end
 
-      # @return [String]
-      def type_arity_decl
-        arity_decl + return_type.items.count.to_s
-      end
-
       def arg?
         decl == :arg
       end

--- a/spec/gem_pins_spec.rb
+++ b/spec/gem_pins_spec.rb
@@ -1,5 +1,7 @@
 # frozen_string_literal: true
 
+require 'tmpdir'
+
 describe Solargraph::GemPins do
   let(:workspace) { Solargraph::Workspace.new(Dir.pwd) }
   let(:doc_map) { Solargraph::DocMap.new(requires, workspace, out: nil) }
@@ -48,23 +50,90 @@ describe Solargraph::GemPins do
   end
 
   context 'with a gem method on a class core also defines' do
-    let(:requires) { ['bigdecimal'] }
+    # Empty, so that the outer before block does not memoize bigdecimal's pins
+    # in DocMap before the uncache below can take effect.
+    let(:requires) { [] }
 
-    it "offers the gem's signature alongside core's" do
+    let(:bigdecimal_map) do
       gemspec = Gem::Specification.find_by_name('bigdecimal')
       # GemPins.combine only runs when the combined entry is absent, so a
       # stale one would leave this asserting on cached output.
       Solargraph::PinCache.uncache_gem(gemspec, out: nil)
       map = Solargraph::DocMap.new(['bigdecimal'], workspace, out: nil)
       map.cache_all!(nil)
+      map
+    end
 
-      # ApiMap loads core too, so this is where bigdecimal's Integer#+ and
-      # core's meet - the layer the signature goes missing at.
-      api_map = Solargraph::ApiMap.new(pins: map.pins)
-      plus = api_map.get_method_stack('Integer', '+', scope: :instance).first
+    # ApiMap loads core too, so this is where bigdecimal's Integer#+ and core's
+    # meet - the layer the signature goes missing at.
+    #
+    # @param map [Solargraph::DocMap]
+    # @return [Array<Array<String>>] the parameter types of each signature
+    def integer_plus_param_types map
+      pin = Solargraph::ApiMap.new(pins: map.pins)
+                              .get_method_stack('Integer', '+', scope: :instance).first
+      param_types pin
+    end
 
-      expect(plus.signatures.map { |sig| sig.parameters.map { |param| param.return_type.to_s } })
-        .to include(['BigDecimal'])
+    # @param pin [Solargraph::Pin::Method]
+    # @return [Array<Array<String>>]
+    def param_types pin
+      pin.signatures.map { |sig| sig.parameters.map { |param| param.return_type.to_s } }
+    end
+
+    it "offers the gem's signature alongside core's" do
+      expect(integer_plus_param_types(bigdecimal_map)).to include(['BigDecimal'])
+    end
+
+    it "still offers core's own signatures" do
+      expect(integer_plus_param_types(bigdecimal_map))
+        .to include(['Integer'], ['Float'], ['Rational'], ['Complex'])
+    end
+
+    it "caches the gem's signature by itself, without core's" do
+      gem_pin = bigdecimal_map.pins.find { |pin| pin.path == 'Integer#+' }
+      expect(param_types(gem_pin)).to eq([['BigDecimal']])
+    end
+
+    it 'accepts an argument of the type the gem declares' do
+      bigdecimal_map # rebuilds the combined entry, so the check below reads pins built here
+
+      Dir.mktmpdir do |dir|
+        filename = File.join(dir, 'main.rb')
+        File.write filename, <<~RUBY
+          require 'bigdecimal'
+
+          # @param big [BigDecimal]
+          # @return [void]
+          def add_a_decimal(big)
+            1 + big
+          end
+        RUBY
+
+        api_map = Solargraph::ApiMap.load(dir)
+        checker = Solargraph::TypeChecker.new(filename, api_map: api_map, level: :strong)
+        expect(checker.problems.map(&:message)).to be_empty
+      end
+    end
+  end
+
+  describe '.combine_method_pins_by_path' do
+    let(:requires) { [] }
+    let(:closure) { Solargraph::Pin::Namespace.new(name: 'Foo') }
+
+    it 'merges method pins sharing a path and passes everything else through' do
+      constant = Solargraph::Pin::Constant.new(name: 'BAR', closure: closure)
+      from_core = Solargraph::Pin::Method.new(name: 'baz', closure: closure, scope: :instance,
+                                              comments: '@return [String]')
+      from_gem = Solargraph::Pin::Method.new(name: 'baz', closure: closure, scope: :instance,
+                                             comments: '@return [Integer]')
+      elsewhere = Solargraph::Pin::Method.new(name: 'qux', closure: closure, scope: :instance,
+                                              comments: '@return [Symbol]')
+
+      out = described_class.combine_method_pins_by_path([from_core, from_gem, elsewhere, constant])
+
+      expect(out.map(&:path)).to contain_exactly('Foo#baz', 'Foo#qux', 'Foo::BAR')
+      expect(out.find { |pin| pin.path == 'Foo#baz' }.return_type.to_s).to eq('String, Integer')
     end
   end
 end

--- a/spec/gem_pins_spec.rb
+++ b/spec/gem_pins_spec.rb
@@ -46,4 +46,25 @@ describe Solargraph::GemPins do
       expect(pin.location.filename).to end_with('task.rb')
     end
   end
+
+  context 'with a gem method on a class core also defines' do
+    let(:requires) { ['bigdecimal'] }
+
+    it "offers the gem's signature alongside core's" do
+      gemspec = Gem::Specification.find_by_name('bigdecimal')
+      # GemPins.combine only runs when the combined entry is absent, so a
+      # stale one would leave this asserting on cached output.
+      Solargraph::PinCache.uncache_gem(gemspec, out: nil)
+      map = Solargraph::DocMap.new(['bigdecimal'], workspace, out: nil)
+      map.cache_all!(nil)
+
+      # ApiMap loads core too, so this is where bigdecimal's Integer#+ and
+      # core's meet - the layer the signature goes missing at.
+      api_map = Solargraph::ApiMap.new(pins: map.pins)
+      plus = api_map.get_method_stack('Integer', '+', scope: :instance).first
+
+      expect(plus.signatures.map { |sig| sig.parameters.map { |param| param.return_type.to_s } })
+        .to include(['BigDecimal'])
+    end
+  end
 end

--- a/spec/language_server/message/text_document/signature_help_spec.rb
+++ b/spec/language_server/message/text_document/signature_help_spec.rb
@@ -2,7 +2,6 @@
 
 describe Solargraph::LanguageServer::Message::TextDocument::SignatureHelp do
   it 'sends one signature when a rooted and an unrooted spelling of one parameter type are combined, since both label the same overload' do
-    pending 'same_parameter_types? compares rooted_tags, so an unrooted YARD parameter type never matches its rooted RBS counterpart and both signatures reach the client'
     namespace = Solargraph::Pin::Namespace.new(name: 'Widget', type: :class)
     rooted_pin = Solargraph::Pin::Method.new(closure: namespace, name: 'scan', scope: :instance, comments: %(
 @overload scan(count)

--- a/spec/language_server/message/text_document/signature_help_spec.rb
+++ b/spec/language_server/message/text_document/signature_help_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+describe Solargraph::LanguageServer::Message::TextDocument::SignatureHelp do
+  it 'sends one signature when a rooted and an unrooted spelling of one parameter type are combined, since both label the same overload' do
+    pending 'same_parameter_types? compares rooted_tags, so an unrooted YARD parameter type never matches its rooted RBS counterpart and both signatures reach the client'
+    namespace = Solargraph::Pin::Namespace.new(name: 'Widget', type: :class)
+    rooted_pin = Solargraph::Pin::Method.new(closure: namespace, name: 'scan', scope: :instance, comments: %(
+@overload scan(count)
+  @param count [::Integer]
+  @return [::String]
+    ))
+    unrooted_pin = Solargraph::Pin::Method.new(closure: namespace, name: 'scan', scope: :instance, comments: %(
+@overload scan(count)
+  @param count [Integer]
+  @return [String]
+    ))
+    combined = rooted_pin.combine_with(unrooted_pin)
+    convention = Class.new(Solargraph::Convention::Base) do
+      define_method(:local) { |_source_map| Solargraph::Environ.new(pins: [namespace, combined]) }
+    end
+    Solargraph::Convention.register convention
+    begin
+      host = Solargraph::LanguageServer::Host.new
+      host.open('file:///test.rb', 'Widget.new.scan()', 1)
+      host.catalog
+      message = described_class.new(host, {
+                                      'params' => {
+                                        'textDocument' => {
+                                          'uri' => 'file:///test.rb'
+                                        },
+                                        'position' => {
+                                          'line' => 0,
+                                          'character' => 16
+                                        }
+                                      }
+                                    })
+      message.process
+      expect(message.result[:signatures].map { |signature| signature[:label] }).to eq(['scan(count)'])
+    ensure
+      Solargraph::Convention.unregister convention
+    end
+  end
+end

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -118,13 +118,10 @@ describe Solargraph::Pin::Method do
     expect(pin.return_type).to be_undefined
   end
 
-  it 'combines many non-mergeable same-type-arity signatures without exponential blowup' do
+  it 'combines many non-mergeable same-arity signatures without exponential blowup' do
     pin = described_class.new(name: 'foo')
-    signatures = (1..8).map { |_i| instance_double(Solargraph::Pin::Signature, type_arity: ['same']) }
-    signatures.each do |sig|
-      allow(sig).to receive(:combine_with).and_return(instance_double(Solargraph::Pin::Signature, type_arity: ['different']))
-    end
-    result = pin.send(:combine_same_type_arity_signatures, signatures)
+    signatures = (1..8).map { |_i| instance_double(Solargraph::Pin::Signature, same_parameter_types?: false) }
+    result = pin.send(:combine_same_arity_signatures, signatures)
     expect(result.length).to eq(signatures.length)
   end
 

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -142,26 +142,6 @@ describe Solargraph::Pin::Method do
     expect(combined.signatures.flat_map { |sig| sig.parameters.map { |param| param.return_type.rooted_tags } }).to contain_exactly('Integer', 'Float')
   end
 
-  it 'merges two signatures whose parameter types are one type spelled rooted and unrooted, since no argument can select between them' do
-    pending 'same_parameter_types? compares rooted_tags, so an unrooted YARD parameter type never matches its rooted RBS counterpart'
-    closure = Solargraph::Pin::Namespace.new(name: 'Foo', type: :class)
-    rooted_pin = described_class.new(closure: closure, name: 'add', scope: :instance, comments: %(
-@overload add(bar)
-  @param bar [::Integer]
-  @return [::String]
-    ))
-    unrooted_pin = described_class.new(closure: closure, name: 'add', scope: :instance, comments: %(
-@overload add(bar)
-  @param bar [Integer]
-  @return [String]
-    ))
-    combined = rooted_pin.combine_with(unrooted_pin)
-    expect(combined.signatures.length).to eq(1)
-    signature = combined.signatures.first
-    expect(signature.parameters.map { |param| param.return_type.rooted_tags }).to eq(['::Integer'])
-    expect(signature.return_type.rooted_tags).to eq('::String').or eq('String')
-  end
-
   it 'does not merge with changes in parameters' do
     # @todo Method pin parameters are pins now
     pin1 = described_class.new(name: 'bar', parameters: %w[one two])

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -126,7 +126,6 @@ describe Solargraph::Pin::Method do
   end
 
   it 'keeps a signature per parameter type when combining, so an argument type can still select its own return type' do
-    pending 'parameter types never widen when combining, so the type_arity check that would keep the signatures apart cannot fire'
     closure = Solargraph::Pin::Namespace.new(name: 'Foo', type: :class)
     integer_pin = described_class.new(closure: closure, name: 'add', scope: :instance, comments: %(
 @overload add(bar)

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -128,6 +128,24 @@ describe Solargraph::Pin::Method do
     expect(result.length).to eq(signatures.length)
   end
 
+  it 'keeps a signature per parameter type when combining, so an argument type can still select its own return type' do
+    pending 'parameter types never widen when combining, so the type_arity check that would keep the signatures apart cannot fire'
+    closure = Solargraph::Pin::Namespace.new(name: 'Foo', type: :class)
+    integer_pin = described_class.new(closure: closure, name: 'add', scope: :instance, comments: %(
+@overload add(bar)
+  @param bar [Integer]
+  @return [Integer]
+    ))
+    float_pin = described_class.new(closure: closure, name: 'add', scope: :instance, comments: %(
+@overload add(bar)
+  @param bar [Float]
+  @return [Float]
+    ))
+    combined = integer_pin.combine_with(float_pin)
+    expect(combined.signatures.length).to eq(2)
+    expect(combined.signatures.flat_map { |sig| sig.parameters.map { |param| param.return_type.rooted_tags } }).to contain_exactly('Integer', 'Float')
+  end
+
   it 'does not merge with changes in parameters' do
     # @todo Method pin parameters are pins now
     pin1 = described_class.new(name: 'bar', parameters: %w[one two])

--- a/spec/pin/method_spec.rb
+++ b/spec/pin/method_spec.rb
@@ -142,6 +142,26 @@ describe Solargraph::Pin::Method do
     expect(combined.signatures.flat_map { |sig| sig.parameters.map { |param| param.return_type.rooted_tags } }).to contain_exactly('Integer', 'Float')
   end
 
+  it 'merges two signatures whose parameter types are one type spelled rooted and unrooted, since no argument can select between them' do
+    pending 'same_parameter_types? compares rooted_tags, so an unrooted YARD parameter type never matches its rooted RBS counterpart'
+    closure = Solargraph::Pin::Namespace.new(name: 'Foo', type: :class)
+    rooted_pin = described_class.new(closure: closure, name: 'add', scope: :instance, comments: %(
+@overload add(bar)
+  @param bar [::Integer]
+  @return [::String]
+    ))
+    unrooted_pin = described_class.new(closure: closure, name: 'add', scope: :instance, comments: %(
+@overload add(bar)
+  @param bar [Integer]
+  @return [String]
+    ))
+    combined = rooted_pin.combine_with(unrooted_pin)
+    expect(combined.signatures.length).to eq(1)
+    signature = combined.signatures.first
+    expect(signature.parameters.map { |param| param.return_type.rooted_tags }).to eq(['::Integer'])
+    expect(signature.return_type.rooted_tags).to eq('::String').or eq('String')
+  end
+
   it 'does not merge with changes in parameters' do
     # @todo Method pin parameters are pins now
     pin1 = described_class.new(name: 'bar', parameters: %w[one two])

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1192,6 +1192,25 @@ describe Solargraph::SourceMap::Clip do
     expect(clip.infer.to_s).to eq('String, nil')
   end
 
+  it 'infers return types from the RBS overload matching the argument type' do
+    source = Solargraph::Source.load_string(%(
+      1 + 1
+      1 + 1.0
+      1 + Rational(1, 2)
+      1 + Complex(1, 2)
+    ), 'test.rb')
+    api_map = Solargraph::ApiMap.new
+    api_map.map source
+    clip = api_map.clip_at('test.rb', [1, 11])
+    expect(clip.infer.to_s).to eq('Integer')
+    clip = api_map.clip_at('test.rb', [2, 13])
+    expect(clip.infer.to_s).to eq('Float')
+    clip = api_map.clip_at('test.rb', [3, 24])
+    expect(clip.infer.to_s).to eq('Rational')
+    clip = api_map.clip_at('test.rb', [4, 23])
+    expect(clip.infer.to_s).to eq('Complex')
+  end
+
   it 'infers overloads with splats' do
     source = Solargraph::Source.load_string(%(
       class Foo

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1232,7 +1232,6 @@ describe Solargraph::SourceMap::Clip do
   end
 
   it 'offers one signature help entry when a rooted and an unrooted spelling of one parameter type are combined, since both signatures describe the same overload' do
-    pending 'same_parameter_types? compares rooted_tags, so an unrooted YARD parameter type never matches its rooted RBS counterpart and both signatures survive'
     namespace = Solargraph::Pin::Namespace.new(name: 'Widget', type: :class)
     rooted_pin = Solargraph::Pin::Method.new(closure: namespace, name: 'scan', scope: :instance, comments: %(
 @overload scan(count)

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1211,6 +1211,26 @@ describe Solargraph::SourceMap::Clip do
     expect(clip.infer.to_s).to eq('Complex')
   end
 
+  it 'infers the return type of the signature matching the argument type when two pins for one method are combined' do
+    namespace = Solargraph::Pin::Namespace.new(name: 'Widget', type: :class)
+    integer_pin = Solargraph::Pin::Method.new(closure: namespace, name: 'scan', scope: :instance, comments: %(
+@overload scan(count)
+  @param count [Integer]
+  @return [Symbol]
+    ))
+    float_pin = Solargraph::Pin::Method.new(closure: namespace, name: 'scan', scope: :instance, comments: %(
+@overload scan(count)
+  @param count [Float]
+  @return [String]
+    ))
+    source = Solargraph::Source.load_string('Widget.new.scan(1.5)', 'test.rb')
+    source_map = Solargraph::SourceMap.map(source)
+    api_map = Solargraph::ApiMap.new
+    api_map.index([namespace, integer_pin.combine_with(float_pin)] + source_map.pins)
+    api_map.send(:source_map_hash)['test.rb'] = source_map
+    expect(api_map.clip_at('test.rb', [0, 12]).infer.to_s).to eq('String')
+  end
+
   it 'infers overloads with splats' do
     source = Solargraph::Source.load_string(%(
       class Foo

--- a/spec/source_map/clip_spec.rb
+++ b/spec/source_map/clip_spec.rb
@@ -1231,6 +1231,28 @@ describe Solargraph::SourceMap::Clip do
     expect(api_map.clip_at('test.rb', [0, 12]).infer.to_s).to eq('String')
   end
 
+  it 'offers one signature help entry when a rooted and an unrooted spelling of one parameter type are combined, since both signatures describe the same overload' do
+    pending 'same_parameter_types? compares rooted_tags, so an unrooted YARD parameter type never matches its rooted RBS counterpart and both signatures survive'
+    namespace = Solargraph::Pin::Namespace.new(name: 'Widget', type: :class)
+    rooted_pin = Solargraph::Pin::Method.new(closure: namespace, name: 'scan', scope: :instance, comments: %(
+@overload scan(count)
+  @param count [::Integer]
+  @return [::String]
+    ))
+    unrooted_pin = Solargraph::Pin::Method.new(closure: namespace, name: 'scan', scope: :instance, comments: %(
+@overload scan(count)
+  @param count [Integer]
+  @return [String]
+    ))
+    source = Solargraph::Source.load_string('Widget.new.scan()', 'test.rb')
+    source_map = Solargraph::SourceMap.map(source)
+    api_map = Solargraph::ApiMap.new
+    api_map.index([namespace, rooted_pin.combine_with(unrooted_pin)] + source_map.pins)
+    api_map.send(:source_map_hash)['test.rb'] = source_map
+    clip = api_map.clip_at('test.rb', [0, 16])
+    expect(clip.signify.flat_map(&:signature_help).map { |help| help[:label] }).to eq(['scan(count)'])
+  end
+
   it 'infers overloads with splats' do
     source = Solargraph::Source.load_string(%(
       class Foo


### PR DESCRIPTION
This PR was written by Claude Code on behalf of @apiology.

**Problem:** A gem's RBS declaration for a method on a class Ruby core already defines is silently dropped, so calls it documents are reported as type errors. `bigdecimal` ships `def +: (BigDecimal) -> BigDecimal`, and in a one-file project that requires it:

```ruby
1 + BigDecimal('2')
# Wrong argument type for Integer#+: arg_0 expected Integer, received BigDecimal
# ...and the same for Float, Rational and Complex
```

Measured across the 133 gems in this repo's bundle, plus activesupport and its `gem_rbs_collection` RBS:

| gem | class | methods lost |
|---|---|---|
| stringio, cgi, csv, open-uri | StringIO | 67 each — `<<` `close` `read` `write` … |
| rbs | Bundler::\*, Gem::Specification, Enumerable | 17 — `find_by_name` `each_slice` … |
| bigdecimal | Integer, Float, Rational, Complex | 16 — `+` `-` `*` `/` on each |
| open3 | Open3 | 5 — `capture2` `capture2e` `capture3` `popen2` `popen3` |
| activesupport | Time | 2 — `+` `-` |

ActiveSupport is small here because only 2 of the 341 methods it declares on core classes share a path with a core method; the rest are new methods and resolve correctly.

**Solution:** `GemPins.combine` resolved the gem's RBS pin through `ApiMap.new(pins: rbs_pins)`, which also loads Ruby core — so it found core's pin, combined that, and discarded the gem's. It now indexes the gem's own pins by path. Core and a gem reopening a core class are also cached separately and meet nowhere, so `resolve_method_aliases` combines by path at lookup.

Stacked on castwide/solargraph#1356, which keeps the recovered signatures distinct instead of merging them into one polluted union. Until that merges, the diff here also shows its commits.
